### PR TITLE
Wrapped long line performance

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxUtilities.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxUtilities.java
@@ -371,7 +371,7 @@ public final class RSyntaxUtilities implements SwingConstants {
 		// token types, etc.), and get the x-location (in pixels) of the
 		// beginning of this new token list.
 		TokenSubList subList = TokenUtils.getSubTokenList(t, p0, e, textArea,
-				0, TEMP_TOKEN);
+				0, TEMP_TOKEN, false, 0);
 		t = subList.tokenList;
 
 		rect = t.listOffsetToView(textArea, e, p1, x0, rect);

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/Token.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/Token.java
@@ -301,6 +301,19 @@ public interface Token extends TokenTypes {
 	 */
 	float getWidth(RSyntaxTextArea textArea, TabExpander e, float x0);
 
+	/**
+	 * Returns the width of this token given the specified parameters.
+	 *
+	 * @param textArea The text area in which the token is being painted.
+	 * @param e Describes how to expand tabs.  This parameter cannot be
+	 *        <code>null</code>.
+	 * @param x0 The pixel-location at which the token begins.  This is needed
+	 *        because of tabs.
+	 * @param maxWidth the maximum width we care about measuring
+	 * @return The width of the token, in pixels.
+	 * @see #getWidthUpTo
+	 */
+	float getWidth(RSyntaxTextArea textArea, TabExpander e, float x0, float maxWidth);
 
 	/**
 	 * Returns the width of a specified number of characters in this token.
@@ -317,6 +330,23 @@ public interface Token extends TokenTypes {
 	 */
 	float getWidthUpTo(int numChars, RSyntaxTextArea textArea,
 			TabExpander e, float x0);
+
+	/**
+	 * Returns the width of a specified number of characters in this token.
+	 * For example, for the token "while", specifying a value of <code>3</code>
+	 * here returns the width of the "whi" portion of the token.
+	 *
+	 * @param numChars The number of characters for which to get the width.
+	 * @param textArea The text area in which the token is being painted.
+	 * @param e How to expand tabs.  This value cannot be <code>null</code>.
+	 * @param x0 The pixel-location at which this token begins.  This is needed
+	 *        because of tabs.
+	 * @param maxWidth the maximum width we care about measuring
+	 * @return The width of the specified number of characters in this token.
+	 * @see #getWidth
+	 */
+	float getWidthUpTo(int numChars, RSyntaxTextArea textArea,
+			TabExpander e, float x0, float maxWidth);
 
 
 	/**

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TokenUtils.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TokenUtils.java
@@ -62,7 +62,7 @@ public final class TokenUtils {
 									TabExpander e,
 									final RSyntaxTextArea textArea,
 									float x0) {
-		return getSubTokenList(tokenList, pos, e, textArea, x0, null);
+		return getSubTokenList(tokenList, pos, e, textArea, x0, null, true, Float.MAX_VALUE);
 	}
 
 
@@ -100,6 +100,8 @@ public final class TokenUtils {
 	 * @param tempToken A temporary token to use  when creating the token list
 	 *        result.  This may be <code>null</code> but callers can pass in
 	 *        a "buffer" token for performance if desired.
+	 * @param careAboutWidth whether we need to know the width or the result or not
+	 * @param maxWidth the maximum width we care about measuring, if we care about width
 	 * @return Information about the "sub" token list.  This will be
 	 *         <code>null</code> if <code>pos</code> was not a valid offset
 	 *         into the token list.
@@ -109,7 +111,10 @@ public final class TokenUtils {
 									TabExpander e,
 									final RSyntaxTextArea textArea,
 									float x0,
-									TokenImpl tempToken) {
+									TokenImpl tempToken,
+									boolean careAboutWidth,
+									float maxWidth) {
+
 
 		if (tempToken==null) {
 			tempToken = new TokenImpl();
@@ -119,7 +124,9 @@ public final class TokenUtils {
 		// Loop through the token list until you find the one that contains
 		// pos.  Remember the cumulative width of all of these tokens.
 		while (t!=null && t.isPaintable() && !t.containsPosition(pos)) {
-			x0 += t.getWidth(textArea, e, x0);
+			if (careAboutWidth) {
+				x0 += t.getWidth(textArea, e, x0, maxWidth);
+			}
 			t = t.getNextToken();
 		}
 
@@ -129,7 +136,9 @@ public final class TokenUtils {
 			if (t.getOffset()!=pos) {
 				// Number of chars between p0 and token start.
 				int difference = pos - t.getOffset();
-				x0 += t.getWidthUpTo(t.length()-difference+1, textArea, e, x0);
+				if (careAboutWidth) {
+					x0 += t.getWidthUpTo(t.length()-difference+1, textArea, e, x0, maxWidth);
+				}
 				tempToken.copyFrom(t);
 				tempToken.makeStartAt(pos);
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/WrappedSyntaxView.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/WrappedSyntaxView.java
@@ -126,7 +126,7 @@ public class WrappedSyntaxView extends BoxView implements TabExpander,
 			// FIXME:  Replace the code below with the commented-out line below.  This will
 			// allow long tokens to be broken at embedded spaces (such as MLC's).  But it
 			// currently throws BadLocationExceptions sometimes...
-			float tokenWidth = t.getWidth(textArea, this, x0);
+			float tokenWidth = t.getWidth(textArea, this, x0, currentWidth + 1);
 			if (tokenWidth>currentWidth) {
 				// If the current token alone is too long for this line,
 				// break at a character boundary.
@@ -1196,7 +1196,7 @@ public class WrappedSyntaxView extends BoxView implements TabExpander,
 				//System.err.println("... ... " + p0 + ", " + p1);
 				nlines += 1;
 				TokenSubList subList = TokenUtils.getSubTokenList(tokenList, p0,
-						WrappedSyntaxView.this, textArea, x0, lineCountTempToken);
+						WrappedSyntaxView.this, textArea, x0, lineCountTempToken, false, 0);
 				x0 = subList!=null ? subList.x : x0;
 				tokenList = subList!=null ? subList.tokenList : null;
 				int p = calculateBreakPosition(p0, tokenList, x0);
@@ -1316,7 +1316,7 @@ public class WrappedSyntaxView extends BoxView implements TabExpander,
 			int loops = 0;
 			while (p0 < p1) {
 				TokenSubList subList = TokenUtils.getSubTokenList(tokenList, p0,
-						WrappedSyntaxView.this, textArea, x0, lineCountTempToken);
+						WrappedSyntaxView.this, textArea, x0, lineCountTempToken, true, width + 1);
 				x0 = subList!=null ? subList.x : x0;
 				tokenList = subList!=null ? subList.tokenList : null;
 				int p = calculateBreakPosition(p0, tokenList, x0);
@@ -1418,7 +1418,7 @@ public class WrappedSyntaxView extends BoxView implements TabExpander,
 					// lines so they start at the beginning of a physical
 					// line.
 					TokenSubList subList = TokenUtils.getSubTokenList(tlist, p0,
-							WrappedSyntaxView.this, textArea, alloc.x, lineCountTempToken);
+							WrappedSyntaxView.this, textArea, alloc.x, lineCountTempToken, false, 0);
 					tlist = subList!=null ? subList.tokenList : null;
 					int p = calculateBreakPosition(p0, tlist, alloc.x);
 


### PR DESCRIPTION
This is related to #159 #41.

This PR contains a few optimisation _suggestions_ for `RSyntaxTextArea`, which have made an _enormous_ difference to the performance of wrapping large single-line text files (e.g. minified JavaScript or JSON).

The first commit is a simple cache of character position in a wrapped line to line height, so we don't have to measure from the start of the string every time.

The second commit avoids measuring widths at all if we don't need to (there were places where the measurement wasn't used), and importantly, to measure only up to a maximum value if that would flip us into an alternative code path that didn't need the accurate result, e.g. in `calculateBreakPosition` where if the measured width is greater than the width of the text area we don't care how wide it actually was.

I say this PR is a suggestion as I have simply duplicated methods in `TokenImpl` and the parameter names aren't A+. But if you like it @bobbylight then I'll happily tidy it up, tidy it up with you, or hand it over to you as per your preference.

Finally, thank you very much for this excellent project.