### PR TITLE
Fix Error Strip's Marker Position when text area does not fill available space

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/ErrorStrip.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/ErrorStrip.java
@@ -306,7 +306,7 @@ public class ErrorStrip extends JPanel {
 	public String getToolTipText(MouseEvent e) {
 		String text = null;
 		int line = yToLine(e.getY());
-		if (line>-1) {
+		if (line>-1) { 
 			text = MSG.getString("Line");
 			text = MessageFormat.format(text, line + 1);
 		}
@@ -325,7 +325,10 @@ public class ErrorStrip extends JPanel {
 	private int lineToY(int line) {
 		int h = textArea.getVisibleRect().height;
 		float lineCount = textArea.getLineCount();
-		return (int)(((line-1)/(lineCount-1)) * (h-2));
+		int lineHeight = textArea.getLineHeight();
+		int linesPerVisibleRect = h / lineHeight;
+
+		return (int)(((line-1)/( Math.max(lineCount, linesPerVisibleRect) -1)) * (h-2));
 	}
 
 
@@ -567,9 +570,14 @@ public class ErrorStrip extends JPanel {
 	private int yToLine(int y) {
 		int line = -1;
 		int h = textArea.getVisibleRect().height;
+		
+		int lineHeight = textArea.getLineHeight();
+		int linesPerVisibleRect = h / lineHeight;
+		int lineCount = textArea.getLineCount();
+		
 		if (y<h) {
 			float at = y/(float)h;
-			line = Math.round((textArea.getLineCount()-1)*at);
+			line = Math.round((Math.min(lineCount, linesPerVisibleRect)-1)*at);
 		}
 		return line;
 	}
@@ -643,9 +651,16 @@ public class ErrorStrip extends JPanel {
 		@Override
 		public void caretUpdate(CaretEvent e) {
 			if (getFollowCaret()) {
-				int line = textArea.getCaretLineNumber();
-				float percent = line / (float)(textArea.getLineCount()-1);
 				textArea.computeVisibleRect(visibleRect);
+				int h = textArea.getVisibleRect().height;
+		
+				int lineHeight = textArea.getLineHeight();
+				int linesPerVisibleRect = h / lineHeight;
+				int lineCount = textArea.getLineCount();
+		
+				int line = textArea.getCaretLineNumber();
+				float percent = line / (float)(Math.max(linesPerVisibleRect, lineCount)-1);
+				
 				caretLineY = (int)(visibleRect.height*percent);
 				if (caretLineY!=lastLineY) {
 					repaint(0,lastLineY, getWidth(), 2); // Erase old position


### PR DESCRIPTION
All credit for work to @manticore-projects; this is just a cherry pick of the related fix (I'm pretty sure; there were two conflicting commits in the history, so I only used the latest).

Fixes #380, duplicates #381 