### PR TITLE
Update syntaxEditingStyle in alternate constructor

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextArea.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextArea.java
@@ -412,6 +412,7 @@ private boolean fractionalFontMetricsEnabled;
 	 */
 	public RSyntaxTextArea(RSyntaxDocument doc, String text,int rows,int cols) {
 		super(doc, text, rows, cols);
+		setSyntaxEditingStyle(doc.getSyntaxStyle());
 	}
 
 


### PR DESCRIPTION
This is a very small fix :)

When you call RSyntaxTextArea with the 4-arg constructor it doesn't set syntaxEditingStyle. You have to set it manually otherwise you get some confusing bugs, because the document's style is correct but code-folding / autocompletion won't work.