### PR TITLE
Fix error strip mouse click navigation

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/ErrorStrip.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/ErrorStrip.java
@@ -579,7 +579,7 @@ public class ErrorStrip extends JPanel {
 
 		if (y<h) {
 			float at = y/(float)h;
-			line = Math.round((Math.min(lineCount, linesPerVisibleRect)-1)*at);
+			line = Math.round((Math.max(lineCount, linesPerVisibleRect)-1)*at);
 		}
 		return line;
 	}


### PR DESCRIPTION
Fixing document navigation on mouse click outside of a marker (see #496)