### PR TITLE
Fix BLE in SearchEngine and add test

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/SearchEngine.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/SearchEngine.java
@@ -72,7 +72,7 @@ public final class SearchEngine {
 		boolean doMarkAll = textArea instanceof RTextArea && context.getMarkAll();
 
 		String text = context.getSearchFor();
-		if (text==null || text.length()==0) {
+		if (text==null || text.length()==0 || textArea.getText().isEmpty()) {
 			if (doMarkAll) {
 				// Force "mark all" event to be broadcast so listeners know to
 				// clear their mark-all markers.  The RSTA already cleared its
@@ -251,7 +251,7 @@ public final class SearchEngine {
 		// Be smart about the text we grab to search in.  We grab more than
 		// a single line because our searches can return multi-line results.
 		// We copy only the chars that will be searched through.
-		String findIn = null;
+		String findIn;
 		try {
 			if (forward) {
 				findIn = textArea.getText(start,
@@ -262,7 +262,7 @@ public final class SearchEngine {
 			}
 		} catch (BadLocationException ble) {
 			// Never happens; findIn will be null anyway.
-			ble.printStackTrace();
+			throw new RuntimeException(ble);
 		}
 
 		return findIn;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/SearchEngine.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/SearchEngine.java
@@ -72,7 +72,7 @@ public final class SearchEngine {
 		boolean doMarkAll = textArea instanceof RTextArea && context.getMarkAll();
 
 		String text = context.getSearchFor();
-		if (text==null || text.length()==0 || textArea.getText().isEmpty()) {
+		if (text == null || text.length() == 0 || textArea.getDocument().getLength() == 0) {
 			if (doMarkAll) {
 				// Force "mark all" event to be broadcast so listeners know to
 				// clear their mark-all markers.  The RSTA already cleared its
@@ -251,7 +251,7 @@ public final class SearchEngine {
 		// Be smart about the text we grab to search in.  We grab more than
 		// a single line because our searches can return multi-line results.
 		// We copy only the chars that will be searched through.
-		String findIn;
+		String findIn = null;
 		try {
 			if (forward) {
 				findIn = textArea.getText(start,
@@ -262,7 +262,7 @@ public final class SearchEngine {
 			}
 		} catch (BadLocationException ble) {
 			// Never happens; findIn will be null anyway.
-			throw new RuntimeException(ble);
+			ble.printStackTrace();
 		}
 
 		return findIn;

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/SearchEngineTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/SearchEngineTest.java
@@ -819,8 +819,8 @@ class SearchEngineTest {
 	 */
 	@Test
 	void testSearchEngineReplaceBackwardOnEmptyDocument() {
-		var textArea = new RSyntaxTextArea();
-		var context = new SearchContext("nothing");
+		RSyntaxTextArea textArea = new RSyntaxTextArea();
+		SearchContext context = new SearchContext("nothing");
 		context.setSearchWrap(true);
 		context.setSearchForward(false);
 		assertDoesNotThrow(() -> {

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/SearchEngineTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/SearchEngineTest.java
@@ -814,6 +814,19 @@ class SearchEngineTest {
 		testSearchEngineReplace(false);
 	}
 
+	/**
+	 * https://github.com/bobbylight/RSyntaxTextArea/issues/427
+	 */
+	@Test
+	void testSearchEngineReplaceBackwardOnEmptyDocument() {
+		var textArea = new RSyntaxTextArea();
+		var context = new SearchContext("nothing");
+		context.setSearchWrap(true);
+		context.setSearchForward(false);
+		assertDoesNotThrow(() -> {
+			SearchEngine.find(textArea, context);
+		});
+	}
 
 	/**
 	 * Tests <code>SearchEngine.replace()</code> when searching forward.


### PR DESCRIPTION
Fixes #427 

Catching and rethrowing the BLE is pretty hokey... but to be fair, catching it and dumping the stack trace wasn't much better 😉 