### PR TITLE
Patch for building OSGi manifest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,15 @@
 ['java', 'distribution', 'maven', 'signing'].each { apply plugin: it }
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath 'org.dm.gradle:gradle-bundle-plugin:0.6.1'
+    }
+}
+
+apply plugin: 'org.dm.bundle'
 
 archivesBaseName = 'rsyntaxtextarea'
 
@@ -30,15 +41,8 @@ compileJava {
 	options.compilerArgs << "-Xlint:deprecation"
 }
 
-ext.sharedManifest = manifest {
-	attributes('Specification-Title': 'RSyntaxTextArea',
-		'Specification-Version': version,
-		'Implementation-Title': 'org.fife.ui',
-		'Implementation-Version': version)
-
-}
 jar {
-	manifest { from sharedManifest }
+
 }
 
 // We use "distributions" to create the zip files uploaded to SourceForge
@@ -77,14 +81,16 @@ buildSourceForgeZips.dependsOn clean, jar, distZip, srcDistZip
 
 // Stuff to generate and upload Maven artifacts
 task javadocJar (type: Jar, dependsOn: javadoc) {
-	manifest { from sharedManifest }
 	classifier = 'javadoc'
 	from javadoc.destinationDir
 }
 task sourceJar (type: Jar) {
-	manifest { from sharedManifest }
 	classifier = 'sources'
 	from sourceSets.main.allSource
+}
+
+bundle {
+    instruction 'Export-Package', '*'
 }
 artifacts {
 	archives jar, javadocJar, sourceJar


### PR DESCRIPTION
Add instructions in build.gradle in order to make OSGi manifest. Next jars should be OSGi compatible.

The plugin used to generate this file is [gradle-bundle-plugin](https://github.com/tomdmitriev/gradle-bundle-plugin)

Here a sample of automatically generated manifest:

```mf
Manifest-Version: 1.0
Bnd-LastModified: 1417794553938
Bundle-ManifestVersion: 2
Bundle-Name: rsyntaxtextarea
Bundle-SymbolicName: rsyntaxtextarea
Bundle-Version: 2.5.4
Created-By: 1.7.0_51 (Oracle Corporation)
Export-Package: org.fife.io;uses:="javax.swing.text";version="2.5.4",org
 .fife.print;uses:="javax.swing.text";version="2.5.4",org.fife.ui.rsynta
 xtextarea;uses:="javax.swing,javax.swing.event,javax.swing.plaf,javax.s
 wing.text,org.fife.ui.rsyntaxtextarea.folding,org.fife.ui.rsyntaxtextar
 ea.parser,org.fife.ui.rsyntaxtextarea.templates,org.fife.ui.rtextarea,o
 rg.fife.util";version="2.5.4",org.fife.ui.rsyntaxtextarea.focusabletip;
 uses:="javax.swing,javax.swing.border,javax.swing.event";version="2.5.4
 ",org.fife.ui.rsyntaxtextarea.folding;uses:="javax.swing.text,org.fife.
 ui.rsyntaxtextarea";version="2.5.4",org.fife.ui.rsyntaxtextarea.modes;u
 ses:="javax.swing.text,org.fife.ui.rsyntaxtextarea";version="2.5.4",org
 .fife.ui.rsyntaxtextarea.parser;uses:="javax.swing.event,org.fife.ui.rs
 yntaxtextarea,org.xml.sax";version="2.5.4",org.fife.ui.rsyntaxtextarea.
 templates;uses:="javax.swing.text,org.fife.ui.rsyntaxtextarea";version=
 "2.5.4",org.fife.ui.rsyntaxtextarea.themes;version="2.5.4",org.fife.ui.
 rtextarea;uses:="javax.swing,javax.swing.border,javax.swing.event,javax
 .swing.plaf,javax.swing.plaf.basic,javax.swing.text,javax.swing.undo,or
 g.fife.ui.rsyntaxtextarea";version="2.5.4",org.fife.util;version="2.5.4
 "
Import-Package: javax.imageio,javax.swing,javax.swing.border,javax.swing
 .event,javax.swing.plaf,javax.swing.plaf.basic,javax.swing.text,javax.s
 wing.text.html,javax.swing.undo,javax.xml.parsers,javax.xml.transform,j
 avax.xml.transform.dom,javax.xml.transform.stream,org.w3c.dom,org.xml.s
 ax,org.xml.sax.helpers
Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.5))"
Tool: Bnd-2.4.0.201411031534
```