### PR TITLE
Fix error marker postion errors in Error Strip

### DIFF
--- a/src/main/java/org/fife/ui/rsyntaxtextarea/ErrorStrip.java
+++ b/src/main/java/org/fife/ui/rsyntaxtextarea/ErrorStrip.java
@@ -306,7 +306,7 @@ public class ErrorStrip extends JComponent {
 	private int lineToY(int line) {
 		int h = textArea.getVisibleRect().height;
 		float lineCount = textArea.getLineCount();
-		return (int)(((line-1)/(lineCount-1)) * h) - 2;
+		return (int)(((line)/(lineCount-1)) * (h-2));
 	}
 
 


### PR DESCRIPTION
This PR resolves #129. Now, the first marker has been made visible, and the off-by-one-line error fixed.

Original:

![image](https://cloud.githubusercontent.com/assets/4526417/8729703/b345bf32-2bfd-11e5-9b4f-d563130c2511.png)

Now:

![fixed_error_tab_position_sml](https://cloud.githubusercontent.com/assets/4526417/8729714/c2b7ffb6-2bfd-11e5-935b-a06ab3c68401.PNG)

The fix was just a tiny correction in the lineToY() method. Instead of going from [-2 to height], Y now goes from [0 to height-2], so that both the first and last markers display. `line-1` has now been made `line` to fix the off-by-one error.