### PR TITLE
Allow TokenMaker implementation from external .jar

### DIFF
--- a/src/org/fife/ui/rsyntaxtextarea/TokenMakerBase.java
+++ b/src/org/fife/ui/rsyntaxtextarea/TokenMakerBase.java
@@ -18,7 +18,7 @@ import javax.swing.text.Segment;
  * @author Robert Futrell
  * @version 1.0
  */
-abstract class TokenMakerBase implements TokenMaker {
+public abstract class TokenMakerBase implements TokenMaker {
 
 	/**
 	 * The first token in the returned linked list.


### PR DESCRIPTION
The base methods are inaccessible from an external jar, as is the case when using maven.
