### PR TITLE
Difficult to make tooltip appear by hovering over error

### DIFF
--- a/src/main/java/org/fife/ui/rsyntaxtextarea/TokenImpl.java
+++ b/src/main/java/org/fife/ui/rsyntaxtextarea/TokenImpl.java
@@ -481,10 +481,7 @@ public class TokenImpl implements Token {
 					nextX = stableX + fm.charsWidth(text, start, i - start + 1);
 				}
 				if (x >= currX && x < nextX) {
-					if ((x - currX) < (nextX - x)) {
-						return last + i - token.textOffset;
-					}
-					return last + i + 1 - token.textOffset;
+                    return last + i - token.textOffset;
 				}
 			}
 


### PR DESCRIPTION
 * Fixing a bug in TokenImpl.getListOffset() which was causing
   the wrong position in the text to be returned based on the
   position provided.  If the position was more than half way
   into the character then it was rounding up to the next character.