### PR TITLE
Fix invalid initial parser manager state

### DIFF
--- a/src/main/java/org/fife/ui/rsyntaxtextarea/ParserManager.java
+++ b/src/main/java/org/fife/ui/rsyntaxtextarea/ParserManager.java
@@ -119,7 +119,7 @@ class ParserManager implements DocumentListener, ActionListener,
 		parsers = new ArrayList<Parser>(1); // Usually small
 		timer = new Timer(delay, this);
 		timer.setRepeats(false);
-		running = true;
+		running = false;
 	}
 
 


### PR DESCRIPTION
We have some trouble with the parser [timer](https://github.com/bobbylight/RSyntaxTextArea/blob/master/src/main/java/org/fife/ui/rsyntaxtextarea/ParserManager.java#L120) within the ParserManager.

How the timer should work:
  * Initialize a new area, parser manager and timer: `area = new RSyntaxTextArea()` (timer not started)
  * Start timer: `somePane.add(area)` and AWT triggers [addNotify()](https://github.com/bobbylight/RSyntaxTextArea/blob/master/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextArea.java#L476)
  * Stop timer: Close window and AWT triggers [removeNotify()](https://github.com/bobbylight/RSyntaxTextArea/blob/master/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextArea.java#L2135)

We using a `RSyntaxTextArea` in some situation where we never add the area to a panel (we only create an instance). In this case AWT never calls `removeNotify()`. What now happens:
  * Initialize a new area. This creates a new parser manager with `running = true`
  * The timer gets started after adding some parser: [addParser](https://github.com/bobbylight/RSyntaxTextArea/blob/master/src/main/java/org/fife/ui/rsyntaxtextarea/ParserManager.java#L202)
  * The timer fires a parse event after 1250ms

There is no way to stop the timer or prevent the parser manager to start the timer. This fix initialize `running = false` and waits for a `addNotify` / `restartParsing` call until the timer starts.
