### PR TITLE
Fixing squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause

### DIFF
--- a/src/main/java/org/fife/ui/rsyntaxtextarea/modes/CSSTokenMaker.java
+++ b/src/main/java/org/fife/ui/rsyntaxtextarea/modes/CSSTokenMaker.java
@@ -637,8 +637,9 @@ public class CSSTokenMaker extends AbstractJFlexCTokenMaker {
 				return TokenTypes.LITERAL_STRING_DOUBLE_QUOTE;
 			case INTERNAL_CSS_MLC:
 				return TokenTypes.COMMENT_MULTILINE;
+            default:
+                return type;
 		}
-		return type;
 	}
 
 
@@ -714,16 +715,16 @@ public class CSSTokenMaker extends AbstractJFlexCTokenMaker {
 				if (initialTokenType<-1024) {
 					int main = -(-initialTokenType & 0xffffff00);
 					switch (main) {
-						default: // Should never happen
-						case INTERNAL_CSS_STRING:
-							state = CSS_STRING;
-							break;
 						case INTERNAL_CSS_CHAR:
 							state = CSS_CHAR_LITERAL;
 							break;
 						case INTERNAL_CSS_MLC:
 							state = CSS_C_STYLE_COMMENT;
 							break;
+                        case INTERNAL_CSS_STRING:
+                        default: // Should never happen
+                            state = CSS_STRING;
+                            break;
 					}
 					cssPrevState = -initialTokenType&0xff;
 				}

--- a/src/main/java/org/fife/ui/rsyntaxtextarea/modes/DTokenMaker.java
+++ b/src/main/java/org/fife/ui/rsyntaxtextarea/modes/DTokenMaker.java
@@ -1363,8 +1363,9 @@ public class DTokenMaker extends AbstractJFlexCTokenMaker {
 		switch (type) {
 			case INTERNAL_IN_NESTABLE_MLC:
 				return TokenTypes.COMMENT_MULTILINE;
+            default:
+                return type;
 		}
-		return type;
 	}
 
 
@@ -1417,10 +1418,10 @@ public class DTokenMaker extends AbstractJFlexCTokenMaker {
 				if (initialTokenType<-1024) {
 					int main = -(-initialTokenType & 0xffffff00);
 					switch (main) {
-						default: // Should never happen
 						case INTERNAL_IN_NESTABLE_MLC:
-							state = NESTABLE_MLC;
-							break;
+                        default: // Should never happen
+                            state = NESTABLE_MLC;
+                            break;
 					}
 					nestedMlcDepth = -initialTokenType&0xff;
 				}

--- a/src/main/java/org/fife/ui/rsyntaxtextarea/modes/DartTokenMaker.java
+++ b/src/main/java/org/fife/ui/rsyntaxtextarea/modes/DartTokenMaker.java
@@ -1553,8 +1553,9 @@ public class DartTokenMaker extends AbstractJFlexCTokenMaker {
 			case INTERNAL_IN_JS_CHAR_INVALID:
 			case INTERNAL_IN_JS_CHAR_VALID:
 				return TokenTypes.LITERAL_STRING_DOUBLE_QUOTE;
+            default:
+                return type;
 		}
-		return type;
 	}
 
 

--- a/src/main/java/org/fife/ui/rsyntaxtextarea/modes/DtdTokenMaker.java
+++ b/src/main/java/org/fife/ui/rsyntaxtextarea/modes/DtdTokenMaker.java
@@ -442,10 +442,10 @@ public class DtdTokenMaker extends AbstractJFlexTokenMaker {
 				if (initialTokenType<-1024) { // INTERNAL_IN_COMMENT - prevState
 					int main = -(-initialTokenType & 0xffffff00);
 					switch (main) {
-						default: // Should never happen
 						case INTERNAL_IN_COMMENT:
-							state = COMMENT;
-							break;
+                        default: // Should never happen
+                            state = COMMENT;
+                            break;
 					}
 					prevState = -initialTokenType&0xff;
 				}

--- a/src/main/java/org/fife/ui/rsyntaxtextarea/modes/HTMLTokenMaker.java
+++ b/src/main/java/org/fife/ui/rsyntaxtextarea/modes/HTMLTokenMaker.java
@@ -2139,16 +2139,16 @@ public class HTMLTokenMaker extends AbstractMarkupTokenMaker {
 				if (initialTokenType<-1024) {
 					int main = -(-initialTokenType & 0xffffff00);
 					switch (main) {
-						default: // Should never happen
-						case INTERNAL_CSS_STRING:
-							state = CSS_STRING;
-							break;
 						case INTERNAL_CSS_CHAR:
 							state = CSS_CHAR_LITERAL;
 							break;
 						case INTERNAL_CSS_MLC:
 							state = CSS_C_STYLE_COMMENT;
 							break;
+                        case INTERNAL_CSS_STRING:
+                        default: // Should never happen
+                            state = CSS_STRING;
+                            break;
 					}
 					cssPrevState = -initialTokenType&0xff;
 					languageIndex = LANG_INDEX_CSS;

--- a/src/main/java/org/fife/ui/rsyntaxtextarea/modes/JSPTokenMaker.java
+++ b/src/main/java/org/fife/ui/rsyntaxtextarea/modes/JSPTokenMaker.java
@@ -6790,11 +6790,6 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
 					// INTERNAL_IN_CSSxxx - cssPrevState
 					int main = -(-initialTokenType & 0xffffff00);
 					switch (main) {
-						default: // Should never happen
-						case INTERNAL_IN_JAVA_DOCCOMMENT:
-							state = JAVA_DOCCOMMENT;
-							jspInState = -initialTokenType&0xff;
-							break;
 						case INTERNAL_IN_JAVA_EXPRESSION:
 							state = JAVA_EXPRESSION;
 							jspInState = -initialTokenType&0xff;
@@ -6818,6 +6813,11 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
 							languageIndex = LANG_INDEX_CSS;
 							cssPrevState = -initialTokenType&0xff;
 							break;
+                        case INTERNAL_IN_JAVA_DOCCOMMENT:
+                        default: // Should never happen
+                            state = JAVA_DOCCOMMENT;
+                            jspInState = -initialTokenType&0xff;
+                            break;
 					}
 				}
 				else {

--- a/src/main/java/org/fife/ui/rsyntaxtextarea/modes/JavaScriptTokenMaker.java
+++ b/src/main/java/org/fife/ui/rsyntaxtextarea/modes/JavaScriptTokenMaker.java
@@ -1273,8 +1273,9 @@ public class JavaScriptTokenMaker extends AbstractJFlexCTokenMaker {
 			case INTERNAL_IN_JS_CHAR_INVALID:
 			case INTERNAL_IN_JS_CHAR_VALID:
 				return TokenTypes.LITERAL_STRING_DOUBLE_QUOTE;
+            default:
+                return type;
 		}
-		return type;
 	}
 
 
@@ -1380,8 +1381,8 @@ public class JavaScriptTokenMaker extends AbstractJFlexCTokenMaker {
 				if (initialTokenType<-1024) { // INTERNAL_IN_E4X_COMMENT - prevState
 					int main = -(-initialTokenType & 0xffffff00);
 					switch (main) {
-						default: // Should never happen
 						case INTERNAL_IN_E4X_COMMENT:
+                        default: // Should never happen
 							state = E4X_COMMENT;
 							break;
 					}

--- a/src/main/java/org/fife/ui/rsyntaxtextarea/modes/NSISTokenMaker.java
+++ b/src/main/java/org/fife/ui/rsyntaxtextarea/modes/NSISTokenMaker.java
@@ -2488,7 +2488,7 @@ public class NSISTokenMaker extends AbstractJFlexCTokenMaker {
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = YYINITIAL;
+		int state;
 		switch (initialTokenType) {
 			case Token.LITERAL_STRING_DOUBLE_QUOTE:
 				state = STRING;
@@ -2502,6 +2502,9 @@ public class NSISTokenMaker extends AbstractJFlexCTokenMaker {
 			case Token.COMMENT_MULTILINE:
 				state = MLC;
 				break;
+            default:
+                state = YYINITIAL;
+                break;
 		}
 
 		start = text.offset;

--- a/src/main/java/org/fife/ui/rsyntaxtextarea/modes/PHPTokenMaker.java
+++ b/src/main/java/org/fife/ui/rsyntaxtextarea/modes/PHPTokenMaker.java
@@ -24598,13 +24598,6 @@ public class PHPTokenMaker extends AbstractMarkupTokenMaker {
 				if (initialTokenType<-1024) { // INTERNAL_IN_PHPxxx - phpInState
 					int main = -(-initialTokenType & 0x0000ff00);
 					switch (main) {
-						default: // Should never happen
-						case INTERNAL_IN_PHP:
-							state = PHP;
-							languageIndex = LANG_INDEX_PHP;
-							phpInState = -initialTokenType&0xff;
-							phpInLangIndex = (-initialTokenType&0x00ff0000)>>16;
-							break;
 						case INTERNAL_IN_PHP_MLC:
 							state = PHP_MLC;
 							languageIndex = LANG_INDEX_PHP;
@@ -24638,6 +24631,13 @@ public class PHPTokenMaker extends AbstractMarkupTokenMaker {
 							languageIndex = LANG_INDEX_CSS;
 							cssPrevState = -initialTokenType&0xff;
 							break;
+                        case INTERNAL_IN_PHP:
+                        default: // Should never happen
+                            state = PHP;
+                            languageIndex = LANG_INDEX_PHP;
+                            phpInState = -initialTokenType&0xff;
+                            phpInLangIndex = (-initialTokenType&0x00ff0000)>>16;
+                            break;
 					}
 				}
 				else {

--- a/src/main/java/org/fife/ui/rsyntaxtextarea/modes/TypeScriptTokenMaker.java
+++ b/src/main/java/org/fife/ui/rsyntaxtextarea/modes/TypeScriptTokenMaker.java
@@ -1280,8 +1280,9 @@ public class TypeScriptTokenMaker extends AbstractJFlexCTokenMaker {
 			case INTERNAL_IN_JS_CHAR_INVALID:
 			case INTERNAL_IN_JS_CHAR_VALID:
 				return TokenTypes.LITERAL_STRING_DOUBLE_QUOTE;
+            default:
+                return type;
 		}
-		return type;
 	}
 
 
@@ -1376,8 +1377,8 @@ public class TypeScriptTokenMaker extends AbstractJFlexCTokenMaker {
 				if (initialTokenType<-1024) { // INTERNAL_IN_E4X_COMMENT - prevState
 					int main = -(-initialTokenType & 0xffffff00);
 					switch (main) {
-						default: // Should never happen
 						case INTERNAL_IN_E4X_COMMENT:
+                        default: // Should never happen
 							state = E4X_COMMENT;
 							break;
 					}

--- a/src/main/java/org/fife/ui/rsyntaxtextarea/modes/WindowsBatchTokenMaker.java
+++ b/src/main/java/org/fife/ui/rsyntaxtextarea/modes/WindowsBatchTokenMaker.java
@@ -61,6 +61,8 @@ public class WindowsBatchTokenMaker extends AbstractTokenMaker {
 				if (value!=-1)
 					tokenType = value;
 				break;
+            default:
+                break;
 		}
 
 		super.addToken(segment, start, end, tokenType, startOffset);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:SwitchLastCaseIsDefaultCheck - ""switch" statements should end with a "default" clause".
You can find more information about the issue here:
https://sonar.spring.io/coding_rules#rule_key=squid:SwitchLastCaseIsDefaultCheck
Please let me know if you have any questions.
Artyom Melnikov