### PR TITLE
Fixing squid:S2184 and squid:S2178

### DIFF
--- a/src/main/java/org/fife/print/RPrintUtilities.java
+++ b/src/main/java/org/fife/print/RPrintUtilities.java
@@ -422,7 +422,7 @@ public abstract class RPrintUtilities {
 						int pos = currentLineString.lastIndexOf(breakChars[i]) + 1;
 						//if (pos>-1 && pos>currentPos)
 						//	currentPos = pos;
-						if (pos>0 && pos>currentPos & pos!=currentLineString.length())
+						if (pos>0 && pos>currentPos && pos!=currentLineString.length())
 							currentPos = pos;
 					}
 
@@ -521,7 +521,7 @@ public abstract class RPrintUtilities {
 				return x;
 			int tabSizeInPixels = tabSizeInSpaces * fm.charWidth(' ');
 			int ntabs = (((int) x) - xOffset) / tabSizeInPixels;
-			return xOffset + ((ntabs + 1) * tabSizeInPixels);
+			return xOffset + ((ntabs + 1f) * tabSizeInPixels);
 		}
 
 	}

--- a/src/main/java/org/fife/ui/rsyntaxtextarea/SyntaxView.java
+++ b/src/main/java/org/fife/ui/rsyntaxtextarea/SyntaxView.java
@@ -362,11 +362,11 @@ public class SyntaxView extends View implements TabExpander,
 				// here, we get no vertical scrollbar (as lineHeight==0).
 				lineHeight = host!=null ? host.getLineHeight() : lineHeight;
 //				return getElement().getElementCount() * lineHeight;
-int visibleLineCount = getElement().getElementCount();
-if (host.isCodeFoldingEnabled()) {
-	visibleLineCount -= host.getFoldManager().getHiddenLineCount();
-}
-return visibleLineCount * lineHeight;
+                int visibleLineCount = getElement().getElementCount();
+                if (host.isCodeFoldingEnabled()) {
+                    visibleLineCount -= host.getFoldManager().getHiddenLineCount();
+                }
+                return visibleLineCount * (float) lineHeight;
 			default:
 				throw new IllegalArgumentException("Invalid axis: " + axis);
 		}
@@ -651,7 +651,7 @@ if (host.isCodeFoldingEnabled()) {
 		if (tabSize == 0)
 			return x;
 		int ntabs = (((int)x) - tabBase) / tabSize;
-		return tabBase + ((ntabs + 1) * tabSize);
+		return tabBase + ((ntabs + 1f) * tabSize);
 	}
 
 

--- a/src/main/java/org/fife/ui/rsyntaxtextarea/WrappedSyntaxView.java
+++ b/src/main/java/org/fife/ui/rsyntaxtextarea/WrappedSyntaxView.java
@@ -256,7 +256,7 @@ return p + 1;
 		if (host.getEOLMarkersVisible()) {
 			g.setColor(host.getForegroundForTokenType(Token.WHITESPACE));
 			g.setFont(host.getFontForTokenType(Token.WHITESPACE));
-			g.drawString("\u00B6", x, y-fontHeight);
+			g.drawString("\u00B6", x, (float) y-fontHeight);
 		}
 
 	}
@@ -454,7 +454,7 @@ return p + 1;
 		if (host.getEOLMarkersVisible()) {
 			g.setColor(host.getForegroundForTokenType(Token.WHITESPACE));
 			g.setFont(host.getFontForTokenType(Token.WHITESPACE));
-			g.drawString("\u00B6", x, y-fontHeight);
+			g.drawString("\u00B6", x, (float) y-fontHeight);
 		}
 
 	}
@@ -840,7 +840,7 @@ return p + 1;
 		if (tabSize == 0)
 			return x;
 		int ntabs = ((int) x - tabBase) / tabSize;
-		return tabBase + ((ntabs + 1) * tabSize);
+		return tabBase + ((ntabs + 1f) * tabSize);
 	}
 
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules:
squid:S2184 - "Math operands should be cast before assignment".
You can find more information about the issue here: 
https://sonarqube.com/coding_rules#q=squid:S2184
squid:S2178 - "Short-circuit logic should be used in boolean contexts".
You can find more information about the issue here: 
https://sonarqube.com/coding_rules#q=squid:S2178
Please let me know if you have any questions.
Artyom Melnikov