### PR TITLE
WIP fix for #160 - Configurable Line Height. This currently makes the…

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextArea.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextArea.java
@@ -1046,6 +1046,18 @@ public class RSyntaxTextArea extends RTextArea implements SyntaxConstants {
 
 
 	/**
+	 * Overridden to return account for all fonts being used
+	 * when determining the line height.
+	 *
+	 * @return The line height.
+	 */
+	@Override
+	public int getActualLineHeight() {
+		return lineHeight;
+	}
+
+
+	/**
 	 * Returns whether bracket matching should be animated.
 	 *
 	 * @return Whether bracket matching should be animated.
@@ -1409,17 +1421,6 @@ public class RSyntaxTextArea extends RTextArea implements SyntaxConstants {
 			}
 		}
 		return getDocument().getLength();
-	}
-
-
-	/**
-	 * Returns the height to use for a line of text in this text area.
-	 *
-	 * @return The height of a line of text in this text area.
-	 */
-	@Override
-	public int getLineHeight() {
-		return lineHeight;
 	}
 
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/SyntaxView.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/SyntaxView.java
@@ -736,10 +736,13 @@ public class SyntaxView extends View implements TabExpander,
 		int heightAbove = clip.y - alloc.y;
 		int linesAbove = Math.max(0, heightAbove / lineHeight);
 
+		// Top and bottom spacing around font if line height > font size
+		int verticalSpacing = (lineHeight - host.getActualLineHeight()) / 2;
+
 		FoldManager fm = host.getFoldManager();
 		linesAbove += fm.getHiddenLineCountAbove(linesAbove, true);
 		Rectangle lineArea = lineToRect(a, linesAbove);
-		int y = lineArea.y + ascent;
+		int y = lineArea.y + verticalSpacing + ascent;
 		int x = lineArea.x;
 		Element map = getElement();
 		int lineCount = map.getElementCount();
@@ -801,8 +804,8 @@ public class SyntaxView extends View implements TabExpander,
 				Color c = RSyntaxUtilities.getFoldedLineBottomColor(host);
 				if (c!=null) {
 					g.setColor(c);
-					g.drawLine(x,y+lineHeight-ascent-1,
-							host.getWidth(),y+lineHeight-ascent-1);
+					int lineY = y - verticalSpacing - ascent + lineHeight - 1;
+					g.drawLine(x, lineY, host.getWidth(), lineY);
 				}
 
 				// Skip to next line to paint, taking extra care for lines with

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/FoldIndicator.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/FoldIndicator.java
@@ -502,7 +502,7 @@ public class FoldIndicator extends AbstractGutterComponent {
 		int topLine = (visibleRect.y-textAreaInsets.top)/cellHeight;
 		int y = topLine*cellHeight +
 			(cellHeight-collapsedFoldIcon.getIconHeight())/2;
-		y += textAreaInsets.top;
+		y += textAreaInsets.top - 1;
 
 		// Get the first and last lines to paint.
 		FoldManager fm = rsta.getFoldManager();
@@ -538,7 +538,7 @@ public class FoldIndicator extends AbstractGutterComponent {
 						if (paintingOutlineLine) {
 							g.setColor(getForeground());
 							int w2 = width / 2;
-							g.drawLine(w2, y + cellHeight / 2, w2, y + cellHeight);
+							g.drawLine(w2, y, w2, y + cellHeight / 2);
 						}
 					}
 					if (mouseOverFoldIcon) {

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/Gutter.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/Gutter.java
@@ -1269,10 +1269,12 @@ public class Gutter extends JPanel {
 
 			String name = e.getPropertyName();
 
-			// If they change the text area's font, we need to update cell
-			// heights to match the font's height.
+			// If they change the text area's font, or any other property
+			// related to line height, we need to update cell heights to
+			// match the font's height.
 			if ("font".equals(name) ||
-					RSyntaxTextArea.SYNTAX_SCHEME_PROPERTY.equals(name)) {
+					RSyntaxTextArea.SYNTAX_SCHEME_PROPERTY.equals(name) ||
+					RTextArea.LINE_HEIGHT_MULTIPLIER_PROPERTY.equals(name)) {
 				for (int i=0; i<getComponentCount(); i++) {
 					AbstractGutterComponent agc =
 								(AbstractGutterComponent)getComponent(i);

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/LineNumberList.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/LineNumberList.java
@@ -377,6 +377,9 @@ public class LineNumberList extends AbstractGutterComponent
 			return;
 		}
 
+		// Top and bottom spacing around font if line height > font size
+		int verticalSpacing = (cellHeight - textArea.getActualLineHeight()) / 2;
+
 		// Get where to start painting (top of the row), and where to paint
 		// the line number (drawString expects y==baseline).
 		// We need to be "scrolled up" just enough for the missing part of
@@ -388,7 +391,7 @@ public class LineNumberList extends AbstractGutterComponent
 		}
 		int topLine = (visibleRect.y-textAreaInsets.top)/cellHeight;
 		int actualTopY = topLine*cellHeight + textAreaInsets.top;
-		int y = actualTopY + ascent;
+		int y = actualTopY + verticalSpacing + ascent;
 
 		// Get the actual first line to paint, taking into account folding.
 		FoldManager fm = null;
@@ -726,9 +729,9 @@ public class LineNumberList extends AbstractGutterComponent
 
 
 	/**
-	 * Changes the height of the cells in the JList so that they are as tall as
-	 * font. This function should be called whenever the user changes the Font
-	 * of <code>textArea</code>.
+	 * Changes the height of the cells in this component so that they are as
+	 * tall as the font. This function should be called whenever the user
+	 * changes the Font of <code>textArea</code>.
 	 */
 	private void updateCellHeights() {
 		if (textArea!=null) {
@@ -744,8 +747,8 @@ public class LineNumberList extends AbstractGutterComponent
 
 
 	/**
-	 * Changes the width of the cells in the JList so you can see every digit
-	 * of each.
+	 * Changes the width of the cells in this component so you can see every
+	 * digit of each.
 	 */
 	void updateCellWidths() {
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextAreaBase.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextAreaBase.java
@@ -48,6 +48,7 @@ public abstract class RTextAreaBase extends JTextArea {
 	public static final String CURRENT_LINE_HIGHLIGHT_COLOR_PROPERTY = "RTA.currentLineHighlightColor";
 	public static final String CURRENT_LINE_HIGHLIGHT_FADE_PROPERTY = "RTA.currentLineHighlightFade";
 	public static final String HIGHLIGHT_CURRENT_LINE_PROPERTY = "RTA.currentLineHighlight";
+	public static final String LINE_HEIGHT_MULTIPLIER_PROPERTY = "RTA.lineHeightMultiplier";
 	public static final String ROUNDED_SELECTION_PROPERTY = "RTA.roundedSelection";
 
 	private boolean tabsEmulatedWithSpaces;		// If true, tabs will be expanded to spaces.

--- a/RSyntaxTextAreaDemo/src/main/java/org/fife/ui/rsyntaxtextarea/demo/DemoRootPane.java
+++ b/RSyntaxTextAreaDemo/src/main/java/org/fife/ui/rsyntaxtextarea/demo/DemoRootPane.java
@@ -263,6 +263,21 @@ public class DemoRootPane extends JRootPane implements HyperlinkListener,
 
 			im.put(KeyStroke.getKeyStroke(KeyEvent.VK_E, ctrlShift), "copyAsStyledTextEclipse");
 			am.put("copyAsStyledTextEclipse", createCopyAsStyledTextAction("eclipse"));
+
+			im.put(KeyStroke.getKeyStroke(KeyEvent.VK_8, 0), "inc");
+			am.put("inc", new AbstractAction() {
+				@Override
+				public void actionPerformed(ActionEvent e) {
+					textArea.setLineHeightMultiplier(textArea.getLineHeightMultiplier() + 0.1f);
+				}
+			});
+			im.put(KeyStroke.getKeyStroke(KeyEvent.VK_9, 0), "dec");
+			am.put("dec", new AbstractAction() {
+				@Override
+				public void actionPerformed(ActionEvent e) {
+					textArea.setLineHeightMultiplier(textArea.getLineHeightMultiplier() - 0.1f);
+				}
+			});
 		} catch (IOException ioe) {
 			ioe.printStackTrace();
 		}


### PR DESCRIPTION
… line height configurable when word wrap is NOT enabled.  Line number list is also updated.

Fold indicators do *not* currently work properly - they only update in the demo app because I've tied '8' and '9' keypresses to tweaking the line height for quick testing.

I think what still needs to be done is:
* fold indicator immediate updating
* fold indicator rendering of 'active' fold line
* "classic" style of fold indicators doesn't render the "region" line indicator completely
* and *everything* when word wrap is enabled
