### PR TITLE
#493 make 2 methods public in RTextArea

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextArea.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextArea.java
@@ -366,7 +366,7 @@ public class RTextArea extends RTextAreaBase implements Printable {
 	 * @see #getMarkAllHighlightColor()
 	 * @see #setMarkAllHighlightColor(Color)
 	 */
-	void clearMarkAllHighlights() {
+	public void clearMarkAllHighlights() {
 		((RTextAreaHighlighter)getHighlighter()).clearMarkAllHighlights();
 		//markedWord = null;
 		repaint();
@@ -956,7 +956,7 @@ public class RTextArea extends RTextAreaBase implements Printable {
 	 * @see #getMarkAllHighlightColor()
 	 * @see #setMarkAllHighlightColor(Color)
 	 */
-	void markAll(List<DocumentRange> ranges) {
+	public void markAll(List<DocumentRange> ranges) {
 
 		RTextAreaHighlighter h = (RTextAreaHighlighter)getHighlighter();
 		if (/*toMark!=null && !toMark.equals(markedWord) && */h!=null) {


### PR DESCRIPTION
If the methods are made  public, I will be able to delete class linked in the issue #493. It was a package rewrite hack to make these 2 methods accessible.