### PR TITLE
Fix FocusHotkey French translation

### DIFF
--- a/RSyntaxTextArea/src/main/resources/org/fife/ui/rsyntaxtextarea/focusabletip/FocusableTip_fr.properties
+++ b/RSyntaxTextArea/src/main/resources/org/fife/ui/rsyntaxtextarea/focusabletip/FocusableTip_fr.properties
@@ -1,1 +1,1 @@
-FocusHotkey=Press 'F2' pour se concentrer
+FocusHotkey=Appuyer sur 'F2' pour déplacer le focus


### PR DESCRIPTION
The French translation of `FocusHotkey` is wrong, "Press F2" wasn't translated but should be "Appuyer sur F2" instead, and "focus" was wrongly translated to "se concentrer", the technical term "focus" should be retained instead.