### PR TITLE
Update workflow actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,17 +35,17 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up JDK 8
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: '8'
-        distribution: 'adopt'
+        distribution: 'temurin'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,7 +56,7 @@ jobs:
     ## Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     ## If this step fails, then you should remove it and run the build manually (see below)
     #- name: Autobuild
-    #  uses: github/codeql-action/autobuild@v1
+    #  uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -67,10 +67,10 @@ jobs:
 
     - name: Build
       #run: ./gradlew build --warning-mode all
-      uses: GabrielBB/xvfb-action@v1
+      uses: hankolsen/xvfb-action@master
       with:
         run: ./gradlew build jacocoTestReport -xsign -xpublish --warning-mode all
         working-directory: ./ #optional
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -16,29 +16,29 @@ jobs:
 
     strategy:
       matrix:
-        java: [ '8', '11', '14', '17']
+        java: [ '8', '11', '17']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: ${{ matrix.java }}
-        distribution: 'adopt'
+        distribution: 'temurin'
 
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
 
     - name: Build with Gradle
       #run: ./gradlew build --warning-mode all
-      uses: GabrielBB/xvfb-action@v1
+      uses: hankolsen/xvfb-action@master
       with:
         run: ./gradlew build jacocoTestReport -xsign -xpublish --warning-mode all
         working-directory: ./ #optional
 
     - name: Submit coverage data to codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       if: matrix.java == '8'
       with:
         file: ./RSyntaxTextArea/build/reports/jacoco/test/jacocoTestReport.xml


### PR DESCRIPTION
GitHub has deprecated some actions within workflows which results in warnings like these:
https://github.com/bobbylight/RSyntaxTextArea/actions/runs/3124686200
This PR updates all of them.