### PR TITLE
Fix: macro name is lost at saving to file.

### DIFF
--- a/src/main/java/org/fife/ui/rtextarea/Macro.java
+++ b/src/main/java/org/fife/ui/rtextarea/Macro.java
@@ -341,6 +341,7 @@ public class Macro {
 
 			// Write the name of the macro.
 			Element nameElement = doc.createElement(MACRO_NAME);
+			nameElement.appendChild(doc.createCDATASection(name));
 			rootElement.appendChild(nameElement);
 
 			// Write all actions (the meat) in the macro.


### PR DESCRIPTION
Actions: save macro to file + load macro from file
Result: macro name is lost
Fix: save name