### PR TITLE
add initial timeout for parse timer and allow access through RSTA

### DIFF
--- a/src/main/java/org/fife/ui/rsyntaxtextarea/ParserManager.java
+++ b/src/main/java/org/fife/ui/rsyntaxtextarea/ParserManager.java
@@ -714,6 +714,7 @@ class ParserManager implements DocumentListener, ActionListener,
 		if (running) {
 			timer.stop();
 		}
+		timer.setInitialDelay(millis);
 		timer.setDelay(millis);
 		if (running) {
 			timer.start();

--- a/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextArea.java
+++ b/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextArea.java
@@ -1449,6 +1449,18 @@ private boolean fractionalFontMetricsEnabled;
 
 
 	/**
+	 * Returns the currently set parser delay.
+	 * 
+	 * @return The currently set parser delay in milliseconds.
+	 * @see #setParserDelay(int)
+	 * @see {@link ParserManager#getDelay()}
+	 */
+	public int getParserDelay() {
+		return parserManager.getDelay();
+	}
+
+
+	/**
 	 * Returns a list of the current parser notices for this text area.
 	 * This method (like most Swing methods) should only be called on the
 	 * EDT.
@@ -2666,6 +2678,16 @@ private boolean fractionalFontMetricsEnabled;
 			repaint();
 			firePropertyChange(TAB_LINES_PROPERTY, !paint, paint);
 		}
+	}
+
+
+	/**
+	 * Sets the parser delay. 
+	 * @param millis Parser delay in milliseconds.
+	 * @see {@link ParserManager#setDelay(int)}
+	 */
+	public void setParserDelay(int millis) {
+		parserManager.setDelay(millis);
 	}
 
 


### PR DESCRIPTION
I ran into a problem with not being able to set the parser delay of an RSTA on a previous version (2.0.x). Fixed it by delegating access to parserManager.delay property. Also, ParserManager did not initialize the initialDelay of the timer it uses, which in turn caused the timer to be ineffective, because handleDocumentEvent() invokes timer.restart(), which fires its first event after its initial delay. So there was no delay while editing, with reparsing occuring between every keystroke.
