### PR TITLE
Behaviour Updates

### DIFF
--- a/src/main/java/org/fife/ui/rsyntaxtextarea/MarkOccurrencesSupport.java
+++ b/src/main/java/org/fife/ui/rsyntaxtextarea/MarkOccurrencesSupport.java
@@ -112,9 +112,10 @@ class MarkOccurrencesSupport implements CaretListener, ActionListener {
 
 				Token t = occurrenceMarker.getTokenToMark(textArea);
 
+				clear();
+				
 				if (t!=null && occurrenceMarker.isValidType(textArea, t) &&
 						!RSyntaxUtilities.isNonWordChar(t)) {
-					clear();
 					RSyntaxTextAreaHighlighter h = (RSyntaxTextAreaHighlighter)
 							textArea.getHighlighter();
 					occurrenceMarker.markOccurrences(doc, t, h, p);

--- a/src/main/java/org/fife/ui/rtextarea/RTextAreaBase.java
+++ b/src/main/java/org/fife/ui/rtextarea/RTextAreaBase.java
@@ -197,7 +197,7 @@ int currentCaretY;							// Used to know when to rehighlight current line.
 		if (getCaretPosition() != 0) {
 			SwingUtilities.invokeLater(new Runnable() {
 				public void run() {
-					System.out.println("Yo");
+					//System.out.println("Yo");
 					possiblyUpdateCurrentLineHighlightLocation();
 				}
 			});


### PR DESCRIPTION
Two small updates: first is to stop printing 'Yo' to sys out. Second is to always clear the highlight for mark occurrences for any token, not only another valid token. This is what IntelliJ idea does and is also more similar to Notepad++ which immediately removes any highlighting when moving the caret.