### PR TITLE
Prevent divide by 0 exception and cleanup

### DIFF
--- a/src/main/java/org/fife/ui/rsyntaxtextarea/SyntaxView.java
+++ b/src/main/java/org/fife/ui/rsyntaxtextarea/SyntaxView.java
@@ -946,11 +946,12 @@ else {
 		else {
 
 			Element map = doc.getDefaultRootElement();
+			lineHeight = host!=null ? host.getLineHeight() : lineHeight;
 			int lineIndex = Math.abs((y - alloc.y) / lineHeight);//metrics.getHeight() );
-FoldManager fm = host.getFoldManager();
-//System.out.print("--- " + lineIndex);
-lineIndex += fm.getHiddenLineCountAbove(lineIndex, true);
-//System.out.println(" => " + lineIndex);
+			FoldManager fm = host.getFoldManager();
+			//System.out.print("--- " + lineIndex);
+			lineIndex += fm.getHiddenLineCountAbove(lineIndex, true);
+			//System.out.println(" => " + lineIndex);
 			if (lineIndex >= map.getElementCount()) {
 				return host.getLastVisibleOffset();
 			}


### PR DESCRIPTION
It seems a check was missed since we initialize lineHeight to 0...

this fixes https://github.com/arduino/Arduino/issues/7861