### PR TITLE
Fixing squid:S1948 - Fields in a "Serializable" class should either be transient or serializable

### DIFF
--- a/src/main/java/org/fife/ui/rsyntaxtextarea/ErrorStrip.java
+++ b/src/main/java/org/fife/ui/rsyntaxtextarea/ErrorStrip.java
@@ -86,7 +86,7 @@ public class ErrorStrip extends JPanel {
 	/**
 	 * Listens for events in this component.
 	 */
-	private Listener listener;
+	private transient Listener listener;
 
 	/**
 	 * Whether "marked occurrences" in the text area should be shown in this
@@ -135,7 +135,7 @@ public class ErrorStrip extends JPanel {
 	/**
 	 * Generates the tool tips for markers in this error strip.
 	 */
-	private ErrorStripMarkerToolTipProvider markerToolTipProvider;
+	private transient ErrorStripMarkerToolTipProvider markerToolTipProvider;
 
 	/**
 	 * The preferred width of this component.

--- a/src/main/java/org/fife/ui/rsyntaxtextarea/MatchedBracketPopup.java
+++ b/src/main/java/org/fife/ui/rsyntaxtextarea/MatchedBracketPopup.java
@@ -32,7 +32,7 @@ class MatchedBracketPopup extends JWindow {
 
 	private RSyntaxTextArea textArea;
 
-	private Listener listener;
+	private transient Listener listener;
 
 	private static final int LEFT_EMPTY_BORDER = 5;
 

--- a/src/main/java/org/fife/ui/rsyntaxtextarea/focusabletip/SizeGrip.java
+++ b/src/main/java/org/fife/ui/rsyntaxtextarea/focusabletip/SizeGrip.java
@@ -41,7 +41,7 @@ class SizeGrip extends JPanel {
 	/**
 	 * The size grip to use if we're on OS X.
 	 */
-	private Image osxSizeGrip;
+	private transient Image osxSizeGrip;
 
 
 	public SizeGrip() {

--- a/src/main/java/org/fife/ui/rsyntaxtextarea/focusabletip/TipWindow.java
+++ b/src/main/java/org/fife/ui/rsyntaxtextarea/focusabletip/TipWindow.java
@@ -56,8 +56,8 @@ class TipWindow extends JWindow implements ActionListener {
 	private FocusableTip ft;
 	private JEditorPane textArea;
 	private String text;
-	private TipListener tipListener;
-	private HyperlinkListener userHyperlinkListener;
+	private transient TipListener tipListener;
+	private transient HyperlinkListener userHyperlinkListener;
 
 	private static TipWindow visibleInstance;
 

--- a/src/main/java/org/fife/ui/rtextarea/ClipboardHistoryPopup.java
+++ b/src/main/java/org/fife/ui/rtextarea/ClipboardHistoryPopup.java
@@ -55,7 +55,7 @@ class ClipboardHistoryPopup extends JWindow {
 	private RTextArea textArea;
 
 	private ChoiceList list;
-	private Listener listener;
+	private transient Listener listener;
 	private boolean prevCaretAlwaysVisible;
 
 	/**

--- a/src/main/java/org/fife/ui/rtextarea/Gutter.java
+++ b/src/main/java/org/fife/ui/rtextarea/Gutter.java
@@ -117,7 +117,7 @@ public class Gutter extends JPanel {
 	/**
 	 * Listens for events in our text area.
 	 */
-	private TextAreaListener listener;
+	private transient TextAreaListener listener;
 
 
 	/**


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1948 - "Fields in a "Serializable" class should either be transient or serializable".
You can find more information about the issue here: 
https://sonarqube.com/coding_rules#q=squid:S2039
Please let me know if you have any questions.
Artyom Melnikov