### PR TITLE
fix off-by-one errors in ErrorStrip

### DIFF
--- a/src/main/java/org/fife/ui/rsyntaxtextarea/ErrorStrip.java
+++ b/src/main/java/org/fife/ui/rsyntaxtextarea/ErrorStrip.java
@@ -309,7 +309,7 @@ public class ErrorStrip extends JComponent {
 	private int lineToY(int line) {
 		int h = textArea.getVisibleRect().height;
 		float lineCount = textArea.getLineCount();
-		return (int)((line/lineCount) * h) - 2;		
+		return (int)(((line-1)/(lineCount-1)) * h) - 2;
 	}
 
 
@@ -533,7 +533,7 @@ public class ErrorStrip extends JComponent {
 		int h = textArea.getVisibleRect().height;
 		if (y<h) {
 			float at = y/(float)h;
-			line = (int)(textArea.getLineCount()*at);
+			line = Math.round((textArea.getLineCount()-1)*at);
 		}
 		return line;
 	}
@@ -550,7 +550,7 @@ public class ErrorStrip extends JComponent {
 		public void caretUpdate(CaretEvent e) {
 			if (getFollowCaret()) {
 				int line = textArea.getCaretLineNumber();
-				float percent = line / ((float)textArea.getLineCount());
+				float percent = line / (float)(textArea.getLineCount()-1);
 				textArea.computeVisibleRect(visibleRect);
 				caretLineY = (int)(visibleRect.height*percent);
 				if (caretLineY!=lastLineY) {
@@ -673,7 +673,7 @@ public class ErrorStrip extends JComponent {
 
 		public int getLine() {
 			try {
-				return textArea.getLineOfOffset(range.getStartOffset());
+				return textArea.getLineOfOffset(range.getStartOffset())+1;
 			} catch (BadLocationException ble) {
 				return 0;
 			}


### PR DESCRIPTION
When editing short documents, I noticed inconsistencies on the ErrorStrip: the cursor's line was not lining up with marked occurences, cursor's marker was a bit off everywhere, etc.
I tracked it down to these errors, which result from the fact that the line numbering is 1-based, while the math here was not. :)
