### PR TITLE
Cleaning & fixing the caret's line-to-Y logic

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/ErrorStrip.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/ErrorStrip.java
@@ -648,22 +648,11 @@ public class ErrorStrip extends JPanel {
 	private class Listener extends MouseAdapter
 					implements PropertyChangeListener, CaretListener {
 
-		private Rectangle visibleRect = new Rectangle();
-
 		@Override
 		public void caretUpdate(CaretEvent e) {
 			if (getFollowCaret()) {
-				textArea.computeVisibleRect(visibleRect);
-				int h = visibleRect.height;
-
-				int lineHeight = textArea.getLineHeight();
-				int linesPerVisibleRect = h / lineHeight;
-				int lineCount = textArea.getLineCount();
-
 				int line = textArea.getCaretLineNumber();
-				float percent = line / (float)(Math.max(linesPerVisibleRect, lineCount)-1);
-
-				caretLineY = (int)(visibleRect.height*percent);
+				caretLineY = lineToY(line);
 				if (caretLineY!=lastLineY) {
 					repaint(0,lastLineY, getWidth(), 2); // Erase old position
 					repaint(0,caretLineY, getWidth(), 2);

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/ErrorStrip.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/ErrorStrip.java
@@ -328,7 +328,7 @@ public class ErrorStrip extends JPanel {
 		int lineHeight = textArea.getLineHeight();
 		int linesPerVisibleRect = h / lineHeight;
 
-		return (int)(((line-1)/(Math.max(lineCount, linesPerVisibleRect) -1)) * (h-2));
+		return Math.round((h-1) * line / Math.max(lineCount, linesPerVisibleRect));
 	}
 
 


### PR DESCRIPTION
Using existing code to compute line-to-Y position rather than manually. Simpler code that also properly aligns caret and marker painting for a same location.