### PR TITLE
Scroll to error strip mouse location

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/ErrorStrip.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/ErrorStrip.java
@@ -686,6 +686,7 @@ public class ErrorStrip extends JPanel {
 				try {
 					int offs = textArea.getLineStartOffset(line);
 					textArea.setCaretPosition(offs);
+					RSyntaxUtilities.selectAndPossiblyCenter(textArea, new DocumentRange(offs, offs), false);
 				} catch (BadLocationException ble) { // Never happens
 					UIManager.getLookAndFeel().provideErrorFeedback(textArea);
 				}


### PR DESCRIPTION
When clicking inside the error strip (not on a marker), the caret is moved and the text pane scrolls but does not center it. This adjustment should do.