### PR TITLE
Add Automatic-Module-Name

### DIFF
--- a/RSyntaxTextArea/build.gradle
+++ b/RSyntaxTextArea/build.gradle
@@ -23,6 +23,7 @@ jacocoTestReport {
 
 ext.sharedManifest = manifest {
 	attributes('Specification-Title': 'RSyntaxTextArea',
+		'Automatic-Module-Name': 'org.fife.RSyntaxTextArea', // jdk 9+ module name
 		'Specification-Version': version,
 		'Implementation-Title': 'org.fife.ui',
 		'Implementation-Version': version,


### PR DESCRIPTION
Add Automatic-Module-Name to MANIFEST.MF. See http://branchandbound.net/blog/java/2017/12/automatic-module-name/.
(don't forget: SWING is still official part of JDK 9+ at least until 2026)