### PR TITLE
Fixing squid:S2162 - "equals" methods should be symmetric and work for subclasses

### DIFF
--- a/src/main/java/org/fife/ui/rsyntaxtextarea/DocumentRange.java
+++ b/src/main/java/org/fife/ui/rsyntaxtextarea/DocumentRange.java
@@ -64,7 +64,10 @@ public class DocumentRange implements Comparable<DocumentRange> {
 		if (other==this) {
 			return true;
 		}
-		if (other instanceof DocumentRange) {
+        if (other == null) {
+            return false;
+        }
+		if (getClass() == other.getClass()) {
 			return this.compareTo((DocumentRange)other)==0;
 		}
 		return false;

--- a/src/main/java/org/fife/ui/rsyntaxtextarea/Style.java
+++ b/src/main/java/org/fife/ui/rsyntaxtextarea/Style.java
@@ -145,7 +145,13 @@ public class Style implements Cloneable {
 	 */
 	@Override
 	public boolean equals(Object o2) {
-		if (o2 instanceof Style) {
+        if (o2 == null) {
+            return false;
+        }
+        if (o2 == this) {
+            return true;
+        }
+		if (getClass() == o2.getClass()) {
 			Style ss2 = (Style)o2;
 			if (this.underline==ss2.underline &&
 				areEqual(foreground, ss2.foreground) &&

--- a/src/main/java/org/fife/ui/rsyntaxtextarea/SyntaxScheme.java
+++ b/src/main/java/org/fife/ui/rsyntaxtextarea/SyntaxScheme.java
@@ -147,28 +147,29 @@ public class SyntaxScheme implements Cloneable, TokenTypes {
 	 */
 	@Override
 	public boolean equals(Object otherScheme) {
+        if (otherScheme == null) {
+            return false;
+        }
+        if (otherScheme == this) {
+            return true;
+        }
+        if (getClass() == otherScheme.getClass()) {
+            Style[] otherSchemes = ((SyntaxScheme)otherScheme).styles;
 
-		// No need for null check; instanceof takes care of this for us,
-		// i.e. "if (!(null instanceof Foo))" evaluates to "true".
-		if (!(otherScheme instanceof SyntaxScheme)) {
-			return false;
-		}
-
-		Style[] otherSchemes = ((SyntaxScheme)otherScheme).styles;
-
-		int length = styles.length;
-		for (int i=0; i<length; i++) {
-			if (styles[i]==null) {
-				if (otherSchemes[i]!=null) {
-					return false;
-				}
-			}
-			else if (!styles[i].equals(otherSchemes[i])) {
-				return false;
-			}
-		}
-		return true;
-
+            int length = styles.length;
+            for (int i=0; i<length; i++) {
+                if (styles[i]==null) {
+                    if (otherSchemes[i]!=null) {
+                        return false;
+                    }
+                }
+                else if (!styles[i].equals(otherSchemes[i])) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return false;
 	}
 
 

--- a/src/main/java/org/fife/ui/rsyntaxtextarea/TokenImpl.java
+++ b/src/main/java/org/fife/ui/rsyntaxtextarea/TokenImpl.java
@@ -290,22 +290,22 @@ public class TokenImpl implements Token {
 
 	@Override
 	public boolean equals(Object obj) {
-
 		if (obj==this) {
 			return true;
 		}
-		if (!(obj instanceof Token)) {
-			return false;
-		}
-
-		Token t2 = (Token)obj;
-		return offset==t2.getOffset() &&
-				type==t2.getType() &&
-				languageIndex==t2.getLanguageIndex() &&
-				hyperlink==t2.isHyperlink() &&
-				((getLexeme()==null && t2.getLexeme()==null) ||
-					(getLexeme()!=null && getLexeme().equals(t2.getLexeme())));
-
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() == obj.getClass()) {
+            Token t2 = (Token)obj;
+            return offset==t2.getOffset() &&
+                    type==t2.getType() &&
+                    languageIndex==t2.getLanguageIndex() &&
+                    hyperlink==t2.isHyperlink() &&
+                    ((getLexeme()==null && t2.getLexeme()==null) ||
+                            (getLexeme()!=null && getLexeme().equals(t2.getLexeme())));
+        }
+		return false;
 	}
 
 

--- a/src/main/java/org/fife/ui/rsyntaxtextarea/folding/Fold.java
+++ b/src/main/java/org/fife/ui/rsyntaxtextarea/folding/Fold.java
@@ -154,7 +154,16 @@ public class Fold implements Comparable<Fold> {
 	 */
 	@Override
 	public boolean equals(Object otherFold) {
-		return otherFold instanceof Fold && compareTo((Fold)otherFold)==0;
+        if (otherFold == null) {
+            return false;
+        }
+        if (otherFold == this) {
+            return true;
+        }
+        if (getClass() == otherFold.getClass()) {
+            return compareTo((Fold)otherFold)==0;
+        }
+		return false;
 	}
 
 

--- a/src/main/java/org/fife/ui/rtextarea/ColorBackgroundPainterStrategy.java
+++ b/src/main/java/org/fife/ui/rtextarea/ColorBackgroundPainterStrategy.java
@@ -50,10 +50,17 @@ public class ColorBackgroundPainterStrategy
 	 */
 	@Override
 	public boolean equals(Object o2) {
-		return o2!=null &&
-			(o2 instanceof ColorBackgroundPainterStrategy) &&
-			this.color.equals(
-				((ColorBackgroundPainterStrategy)o2).getColor());
+        if (o2 == null) {
+            return false;
+        }
+        if (o2 == this) {
+            return true;
+        }
+        if (getClass() == o2.getClass()) {
+            ColorBackgroundPainterStrategy other = (ColorBackgroundPainterStrategy) o2;
+            return color != null ? color.equals(other.color) : other.color == null;
+        }
+		return false;
 	}
 
 

--- a/src/main/java/org/fife/ui/rtextarea/IconGroup.java
+++ b/src/main/java/org/fife/ui/rtextarea/IconGroup.java
@@ -118,18 +118,24 @@ public class IconGroup {
 	 */
 	@Override
 	public boolean equals(Object o2) {
-		if (o2!=null && o2 instanceof IconGroup) {
-			IconGroup ig2 = (IconGroup)o2;
-			if (ig2.getName().equals(getName()) &&
-					separateLargeIcons==ig2.hasSeparateLargeIcons()) {
-				if (separateLargeIcons) {
-					if (!largeIconSubDir.equals(ig2.largeIconSubDir))
-						return false;
-				}
-				return path.equals(ig2.path);
-			}
-			// If we got here, separateLargeIcons values weren't equal.
-		}
+        if (o2 == null) {
+            return false;
+        }
+        if (o2 == this) {
+            return true;
+        }
+        if (getClass() == o2.getClass()) {
+            IconGroup ig2 = (IconGroup)o2;
+            if (ig2.getName().equals(getName()) &&
+                    separateLargeIcons==ig2.hasSeparateLargeIcons()) {
+                if (separateLargeIcons) {
+                    if (!largeIconSubDir.equals(ig2.largeIconSubDir))
+                        return false;
+                }
+                return path.equals(ig2.path);
+            }
+            // If we got here, separateLargeIcons values weren't equal.
+        }
 		return false;
 	}
 

--- a/src/main/java/org/fife/ui/rtextarea/SearchResult.java
+++ b/src/main/java/org/fife/ui/rtextarea/SearchResult.java
@@ -110,10 +110,13 @@ public class SearchResult implements Comparable<SearchResult> {
 	 */
 	@Override
 	public boolean equals(Object other) {
-		if (other==this) {
+		if (other == this) {
 			return true;
 		}
-		if (other instanceof SearchResult) {
+        if (other == null) {
+            return false;
+        }
+		if (getClass() == other.getClass()) {
 			return this.compareTo((SearchResult)other)==0;
 		}
 		return false;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S2162 - ""equals" methods should be symmetric and work for subclasses".
You can find more information about the issue here:
https://sonar.spring.io/coding_rules#rule_key=squid:S2162
Please let me know if you have any questions.
Artyom Melnikov