### PR TITLE
Gutter Style enhancement

### DIFF
--- a/src/main/java/org/fife/ui/rsyntaxtextarea/Theme.java
+++ b/src/main/java/org/fife/ui/rsyntaxtextarea/Theme.java
@@ -95,6 +95,7 @@ public class Theme {
 
 	public SyntaxScheme scheme;
 
+	public Color gutterBackgroundColor;
 	public Color gutterBorderColor;
 	public Color activeLineRangeColor;
 	public boolean iconRowHeaderInheritsGutterBG;
@@ -157,7 +158,7 @@ public class Theme {
 
 		Gutter gutter = RSyntaxUtilities.getGutter(textArea);
 		if (gutter!=null) {
-			bgColor = gutter.getBackground();
+			gutterBackgroundColor = gutter.getBackground();
 			gutterBorderColor = gutter.getBorderColor();
 			activeLineRangeColor = gutter.getActiveLineRangeColor();
 			iconRowHeaderInheritsGutterBG = gutter.getIconRowHeaderInheritsGutterBackground();
@@ -206,7 +207,7 @@ public class Theme {
 
 		Gutter gutter = RSyntaxUtilities.getGutter(textArea);
 		if (gutter!=null) {
-			gutter.setBackground(bgColor);
+			gutter.setBackground(gutterBackgroundColor);
 			gutter.setBorderColor(gutterBorderColor);
 			gutter.setActiveLineRangeColor(activeLineRangeColor);
 			gutter.setIconRowHeaderInheritsGutterBackground(iconRowHeaderInheritsGutterBG);
@@ -440,6 +441,10 @@ public class Theme {
 			}
 			root.appendChild(elem);
 
+			elem = doc.createElement("gutterBackground");
+			elem.setAttribute("color", colorToString(gutterBackgroundColor));
+			root.appendChild(elem);
+			
 			elem = doc.createElement("gutterBorder");
 			elem.setAttribute("color", colorToString(gutterBorderColor));
 			root.appendChild(elem);
@@ -615,7 +620,7 @@ public class Theme {
 				is.setEncoding("UTF-8");
 				reader.parse(is);
 			} catch (/*SAX|ParserConfiguration*/Exception se) {
-				se.printStackTrace();
+//				se.printStackTrace();
 				throw new IOException(se.toString());
 			}
 		}
@@ -650,6 +655,7 @@ public class Theme {
 				String color = attrs.getValue("color");
 				if (color!=null) {
 					theme.bgColor = stringToColor(color, getDefaultBG());
+					theme.gutterBackgroundColor = theme.bgColor;
 				}
 				else {
 					String img = attrs.getValue("image");
@@ -694,6 +700,13 @@ public class Theme {
 				theme.foldIndicatorFG = stringToColor(color);
 				color = attrs.getValue("iconBg");
 				theme.foldBG = stringToColor(color);
+			}
+
+			else if ("gutterBackground".equals(qName)) {
+				String color = attrs.getValue("color");
+				if (color!=null) {
+					theme.gutterBackgroundColor = stringToColor(color);
+				}
 			}
 
 			else if ("gutterBorder".equals(qName)) {

--- a/src/main/java/org/fife/ui/rtextarea/Gutter.java
+++ b/src/main/java/org/fife/ui/rtextarea/Gutter.java
@@ -846,12 +846,12 @@ public void setBorder(Border border) {
 	/**
 	 * The border used by the gutter.
 	 */
-	private static class GutterBorder extends EmptyBorder {
+	public static class GutterBorder extends EmptyBorder {
 
 		private Color color;
 		private Rectangle visibleRect;
 
-		GutterBorder(int top, int left, int bottom, int right) {
+		public GutterBorder(int top, int left, int bottom, int right) {
 			super(top, left, bottom, right);
 			color = new Color(221, 221, 221);
 			visibleRect = new Rectangle();

--- a/src/main/resources/org/fife/ui/rsyntaxtextarea/themes/theme.dtd
+++ b/src/main/resources/org/fife/ui/rsyntaxtextarea/themes/theme.dtd
@@ -1,7 +1,7 @@
 <!-- DTD for RSyntaxTextArea Theme XML. See /themes folder for examples. -->
 <!ELEMENT RSyntaxTheme (baseFont?, background, caret, selection,
       currentLineHighlight, marginLine, markAllHighlight, markOccurrencesHighlight,
-      matchedBracket, hyperlinks, secondaryLanguages, gutterBorder, lineNumbers,
+      matchedBracket, hyperlinks, secondaryLanguages, gutterBackground?, gutterBorder, lineNumbers,
       foldIndicator, iconRowHeader?, tokenStyles)>
 <!ELEMENT background EMPTY>
 <!ELEMENT baseFont EMPTY>
@@ -15,6 +15,7 @@
 <!ELEMENT hyperlinks EMPTY>
 <!ELEMENT secondaryLanguages (language+)>
 <!ELEMENT language EMPTY>
+<!ELEMENT gutterBackground EMPTY>
 <!ELEMENT gutterBorder EMPTY>
 <!ELEMENT lineNumbers EMPTY>
 <!ELEMENT foldIndicator EMPTY>
@@ -56,6 +57,8 @@
 <!ATTLIST language
       index      (1|2|3) #REQUIRED
       bg         CDATA   #REQUIRED>
+<!ATTLIST gutterBackground
+      color      CDATA #REQUIRED>
 <!ATTLIST gutterBorder
       color      CDATA #REQUIRED>
 <!ATTLIST lineNumbers


### PR DESCRIPTION
**Gutter Style changes from  (#198)**
- Added gutterBackgroundColor with the according functions to read and write to xml
- Adjusted theme.dtd to support the new gutter background color
- Made GutterBorder public so that the margin can be changed
(Old theme xmls still supported, since "gutterBackground" is optional)

**Solved the issue from (#190)**
- Removed a redundant stacktrace before a throw