### PR TITLE
[feature] possibility to implement custom line number formatting

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/Gutter.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/Gutter.java
@@ -103,6 +103,11 @@ public class Gutter extends JPanel {
 	private int lineNumberingStartIndex;
 
 	/**
+	 * Formats line numbers into a string to be displayed.
+	 */
+	private LineNumberFormatter lineNumberFormatter;
+
+	/**
 	 * The font used to render line numbers.
 	 */
 	private Font lineNumberFont;
@@ -152,6 +157,7 @@ public class Gutter extends JPanel {
 		lineNumberColor = LineNumberList.DEFAULT_LINE_NUMBER_COLOR;
 		lineNumberFont = RTextArea.getDefaultFont();
 		lineNumberingStartIndex = 1;
+		lineNumberFormatter = LineNumberList.DEFAULT_LINE_NUMBER_FORMATTER;
 		iconRowHeaderInheritsGutterBackground = false;
 
 		setTextArea(textArea);
@@ -436,6 +442,17 @@ public class Gutter extends JPanel {
 	 */
 	public int getLineNumberingStartIndex() {
 		return lineNumberingStartIndex;
+	}
+
+	/**
+	 * Returns the line number formatter. The default value is
+	 * {@link LineNumberList#DEFAULT_LINE_NUMBER_FORMATTER}
+	 *
+	 * @return The formatter
+	 * @see #setLineNumberFormatter(LineNumberFormatter)
+	 */
+	public LineNumberFormatter getLineNumberFormatter() {
+		return lineNumberFormatter;
 	}
 
 
@@ -920,6 +937,21 @@ public class Gutter extends JPanel {
 
 
 	/**
+	 * Sets a custom line number formatter. Can be called when other number
+	 * formats are needed like arabic-indic numerals.
+	 *
+	 * @param formatter The new line number formatter
+	 * @see #getLineNumberFormatter()
+	 */
+	public void setLineNumberFormatter(LineNumberFormatter formatter) {
+		if (formatter != lineNumberFormatter) {
+			lineNumberFormatter = formatter;
+			lineNumberList.setLineNumberFormatter(formatter);
+		}
+	}
+
+
+	/**
 	 * Toggles whether line numbers are visible.<p>
 	 *
 	 * Most clients do not need to call this method directly. This is usually
@@ -1004,6 +1036,8 @@ public class Gutter extends JPanel {
 					getCurrentLineNumberColor());
 				lineNumberList.setLineNumberingStartIndex(
 						getLineNumberingStartIndex());
+				lineNumberList.setLineNumberFormatter(
+					getLineNumberFormatter());
 			}
 			else {
 				lineNumberList.setTextArea(textArea);

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/Gutter.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/Gutter.java
@@ -938,7 +938,7 @@ public class Gutter extends JPanel {
 
 	/**
 	 * Sets a custom line number formatter. Can be called when other number
-	 * formats are needed like arabic-indic numerals.
+	 * formats are needed like hindu-arabic numerals.
 	 *
 	 * @param formatter The new line number formatter
 	 * @see #getLineNumberFormatter()

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/LineNumberFormatter.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/LineNumberFormatter.java
@@ -1,0 +1,32 @@
+/*
+ * 29/07/2023
+ *
+ * LineNumber - Format line numbers into a comprehensible String.
+ *
+ * This library is distributed under a modified BSD license.  See the included
+ * LICENSE file for details.
+ */
+package org.fife.ui.rtextarea;
+
+/**
+ * Formats line numbers into a comprehensible String to be
+ * displayed to the user.
+ * */
+public interface LineNumberFormatter {
+	/**
+	 * Formats the given line number into a String.
+	 *
+	 * @param lineNumber the line number
+	 * @return the formatted line number
+	 */
+	String format(int lineNumber);
+
+	/**
+	 * Returns the maximum number of characters of any string returned
+	 * by {@link #format} provided a certain maximum line number.
+	 *
+	 * @param maxLineNumber the maximum line number
+	 * @return the maximum length
+	 */
+	int getMaxLength(int maxLineNumber);
+}

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/LineNumberList.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/LineNumberList.java
@@ -679,7 +679,7 @@ public class LineNumberList extends AbstractGutterComponent
 
 	/**
 	 * Sets a custom line number formatter. Can be called when other number
-	 * formats are needed like arabic-indic numerals.
+	 * formats are needed like hindu-arabic numerals.
 	 *
 	 * @param formatter The new line number formatter
 	 * @see #getLineNumberFormatter()

--- a/RSyntaxTextAreaDemo/src/main/java/org/fife/ui/rsyntaxtextarea/demo/DemoRootPane.java
+++ b/RSyntaxTextAreaDemo/src/main/java/org/fife/ui/rsyntaxtextarea/demo/DemoRootPane.java
@@ -22,9 +22,7 @@ import javax.swing.event.HyperlinkListener;
 //import javax.swing.text.StyleConstants;
 
 import org.fife.ui.rsyntaxtextarea.*;
-import org.fife.ui.rtextarea.FoldIndicatorStyle;
-import org.fife.ui.rtextarea.Gutter;
-import org.fife.ui.rtextarea.RTextScrollPane;
+import org.fife.ui.rtextarea.*;
 
 
 /**
@@ -140,6 +138,18 @@ public class DemoRootPane extends JRootPane implements HyperlinkListener,
 		foldStyleSubMenu.add(classicStyleItem);
 		foldStyleSubMenu.add(modernStyleItem);
 		menu.add(foldStyleSubMenu);
+		JMenu lineNumberFormatSubMenu = new JMenu("Line Number Format");
+		JRadioButtonMenuItem normalStyleItem = new JRadioButtonMenuItem(
+			new LineNumberFormatAction("Normal", LineNumberList.DEFAULT_LINE_NUMBER_FORMATTER));
+		JRadioButtonMenuItem hinduArabicStyleItem = new JRadioButtonMenuItem(
+			new LineNumberFormatAction("Hindu-Arabic", new HinduArabicLineNumberFormatter()));
+		normalStyleItem.setSelected(true);
+		bg = new ButtonGroup();
+		bg.add(normalStyleItem);
+		bg.add(hinduArabicStyleItem);
+		lineNumberFormatSubMenu.add(normalStyleItem);
+		lineNumberFormatSubMenu.add(hinduArabicStyleItem);
+		menu.add(lineNumberFormatSubMenu);
 		JCheckBoxMenuItem cbItem = new JCheckBoxMenuItem(new CodeFoldingAction());
 		cbItem.setSelected(true);
 		menu.add(cbItem);
@@ -410,6 +420,25 @@ public class DemoRootPane extends JRootPane implements HyperlinkListener,
 	}
 
 	/**
+	 * Changes how line numbers are displayed.
+	 */
+	private class LineNumberFormatAction extends AbstractAction {
+
+		private final LineNumberFormatter formatter;
+
+		LineNumberFormatAction(String name, LineNumberFormatter formatter) {
+			this.formatter = formatter;
+			putValue(NAME, name);
+		}
+
+		@Override
+		public void actionPerformed(ActionEvent e) {
+			scrollPane.getGutter().setLineNumberFormatter(formatter);
+		}
+
+	}
+
+	/**
 	 * Changes the look and feel of the demo application.
 	 */
 	private class LookAndFeelAction extends AbstractAction {
@@ -559,6 +588,36 @@ public class DemoRootPane extends JRootPane implements HyperlinkListener,
 			textArea.setLineWrap(!textArea.getLineWrap());
 		}
 
+	}
+
+	/**
+	 * Formats line numbers into Hindu-Arabic numerals.
+	 */
+	private static class HinduArabicLineNumberFormatter implements LineNumberFormatter {
+		private static final String[] NUMERALS = {
+			"٠", "١", "٢", "٣", "٤", "٥", "٦", "٧", "٨", "٩"
+		};
+
+		@Override
+		public String format(int lineNumber) {
+			if (lineNumber == 0) {
+				return NUMERALS[0];
+			}
+
+			StringBuilder sb = new StringBuilder();
+			while (lineNumber > 0) {
+				int digit = lineNumber % 10;
+				sb.insert(0, NUMERALS[digit]);
+				lineNumber /= 10;
+			}
+
+			return sb.toString();
+		}
+
+		@Override
+		public int getMaxLength(int maxLineNumber) {
+			return String.valueOf(maxLineNumber).length();
+		}
 	}
 
 

--- a/RSyntaxTextAreaDemo/src/main/java/org/fife/ui/rsyntaxtextarea/demo/DemoRootPane.java
+++ b/RSyntaxTextAreaDemo/src/main/java/org/fife/ui/rsyntaxtextarea/demo/DemoRootPane.java
@@ -22,7 +22,11 @@ import javax.swing.event.HyperlinkListener;
 //import javax.swing.text.StyleConstants;
 
 import org.fife.ui.rsyntaxtextarea.*;
-import org.fife.ui.rtextarea.*;
+import org.fife.ui.rtextarea.FoldIndicatorStyle;
+import org.fife.ui.rtextarea.Gutter;
+import org.fife.ui.rtextarea.RTextScrollPane;
+import org.fife.ui.rtextarea.LineNumberFormatter;
+import org.fife.ui.rtextarea.LineNumberList;
 
 
 /**


### PR DESCRIPTION
Suggested here #517

Now configurable via Gutter.setLineNumberFormatter, by implementing LineNumberFormatter interface
Also added an example in demo

<details>
<summary>Demo</summary>

Added under `View > Line Number Format > Hindu-Arabic` (default selected option is `Normal`)
![demo](https://github.com/bobbylight/RSyntaxTextArea/assets/53614199/c7436c7b-85e5-49d7-bd04-e74b0d4cf317)

</details>