### PR TITLE
Add wrap flag to SearchContext

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/SearchContext.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/SearchContext.java
@@ -41,6 +41,9 @@ public class SearchContext implements Cloneable, Serializable {
 	/** Fired when search direction is toggled. */
 	public static final String PROPERTY_SEARCH_FORWARD = "Search.Forward";
 
+	/** Fired when search wrap is toggled. */
+	public static final String PROPERTY_SEARCH_WRAP = "Search.Wrap";
+
 	/** Fired when "search in selection" is toggled (not currently supported). */
 	public static final String PROPERTY_SELECTION_ONLY = "Search.SelectionOnly";
 
@@ -53,6 +56,7 @@ public class SearchContext implements Cloneable, Serializable {
 	private String searchFor;
 	private String replaceWith;
 	private boolean forward;
+	private boolean wrap;
 	private boolean matchCase;
 	private boolean wholeWord;
 	private boolean regex;
@@ -97,6 +101,7 @@ public class SearchContext implements Cloneable, Serializable {
 		this.matchCase = matchCase;
 		markAll = true;
 		forward = true;
+		wrap = false;
 	}
 
 
@@ -192,6 +197,17 @@ public class SearchContext implements Cloneable, Serializable {
 	 */
 	public boolean getSearchForward() {
 		return forward;
+	}
+
+
+	/**
+	 * Returns whether the search should wrap.
+	 *
+	 * @return Whether we should search wrap
+	 * @see #setSearchWrap(boolean)
+	 */
+	public boolean getSearchWrap() {
+		return wrap;
 	}
 
 
@@ -338,6 +354,22 @@ public class SearchContext implements Cloneable, Serializable {
 		if (forward!=this.forward) {
 			this.forward = forward;
 			firePropertyChange(PROPERTY_SEARCH_FORWARD, !forward, forward);
+		}
+	}
+
+
+	/**
+	 * Sets whether the search should be wrap through the text.
+	 * This method fires a property change event of type
+	 * {@link #PROPERTY_SEARCH_WRAP}.
+	 *
+	 * @param wrap Whether we should search wrap
+	 * @see #getSearchWrap()
+	 */
+	public void setSearchWrap(boolean wrap) {
+		if (wrap!=this.wrap) {
+			this.wrap = wrap;
+			firePropertyChange(PROPERTY_SEARCH_WRAP, !wrap, wrap);
 		}
 	}
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/SearchEngine.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/SearchEngine.java
@@ -124,7 +124,9 @@ public final class SearchEngine {
 			findIn = getFindInText(textArea, start, forward);
 
 			if (findIn == null || findIn.length() == 0) {
-				return new SearchResult();
+				SearchResult emptyResult = new SearchResult();
+				emptyResult.setWrapped(true);
+				return emptyResult;
 			}
 
 			if (doMarkAll) {
@@ -133,6 +135,7 @@ public final class SearchEngine {
 			}
 
 			result = SearchEngine.findImpl(findIn, context);
+			result.setWrapped(true);
 			if (result.wasFound() && !result.getMatchRange().isZeroLength()) {
 				// Without this, if JTextArea isn't in focus, selection
 				// won't appear selected.

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/SearchEngine.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/SearchEngine.java
@@ -94,7 +94,7 @@ public final class SearchEngine {
 						Math.min(c.getDot(), c.getMark());
 
 		String findIn = getFindInText(textArea, start, forward);
-		if (findIn==null || findIn.length()==0) {
+		if (!context.getSearchWrap() && (findIn == null || findIn.length() == 0)) {
 			return new SearchResult();
 		}
 
@@ -104,7 +104,7 @@ public final class SearchEngine {
 					getMarkedCount();
 		}
 
-		SearchResult result = SearchEngine.findImpl(findIn, context);
+		SearchResult result = SearchEngine.findImpl(findIn == null ? "" : findIn, context);
 		if (result.wasFound() && !result.getMatchRange().isZeroLength()) {
 			// Without this, if JTextArea isn't in focus, selection
 			// won't appear selected.
@@ -114,6 +114,36 @@ public final class SearchEngine {
 			}
 			RSyntaxUtilities.selectAndPossiblyCenter(textArea,
 					result.getMatchRange(), true);
+		} else if (context.getSearchWrap() && !result.wasFound()) {
+			if (forward) {
+				start = 0;
+			} else {
+				start = textArea.getDocument().getLength() - 1;
+			}
+
+			findIn = getFindInText(textArea, start, forward);
+
+			if (findIn == null || findIn.length() == 0) {
+				return new SearchResult();
+			}
+
+			if (doMarkAll) {
+				markAllCount = markAllImpl((RTextArea) textArea, context).
+					getMarkedCount();
+			}
+
+			result = SearchEngine.findImpl(findIn, context);
+			if (result.wasFound() && !result.getMatchRange().isZeroLength()) {
+				// Without this, if JTextArea isn't in focus, selection
+				// won't appear selected.
+				textArea.getCaret().setSelectionVisible(true);
+				if (forward) {
+					result.getMatchRange().translate(start);
+				}
+				RSyntaxUtilities.selectAndPossiblyCenter(textArea,
+					result.getMatchRange(), true
+				);
+			}
 		}
 
 		result.setMarkedCount(markAllCount);

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/SearchResult.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/SearchResult.java
@@ -43,6 +43,12 @@ public class SearchResult implements Comparable<SearchResult> {
 	 */
 	private int markedCount;
 
+	/**
+	 * Whether this result is from a "wrapping" search - that is, no results were found from caret -> end of document,
+	 * but a result _was_ found in a subsequent search from document start -> caret.
+	 */
+	private boolean wrapped;
+
 
 	/**
 	 * Constructor; indicates no match is found.
@@ -212,6 +218,31 @@ public class SearchResult implements Comparable<SearchResult> {
 	 */
 	public void setMatchRange(DocumentRange range) {
 		this.matchRange = range;
+	}
+
+
+	/**
+	 * Marks this search result as a 'wrapped' result; that is, it came from the second pass through a
+	 * document, after an initial search forward or backward from the caret didn't return anything.
+	 *
+	 * @param wrapped The new 'wrapped' state. Defaults to false.
+	 * @see #isWrapped()
+	 * @see SearchContext#setSearchWrap(boolean)
+	 */
+	public void setWrapped(boolean wrapped) {
+		this.wrapped = wrapped;
+	}
+
+
+	/**
+	 * Returns whether this is a 'wrapped' result, meaning it came from a second pass through the document, after an
+	 * initial search forward or backward from the caret didn't return anything.
+	 *
+	 * @return true if the result was from a 'wrapping' search; false otherwise.
+	 * @see SearchContext#setSearchWrap(boolean)
+	 */
+	public boolean isWrapped() {
+		return wrapped;
 	}
 
 

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/SearchEngineTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/SearchEngineTest.java
@@ -480,6 +480,7 @@ public class SearchEngineTest {
 		textArea.setCaretPosition(27);
 		boolean found = findImpl(context);
 		assertFalse(found);
+		assertFalse(result.isWrapped());
 
 		// Search for "Chuck", matching case.
 		context.setSearchFor("Chuck");
@@ -488,6 +489,7 @@ public class SearchEngineTest {
 		textArea.setCaretPosition(27);
 		found = findImpl(context);
 		assertTrue(found);
+		assertTrue(result.isWrapped());
 
 		// Search for "Chuck", non matching case.
 		context.setSearchForward(true);
@@ -497,6 +499,7 @@ public class SearchEngineTest {
 		textArea.setCaretPosition(49);
 		found = findImpl(context);
 		assertFalse(found);
+		assertFalse(result.isWrapped());
 
 		// Search for "Chuck", matching case.
 		context.setSearchFor("Chuck");
@@ -505,6 +508,7 @@ public class SearchEngineTest {
 		textArea.setCaretPosition(49);
 		found = findImpl(context);
 		assertTrue(found);
+		assertTrue(result.isWrapped());
 	}
 
 

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/SearchEngineTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/SearchEngineTest.java
@@ -456,6 +456,59 @@ public class SearchEngineTest {
 
 
 	/**
+	 * Tests <code>SearchEngine.find()</code> when searching with wrap.
+	 */
+	@Test
+	public void testSearchEngineFindWrap() {
+		testSearchEngineWrapImpl();
+	}
+
+	/**
+	 * Tests <code>SearchEngine.find()</code> when searching the entire document.
+	 *
+	 */
+	private void testSearchEngineWrapImpl() {
+		textArea.setText(text);
+
+		SearchContext context = new SearchContext();
+
+		// Search for "Chuck", non matching case.
+		context.setSearchForward(false);
+		context.setSearchFor("Chuck");
+		context.setSearchWrap(false);
+		context.setMatchCase(true);
+		textArea.setCaretPosition(27);
+		boolean found = findImpl(context);
+		assertFalse(found);
+
+		// Search for "Chuck", matching case.
+		context.setSearchFor("Chuck");
+		context.setSearchWrap(true);
+		context.setMatchCase(true);
+		textArea.setCaretPosition(27);
+		found = findImpl(context);
+		assertTrue(found);
+
+		// Search for "Chuck", non matching case.
+		context.setSearchForward(true);
+		context.setSearchFor("wood");
+		context.setSearchWrap(false);
+		context.setMatchCase(true);
+		textArea.setCaretPosition(49);
+		found = findImpl(context);
+		assertFalse(found);
+
+		// Search for "Chuck", matching case.
+		context.setSearchFor("Chuck");
+		context.setSearchWrap(true);
+		context.setMatchCase(true);
+		textArea.setCaretPosition(49);
+		found = findImpl(context);
+		assertTrue(found);
+	}
+
+
+	/**
 	 * https://github.com/bobbylight/RSyntaxTextArea/issues/38
 	 */
 	@Test


### PR DESCRIPTION
Replaces #276 (thanks, @giles7777!), closes #13.

Unlike Giles' original PR, I left the default behavior to _not_ wrap, and also suppressed a potential NPE Sonarlint detected. Otherwise, body is entirely Gile's original work on #276.