### PR TITLE
Clear out the marked out occurences

### DIFF
--- a/src/main/java/org/fife/ui/rsyntaxtextarea/MarkOccurrencesSupport.java
+++ b/src/main/java/org/fife/ui/rsyntaxtextarea/MarkOccurrencesSupport.java
@@ -124,6 +124,8 @@ class MarkOccurrencesSupport implements CaretListener, ActionListener {
 					// TODO: Do a textArea.repaint() instead of repainting each
 					// marker as it's added if count is huge
 					occurrencesChanged = true;
+				} else {
+					clear();
 				}
 
 			} finally {


### PR DESCRIPTION
If a user has a marked occurence, then he selects all the text and deletes it the entire text area becomes marked. Created a small fix that clears all the marked occurences.