### PR TITLE
Defaulting styled copy/cut action for RSyntaxTextArea.

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/HtmlUtil.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/HtmlUtil.java
@@ -134,13 +134,13 @@ public final class HtmlUtil {
 	public static String getTextAsHtml(RSyntaxTextArea textArea, int start, int end) {
 
 		// Create the selection as HTML
-		StringBuilder sb = new StringBuilder("<pre style='")
-			.append("font-family: \"").append(textArea.getFont().getFamily()).append("\", courier;");
+		StringBuilder sb = new StringBuilder("<pre style=\"")
+			.append("font-family: '").append(textArea.getFont().getFamily()).append("', courier;");
 		if (textArea.getBackground() != null) { // May be null if it is an image
 			sb.append(" background: ")
 				.append(HtmlUtil.getHexString(textArea.getBackground()));
 		}
-		sb.append("'>");
+		sb.append("\">");
 
 		Token token = textArea.getTokenListFor(start, end);
 		for (Token t = token; t != null; t = t.getNextToken()) {

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextArea.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextArea.java
@@ -17,10 +17,7 @@ import java.awt.Rectangle;
 import java.awt.RenderingHints;
 import java.awt.Window;
 import java.awt.datatransfer.Clipboard;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.InputEvent;
-import java.awt.event.MouseEvent;
+import java.awt.event.*;
 import java.awt.font.FontRenderContext;
 import java.io.File;
 import java.lang.reflect.Method;
@@ -33,13 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.ResourceBundle;
 
-import javax.swing.JLabel;
-import javax.swing.JMenu;
-import javax.swing.JPopupMenu;
-import javax.swing.JViewport;
-import javax.swing.SwingUtilities;
-import javax.swing.Timer;
-import javax.swing.UIManager;
+import javax.swing.*;
 import javax.swing.event.CaretEvent;
 import javax.swing.event.CaretListener;
 import javax.swing.event.HyperlinkEvent;
@@ -56,10 +47,7 @@ import org.fife.ui.rsyntaxtextarea.folding.FoldManager;
 import org.fife.ui.rsyntaxtextarea.parser.Parser;
 import org.fife.ui.rsyntaxtextarea.parser.ParserNotice;
 import org.fife.ui.rsyntaxtextarea.parser.ToolTipInfo;
-import org.fife.ui.rtextarea.ClipboardHistory;
-import org.fife.ui.rtextarea.RTextArea;
-import org.fife.ui.rtextarea.RTextAreaUI;
-import org.fife.ui.rtextarea.RecordableTextAction;
+import org.fife.ui.rtextarea.*;
 
 
 /**
@@ -785,7 +773,21 @@ private boolean fractionalFontMetricsEnabled;
 		collapseAllFoldsAction = new RSyntaxTextAreaEditorKit.CollapseAllFoldsAction(true);
 		expandAllFoldsAction = new RSyntaxTextAreaEditorKit.ExpandAllFoldsAction(true);
 
+		RecordableTextAction plainCut = cutAction;
+		RecordableTextAction plainCopy = copyAction;
+		cutAction = new RSyntaxTextAreaEditorKit.CopyCutAsStyledTextAction(true);
+		copyAction = new RSyntaxTextAreaEditorKit.CopyCutAsStyledTextAction(false);
+		copyActionAttributes(plainCopy, copyAction);
+		copyActionAttributes(plainCut, cutAction);
 	}
+
+	private static void copyActionAttributes(RecordableTextAction from, RecordableTextAction to) {
+		to.setName(from.getName());
+		to.setMnemonic(from.getMnemonic());
+		to.setShortDescription(from.getShortDescription());
+		to.setAccelerator(from.getAccelerator());
+	}
+
 
 
 	/**

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextArea.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextArea.java
@@ -676,13 +676,15 @@ private boolean fractionalFontMetricsEnabled;
 		// Get the selection as RTF
 		byte[] rtfBytes = getTextAsRtf(selStart, selEnd);
 
+		String plainText = getSelectedText();
+
 		// Set the system clipboard contents to the RTF selection.
-		StyledTextTransferable contents = new StyledTextTransferable(html, rtfBytes);
+		StyledTextTransferable contents = new StyledTextTransferable(plainText, html, rtfBytes);
 
 		Clipboard cb = getToolkit().getSystemClipboard();
 		try {
 			cb.setContents(contents, null);
-			ClipboardHistory.get().add(getSelectedText());
+			ClipboardHistory.get().add(plainText);
 		} catch (IllegalStateException ise) {
 			UIManager.getLookAndFeel().provideErrorFeedback(null);
 		}

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaDefaultInputMap.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaDefaultInputMap.java
@@ -74,5 +74,12 @@ public class RSyntaxTextAreaDefaultInputMap extends RTADefaultInputMap {
 
 	}
 
+	protected String getCopyAction() {
+		return RSyntaxTextAreaEditorKit.rstaCopyAsStyledTextAction;
+	}
+
+	protected String getCutAction() {
+		return RSyntaxTextAreaEditorKit.rstaCutAsStyledTextAction;
+	}
 
 }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaEditorKit.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaEditorKit.java
@@ -658,6 +658,12 @@ public class RSyntaxTextAreaEditorKit extends RTextAreaEditorKit {
 
 		@Override
 		public void actionPerformedImpl(ActionEvent e, RTextArea textArea) {
+
+			if (cutAction && (!textArea.isEditable() || !textArea.isEnabled())) {
+				UIManager.getLookAndFeel().provideErrorFeedback(textArea);
+				return;
+			}
+
 			((RSyntaxTextArea)textArea).copyAsStyledText(theme);
 			if (cutAction) {
 				int selStart = textArea.getSelectionStart();

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/StyledTextTransferable.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/StyledTextTransferable.java
@@ -29,7 +29,7 @@ import java.io.StringReader;
 class StyledTextTransferable implements Transferable {
 
 	/**
-	 * The tranferred plain text
+	 * The transferred plain text.
 	 */
 	private String plain;
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/StyledTextTransferable.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/StyledTextTransferable.java
@@ -29,6 +29,11 @@ import java.io.StringReader;
 class StyledTextTransferable implements Transferable {
 
 	/**
+	 * The tranferred plain text
+	 */
+	private String plain;
+
+	/**
 	 * The transferred text, as HTML.
 	 */
 	private String html;
@@ -56,7 +61,8 @@ class StyledTextTransferable implements Transferable {
 	 * @param html The transferred text, as HTML.
 	 * @param rtfBytes The transferred text, as RTF bytes.
 	 */
-	StyledTextTransferable(String html, byte[] rtfBytes) {
+	StyledTextTransferable(String plain, String html, byte[] rtfBytes) {
+		this.plain = plain;
 		this.html = html;
 		this.rtfBytes = rtfBytes;
 	}
@@ -75,15 +81,11 @@ class StyledTextTransferable implements Transferable {
 		}
 
 		else if (flavor.equals(FLAVORS[2])) { // stringFlavor
-			return rtfBytes ==null ? "" : RtfToText.getPlainText(rtfBytes);
+			return plain;
 		}
 
 		else if (flavor.equals(FLAVORS[3])) { // plainTextFlavor (deprecated)
-			String text = ""; // Valid if data==null
-			if (rtfBytes !=null) {
-				text = RtfToText.getPlainText(rtfBytes);
-			}
-			return new StringReader(text);
+			return new StringReader(plain);
 		}
 
 		throw new UnsupportedFlavorException(flavor);

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTADefaultInputMap.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTADefaultInputMap.java
@@ -89,20 +89,20 @@ public class RTADefaultInputMap extends InputMap {
 		put(KeyStroke.getKeyStroke(KeyEvent.VK_PAGE_DOWN,shift),				RTextAreaEditorKit.rtaSelectionPageDownAction);
 		put(KeyStroke.getKeyStroke(KeyEvent.VK_PAGE_DOWN,defaultModifier|shift),	RTextAreaEditorKit.rtaSelectionPageRightAction);
 
-		put(KeyStroke.getKeyStroke(KeyEvent.VK_CUT,    0),					DefaultEditorKit.cutAction);
-		put(KeyStroke.getKeyStroke(KeyEvent.VK_COPY,   0),					DefaultEditorKit.copyAction);
+		put(KeyStroke.getKeyStroke(KeyEvent.VK_CUT,    0),					getCutAction());
+		put(KeyStroke.getKeyStroke(KeyEvent.VK_COPY,   0),					getCopyAction());
 		put(KeyStroke.getKeyStroke(KeyEvent.VK_PASTE,  0),					DefaultEditorKit.pasteAction);
 
-		put(KeyStroke.getKeyStroke(KeyEvent.VK_X,      defaultModifier),			DefaultEditorKit.cutAction);
-		put(KeyStroke.getKeyStroke(KeyEvent.VK_C,      defaultModifier),			DefaultEditorKit.copyAction);
+		put(KeyStroke.getKeyStroke(KeyEvent.VK_X,      defaultModifier),			getCutAction());
+		put(KeyStroke.getKeyStroke(KeyEvent.VK_C,      defaultModifier),			getCopyAction());
 		put(KeyStroke.getKeyStroke(KeyEvent.VK_V,      defaultModifier),			DefaultEditorKit.pasteAction);
 		put(KeyStroke.getKeyStroke(KeyEvent.VK_V,      defaultModifier|shift),		RTextAreaEditorKit.clipboardHistoryAction);
 		put(KeyStroke.getKeyStroke(KeyEvent.VK_DELETE, 0),					DefaultEditorKit.deleteNextCharAction);
-		put(KeyStroke.getKeyStroke(KeyEvent.VK_DELETE, shift),					DefaultEditorKit.cutAction);
+		put(KeyStroke.getKeyStroke(KeyEvent.VK_DELETE, shift),					getCutAction());
 		put(KeyStroke.getKeyStroke(KeyEvent.VK_DELETE, defaultModifier),			RTextAreaEditorKit.rtaDeleteRestOfLineAction);
 		put(KeyStroke.getKeyStroke(KeyEvent.VK_INSERT, 0),					RTextAreaEditorKit.rtaToggleTextModeAction);
 		put(KeyStroke.getKeyStroke(KeyEvent.VK_INSERT, shift),					DefaultEditorKit.pasteAction);
-		put(KeyStroke.getKeyStroke(KeyEvent.VK_INSERT, defaultModifier),			DefaultEditorKit.copyAction);
+		put(KeyStroke.getKeyStroke(KeyEvent.VK_INSERT, defaultModifier),			getCopyAction());
 		put(KeyStroke.getKeyStroke(KeyEvent.VK_A,      defaultModifier),			DefaultEditorKit.selectAllAction);
 
 		put(KeyStroke.getKeyStroke(KeyEvent.VK_D,      defaultModifier),			RTextAreaEditorKit.rtaDeleteLineAction);
@@ -144,6 +144,14 @@ public class RTADefaultInputMap extends InputMap {
 		put(KeyStroke.getKeyStroke(KeyEvent.VK_M,      defaultModifier|shift),	RTextAreaEditorKit.rtaPlaybackLastMacroAction);
 		*/
 
+	}
+
+	protected String getCopyAction() {
+		return DefaultEditorKit.copyAction;
+	}
+
+	protected String getCutAction() {
+		return DefaultEditorKit.cutAction;
 	}
 
 }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextArea.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextArea.java
@@ -23,14 +23,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
 
-import javax.swing.Action;
-import javax.swing.Icon;
-import javax.swing.InputMap;
-import javax.swing.JMenuItem;
-import javax.swing.JPopupMenu;
-import javax.swing.KeyStroke;
-import javax.swing.SwingUtilities;
-import javax.swing.UIManager;
+import javax.swing.*;
 import javax.swing.event.CaretEvent;
 import javax.swing.plaf.TextUI;
 import javax.swing.text.AbstractDocument;
@@ -159,8 +152,8 @@ public class RTextArea extends RTextAreaBase implements Printable {
 	 */
 	private ToolTipSupplier toolTipSupplier;
 
-	private static RecordableTextAction cutAction;
-	private static RecordableTextAction copyAction;
+	protected static RecordableTextAction cutAction;
+	protected static RecordableTextAction copyAction;
 	private static RecordableTextAction pasteAction;
 	private static RecordableTextAction deleteAction;
 	private static RecordableTextAction undoAction;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RecordableTextAction.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RecordableTextAction.java
@@ -189,6 +189,15 @@ public abstract class RecordableTextAction extends TextAction {
 		return (String)getValue(NAME);
 	}
 
+	/**
+	 * Returns the short description for this action.
+	 *
+	 * @return The short description for this action.
+	 * @see #setShortDescription(String)
+	 */
+	public String getShortDescription() {
+		return (String)getValue(SHORT_DESCRIPTION);
+	}
 
 	/**
 	 * Returns whether or not this action will be recorded and replayed in

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/HtmlUtilTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/HtmlUtilTest.java
@@ -101,7 +101,7 @@ class HtmlUtilTest {
 		textArea.setText("package foo;\npublic class Foobar {}");
 
 		// We can't do an exact string comparison due to differing default fonts on different OS's
-		String expectedRegex = "<pre style='font-family: \"\\w+\", courier; background: #ffffff'>" +
+		String expectedRegex = "<pre style=\"font-family: '\\w+', courier; background: #ffffff\">" +
 			"<span style=\"color: #000000;\">age</span><span style=\"color: #808080;\"> </span>" +
 			"<span style=\"color: #000000;\">foo</span><span style=\"color: #000000;\">;</span><br>" +
 			"<span style=\"color: #000000;\">public</span>" +
@@ -122,7 +122,7 @@ class HtmlUtilTest {
 		Image image = new BufferedImage(100, 100, BufferedImage.TYPE_INT_ARGB);
 		textArea.setBackgroundImage(image);
 		// We can't do an exact string comparison due to differing default fonts on different OS's
-		String expectedRegex = "<pre style='font-family: \"\\w+\", courier;'>.*" +
+		String expectedRegex = "<pre style=\"font-family: '\\w+', courier;\">.*" +
 			"<span style=\"color: #000000;\">ag</span></pre>";
 
 		String actual = HtmlUtil.getTextAsHtml(textArea, 4, 6);

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaEditorKitCopyAsStyledTextActionTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaEditorKitCopyAsStyledTextActionTest.java
@@ -84,6 +84,43 @@ class RSyntaxTextAreaEditorKitCopyAsStyledTextActionTest extends AbstractRSyntax
 	}
 
 	@Test
+	void test_disabledStyledCopyCutAction() throws Exception {
+
+		String text = "/*\n" +
+			"* comment\n" +
+			"*/\n" +
+			"public void foo() {\n" +
+			"  /* comment\n" +
+			"     two */\n" +
+			"}";
+		RSyntaxTextArea textArea = createTextArea(SyntaxConstants.SYNTAX_STYLE_JAVA, text);
+		textArea.setEditable(false);
+
+		textArea.setCaretPosition(5);
+		textArea.moveCaretPosition(8);
+
+		RSyntaxTextAreaEditorKit.CopyCutAsStyledTextAction a = new RSyntaxTextAreaEditorKit.CopyCutAsStyledTextAction(false);
+		ActionEvent e = createActionEvent(textArea, RSyntaxTextAreaEditorKit.rstaCopyAsStyledTextAction);
+		a.actionPerformedImpl(e, textArea);
+
+		String clipboardContent = (String)textArea.getToolkit().getSystemClipboard().getData(DataFlavor.stringFlavor);
+		Assertions.assertEquals("com", clipboardContent);
+		Assertions.assertEquals(text, textArea.getText());
+
+		textArea.setCaretPosition(8);
+		textArea.moveCaretPosition(11);
+
+		//Trying to cut "men". This shouldn't happen as the textArea is not editable.
+		a = new RSyntaxTextAreaEditorKit.CopyCutAsStyledTextAction(true);
+		e = createActionEvent(textArea, RSyntaxTextAreaEditorKit.rstaCutAsStyledTextAction);
+		a.actionPerformedImpl(e, textArea);
+		clipboardContent = (String)textArea.getToolkit().getSystemClipboard().getData(DataFlavor.stringFlavor);
+		Assertions.assertEquals("com", clipboardContent, "Clipboard content should be unchanged");
+		Assertions.assertEquals(text, textArea.getText());
+
+	}
+
+	@Test
 	void testGetMacroId() {
 		RSyntaxTextAreaEditorKit.CopyCutAsStyledTextAction a = new RSyntaxTextAreaEditorKit.CopyCutAsStyledTextAction(false);
 		Assertions.assertEquals(RSyntaxTextAreaEditorKit.rstaCopyAsStyledTextAction, a.getMacroID());

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/StyledTextTransferableTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/StyledTextTransferableTest.java
@@ -22,7 +22,7 @@ class StyledTextTransferableTest {
 	@Test
 	void testGetDataFlavors() {
 		byte[] rtfBytes = {};
-		StyledTextTransferable t = new StyledTextTransferable("foo", rtfBytes);
+		StyledTextTransferable t = new StyledTextTransferable("", "foo", rtfBytes);
 		Assertions.assertEquals(4, t.getTransferDataFlavors().length);
 	}
 
@@ -30,7 +30,7 @@ class StyledTextTransferableTest {
 	@Test
 	void testIsDataFlavorSupported_true() {
 		byte[] rtfBytes = {};
-		StyledTextTransferable t = new StyledTextTransferable("foo", rtfBytes);
+		StyledTextTransferable t = new StyledTextTransferable("", "foo", rtfBytes);
 		Assertions.assertTrue(t.isDataFlavorSupported(DataFlavor.fragmentHtmlFlavor));
 		Assertions.assertTrue(t.isDataFlavorSupported(new DataFlavor("text/rtf", "RTF")));
 		Assertions.assertTrue(t.isDataFlavorSupported(DataFlavor.stringFlavor));
@@ -40,7 +40,7 @@ class StyledTextTransferableTest {
 	@Test
 	void testIsDataFlavorSupported_false() {
 		byte[] rtfBytes = {};
-		StyledTextTransferable t = new StyledTextTransferable("foo", rtfBytes);
+		StyledTextTransferable t = new StyledTextTransferable("", "foo", rtfBytes);
 		Assertions.assertFalse(t.isDataFlavorSupported(DataFlavor.imageFlavor));
 	}
 }


### PR DESCRIPTION
As suggested at #405, this is to copy selected text as plain-text flavor. Also I've put styled copy and cut actions as default for RSyntaxTextArea (do you think we should preserve the old behaviour and add a method like `RSTA.setStyleCopyCutAction(boolean)` ?) 

And finally, I changed the style of top \<pre\> tag to have attribute in double quote rather single quote. While I think old and new syntax are valid from the HTML specification, for some reason the old syntax doesn't work in Skype for Business under Windows 