### PR TITLE
Add search wrap capability

### DIFF
--- a/src/main/java/org/fife/ui/rtextarea/SearchContext.java
+++ b/src/main/java/org/fife/ui/rtextarea/SearchContext.java
@@ -40,6 +40,9 @@ public class SearchContext implements Cloneable {
 	/** Fired when search direction is toggled. */
 	public static final String PROPERTY_SEARCH_FORWARD = "Search.Forward";
 
+	/** Fired when search wrap is toggled. */
+	public static final String PROPERTY_SEARCH_WRAP = "Search.Wrap";
+
 	/** Fired when "search in selection" is toggled (not currently supported). */
 	public static final String PROPERTY_SELECTION_ONLY = "Search.SelectionOnly";
 
@@ -52,6 +55,7 @@ public class SearchContext implements Cloneable {
 	private String searchFor;
 	private String replaceWith;
 	private boolean forward;
+	private boolean wrap;
 	private boolean matchCase;
 	private boolean wholeWord;
 	private boolean regex;
@@ -94,6 +98,7 @@ public class SearchContext implements Cloneable {
 		this.matchCase = matchCase;
 		markAll = true;
 		forward = true;
+		wrap = true;
 	}
 
 
@@ -189,6 +194,16 @@ public class SearchContext implements Cloneable {
 	 */
 	public boolean getSearchForward() {
 		return forward;
+	}
+
+	/**
+	 * Returns whether the search should wrap.
+	 *
+	 * @return Whether we should search wrap
+	 * @see #setSearchWrap(boolean)
+	 */
+	public boolean getSearchWrap() {
+		return wrap;
 	}
 
 
@@ -335,6 +350,21 @@ public class SearchContext implements Cloneable {
 		if (forward!=this.forward) {
 			this.forward = forward;
 			firePropertyChange(PROPERTY_SEARCH_FORWARD, !forward, forward);
+		}
+	}
+
+	/**
+	 * Sets whether the search should be wrap through the text.
+	 * This method fires a property change event of type
+	 * {@link #PROPERTY_SEARCH_WRAP}.
+	 *
+	 * @param wrap Whether we should search wrap
+	 * @see #getSearchWrap()
+	 */
+	public void setSearchWrap(boolean wrap) {
+		if (wrap!=this.wrap) {
+			this.wrap = wrap;
+			firePropertyChange(PROPERTY_SEARCH_WRAP, !wrap, wrap);
 		}
 	}
 

--- a/src/test/java/org/fife/ui/rtextarea/SearchEngineTest.java
+++ b/src/test/java/org/fife/ui/rtextarea/SearchEngineTest.java
@@ -133,10 +133,17 @@ public class SearchEngineTest {
 	 */
 	@Test
 	public void testSearchEngineFindBackward() {
-		testSearchEngineFindBackwardImpl(true);
-		testSearchEngineFindBackwardImpl(false);
+		testSearchEngineFindBackwardImpl(true,false);
+		testSearchEngineFindBackwardImpl(false,false);
 	}
 
+	/**
+	 * Tests <code>SearchEngine.find()</code> when searching with wrap.
+	 */
+	@Test
+	public void testSearchEngineFindWrap() {
+		testSearchEngineWrapImpl();
+	}
 
 	/**
 	 * Tests <code>SearchEngine.find()</code> when searching backward.
@@ -144,7 +151,40 @@ public class SearchEngineTest {
 	 * @param markAll Whether or not "mark all" should be enabled during the
 	 *        test.
 	 */
-	private void testSearchEngineFindBackwardImpl(boolean markAll) {
+	private void testSearchEngineWrapImpl() {
+
+		textArea.setText(text);
+
+		int end = text.length();
+		SearchContext context = new SearchContext();
+		context.setSearchForward(false);
+		context.setMarkAll(false);
+
+		// Search for "Chuck", non matching case.
+		context.setSearchFor("Chuck");
+		context.setSearchWrap(false);
+		context.setMatchCase(true);
+		textArea.setCaretPosition(27);
+		boolean found = findImpl(context);
+		assertFalse(found);
+
+		// Search for "Chuck", matching case.
+		context.setSearchFor("Chuck");
+		context.setSearchWrap(true);
+		context.setMatchCase(true);
+		textArea.setCaretPosition(27);
+		found = findImpl(context);
+		assertTrue(found);
+
+	}
+
+	/**
+	 * Tests <code>SearchEngine.find()</code> when searching backward.
+	 *
+	 * @param markAll Whether or not "mark all" should be enabled during the
+	 *        test.
+	 */
+	private void testSearchEngineFindBackwardImpl(boolean markAll,boolean wrap) {
 
 		textArea.setText(text);
 
@@ -152,6 +192,7 @@ public class SearchEngineTest {
 		SearchContext context = new SearchContext();
 		context.setSearchForward(false);
 		context.setMarkAll(markAll);
+		context.setSearchWrap(wrap);
 
 		// Search for "chuck", ignoring case.
 		context.setSearchFor("chuck");
@@ -299,8 +340,8 @@ public class SearchEngineTest {
 	 */
 	@Test
 	public void testSearchEngineFindForward() {
-		testSearchEngineFindForwardImpl(true);
-		testSearchEngineFindForwardImpl(false);
+		testSearchEngineFindForwardImpl(true,false);
+		testSearchEngineFindForwardImpl(false,false);
 	}
 
 
@@ -309,12 +350,13 @@ public class SearchEngineTest {
 	 *
 	 * @param markAll Whether "mark all" should be enabled during the test.
 	 */
-	private void testSearchEngineFindForwardImpl(boolean markAll) {
+	private void testSearchEngineFindForwardImpl(boolean markAll,boolean wrap) {
 
 		textArea.setText(text);
 
 		SearchContext context = new SearchContext();
 		context.setMarkAll(markAll);
+		context.setSearchWrap(wrap);
 
 		// Search for "chuck", ignoring case.
 		context.setSearchFor("chuck");
@@ -466,6 +508,7 @@ public class SearchEngineTest {
 		String searchFor = "[how]{3}|";
 		SearchContext context = new SearchContext(searchFor);
 		context.setRegularExpression(true);
+		context.setSearchWrap(false);
 
 		assertTrue(findImpl(context));
 		assertResult(new SearchResult(new DocumentRange(0, 3), 1, 4));

--- a/src/test/java/org/fife/ui/rtextarea/SearchEngineTest.java
+++ b/src/test/java/org/fife/ui/rtextarea/SearchEngineTest.java
@@ -157,10 +157,10 @@ public class SearchEngineTest {
 
 		int end = text.length();
 		SearchContext context = new SearchContext();
-		context.setSearchForward(false);
 		context.setMarkAll(false);
 
 		// Search for "Chuck", non matching case.
+		context.setSearchForward(false);
 		context.setSearchFor("Chuck");
 		context.setSearchWrap(false);
 		context.setMatchCase(true);
@@ -173,6 +173,23 @@ public class SearchEngineTest {
 		context.setSearchWrap(true);
 		context.setMatchCase(true);
 		textArea.setCaretPosition(27);
+		found = findImpl(context);
+		assertTrue(found);
+
+		// Search for "Chuck", non matching case.
+		context.setSearchForward(true);
+		context.setSearchFor("wood");
+		context.setSearchWrap(false);
+		context.setMatchCase(true);
+		textArea.setCaretPosition(49);
+	    found = findImpl(context);
+		assertFalse(found);
+
+		// Search for "Chuck", matching case.
+		context.setSearchFor("Chuck");
+		context.setSearchWrap(true);
+		context.setMatchCase(true);
+		textArea.setCaretPosition(49);
 		found = findImpl(context);
 		assertTrue(found);
 


### PR DESCRIPTION
I added a SearchContext capability to wrap around the direction of searching.  A separate pull request for the rsta project contains the user interface changes.