### PR TITLE
More Impactful Current Line Number Font.

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/LineNumberList.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/LineNumberList.java
@@ -739,7 +739,10 @@ public class LineNumberList extends AbstractGutterComponent
 					lineCount = lineCount/10;
 					count++;
 				} while (lineCount >= 10);
-				cellWidth += fontMetrics.charWidth('9')*(count+1) + 3;
+				// This was required since the current line number has a higher font size so the previous method can cause the first digit of the
+				// number to go out of bounds of the line number list.
+				// Maybe there is some better solution to this situation.
+				cellWidth += fontMetrics.charWidth('9')*(count+1) + (fontMetrics.charWidth('9') * (int)currentLineNumberFontIncreaseSize);
 			}
 		}
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/LineNumberList.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/LineNumberList.java
@@ -87,6 +87,11 @@ public class LineNumberList extends AbstractGutterComponent
 	 */
 	private Color currentLineNumberColor;
 
+	/**
+	 * The Increase Required from the base font size of the current line number.
+	 */
+	private float currentLineNumberFontIncreaseSize = 2f;
+
 	public static final Color DEFAULT_LINE_NUMBER_COLOR = Color.GRAY;
 
 
@@ -387,6 +392,8 @@ public class LineNumberList extends AbstractGutterComponent
 
 		// Paint line numbers
 		boolean ltr = getComponentOrientation().isLeftToRight();
+		Font baseFont = g.getFont();
+		Font currentLineNumberFont = baseFont.deriveFont(Font.BOLD).deriveFont(baseFont.getSize() + currentLineNumberFontIncreaseSize); // Forcing Bold Style on the current line number
 		if (ltr) {
 			FontMetrics metrics = g.getFontMetrics();
 			int rhs = getWidth() - rhsBorderWidth;
@@ -397,12 +404,16 @@ public class LineNumberList extends AbstractGutterComponent
 				if (currentLine + 1 == line + getLineNumberingStartIndex() - 1) {
 					Color color = currentLineNumberColor != null ? currentLineNumberColor :
 						getForeground();
+					g.setFont(currentLineNumberFont);
 					g.setColor(color);
+					// Calculating the shift width required in Left to Right View Mode since the current line number font will have a greater size than the base font.
+					g.drawString(number, rhs - width - (g.getFontMetrics().stringWidth(number) - g.getFontMetrics(baseFont).stringWidth(number)), y);
 				}
 				else {
+					g.setFont(baseFont);
 					g.setColor(getForeground());
+					g.drawString(number, rhs-width, y);
 				}
-				g.drawString(number, rhs-width,y);
 				y += cellHeight;
 				if (fm!=null) {
 					Fold fold = fm.getFoldForLine(line-1);
@@ -430,11 +441,13 @@ public class LineNumberList extends AbstractGutterComponent
 					Color color = currentLineNumberColor != null ? currentLineNumberColor :
 						getForeground();
 					g.setColor(color);
+					// Calculating the shift width required in Right to Left View Mode since the current line number font will have a greater size than the base font.
+					g.drawString(number, rhsBorderWidth + (g.getFontMetrics().stringWidth(number) - g.getFontMetrics(baseFont).stringWidth(number)), y);
 				}
 				else {
 					g.setColor(getForeground());
+					g.drawString(number, rhsBorderWidth, y);
 				}
-				g.drawString(number, rhsBorderWidth, y);
 				y += cellHeight;
 				if (fm!=null) {
 					Fold fold = fm.getFoldForLine(line-1);


### PR DESCRIPTION
First let me tell something...

Today I installed **Fedora 36** which comes with gnome's new **Text Editor**.

Take a look 

![image](https://user-images.githubusercontent.com/73544069/170873158-b013f54f-0040-4abb-b41c-df1c4b0f81d8.png)

#### Notice the difference between the current line number and others.

See how the current line number is popping out because of higher font size and bold style.

First I implemented this feature on my copy of the library, with more impactful look that feels more like a 3d effect. 

![image](https://user-images.githubusercontent.com/73544069/170873314-0a96d0b3-2512-4cc8-a17e-03af7da7f803.png)

To achieve this I also needed to alter the `updateCellWidths()` function to include more size for the popping current line number.

```java
void updateCellWidths() {

	int oldCellWidth = cellWidth;
	cellWidth = getRhsBorderWidth();

	// Adjust the amount of space the line numbers take up, if necessary.
	if (textArea!=null) {
		Font font = getFont();
		if (font!=null) {
			FontMetrics fontMetrics = getFontMetrics(font);
			int count = 0;
			int lineCount = textArea.getLineCount() +
			getLineNumberingStartIndex() - 1;
			do {
				lineCount = lineCount/10;
				count++;
			} while (lineCount >= 10);
			// This was required since the current line number has a higher font size so the previous method can cause the first digit of the
			// number to go out of bounds of the line number list.
			// Maybe there is some better solution to this situation.
			cellWidth += fontMetrics.charWidth('9')*(count+1) + (fontMetrics.charWidth('9') * (int)currentLineNumberFontIncreaseSize);
		}
	}

	if (cellWidth!=oldCellWidth) { // Always true
		revalidate();
	}

}
```
And that's it, the end results are amazing.

![image](https://user-images.githubusercontent.com/73544069/170873634-d36694d2-12e4-436e-8713-e4718e35a55d.png)
