### PR TITLE
fix: Could not copy the character not in US-ASCII charset

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RTfToText.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RTfToText.java
@@ -17,7 +17,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringReader;
-
+import java.nio.charset.StandardCharsets;
 
 /**
  * Gets the plain text version of RTF documents.<p>
@@ -200,7 +200,7 @@ final class RtfToText {
 	 * @throws IOException If an IO error occurs.
 	 */
 	public static String getPlainText(InputStream in) throws IOException {
-		return getPlainText(new InputStreamReader(in, "US-ASCII"));
+		return getPlainText(new InputStreamReader(in, StandardCharsets.UTF_8));
 	}
 
 


### PR DESCRIPTION
English is not my native language; please excuse typing errors.

`copyAsStyledText` method in `RSyntaxTextArea` call `getTextAsRtf`, and `getTextAsRtf` get string bytes with charset UTF-8
https://github.com/bobbylight/RSyntaxTextArea/blob/6e11bfe67470b6d019615f004f378ad793904c9d/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextArea.java#L1713

than, when paste text, `StyledTextTransferable` call `RtfToText.getPlainText` to get plain text, but `getPlainText` use charset US-ASCII
https://github.com/bobbylight/RSyntaxTextArea/blob/6e11bfe67470b6d019615f004f378ad793904c9d/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RTfToText.java#L202-L204

This causes it can only copy characters in the US-ASCII charset.
I just change `"US-ASCII"` to `StandardCharsets.UTF_8` to fix this.