### PR TITLE
Fix gradle builds on Mac OS X.

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -58,7 +58,7 @@
     <!-- Checks that property files contain the same keys.         -->
     <!-- See http://checkstyle.sf.net/config_misc.html#Translation -->
     <module name="Translation"/>
-    
+
     <!-- Checks for Size Violations.                    -->
     <!-- See http://checkstyle.sf.net/config_sizes.html -->
     <module name="FileLength">
@@ -211,9 +211,9 @@
         <module name="UpperEll"/>
 
     </module>
-	
+
 	<module name="SuppressionFilter">
-		<property name="file" value="config/checkstyle/rstaSuppressions.xml"/>
+		<property name="file" value="${config_loc}//rstaSuppressions.xml"/>
 	</module>
 
 </module>


### PR DESCRIPTION
The checkstyles plugin configuration file being included could not be
found. This change uses the built-in configuration directory variable
to make it work cross-platform.

I had to do this because I was trying to fix the RSTAUI gradle build
to properly use Maven-based dependencies as discussed in
https://github.com/bobbylight/RSTAUI/issues/16 but I could not get
that to compile because of serialization problems that you fixed in
RSyntaxTextArea version 3.0.8-SNAPSHOT, but you had not pushed that
snapshot to the Sonatype OSSRH repository. By fixing this build, I am
now able to run `gradlew publishToMavenLocal` and it builds and
installs the latest snapshot into my local `.m2` Maven cache
repository, and I can proceed with fixing the RSTAUI build.