### PR TITLE
No marking if cursor is at end of file

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/SearchEngine.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/SearchEngine.java
@@ -93,15 +93,16 @@ public final class SearchEngine {
 		int start = forward ? Math.max(c.getDot(), c.getMark()) :
 						Math.min(c.getDot(), c.getMark());
 
-		String findIn = getFindInText(textArea, start, forward);
-		if (!context.getSearchWrap() && (findIn == null || findIn.isEmpty())) {
-			return new SearchResult();
-		}
 
 		int markAllCount = 0;
 		if (doMarkAll) {
 			markAllCount = markAllImpl((RTextArea)textArea, context).
 					getMarkedCount();
+		}
+
+		String findIn = getFindInText(textArea, start, forward);
+		if (!context.getSearchWrap() && (findIn == null || findIn.isEmpty())) {
+			return new SearchResult();
 		}
 
 		SearchResult result = SearchEngine.findImpl(findIn == null ? "" : findIn, context);


### PR DESCRIPTION
# Pullrequest for issue #536

**Description**
There is a bug when using `SearchEngine.find(...)` . The problem is, that `getFindInText()` is called before the marking and if there is no text after the cursot (Caret), a `new SearchResult()` is returned. 

**Steps to Reproduce**
Specific steps to reproduce the behavior:
1. Set the cursor at the end of a JTextArea
2. call the `find` method using a valid SearchContext (e.g. search for "e" in a text that contains some "e")
3. Now a empty new SearchResult is returned and no "e" got marked in the text.
4. If you set the cursor one back (second last position), everything works as expected

**Expected behavior**
All matching results should be marked regardless of the current cursor position. Even if wrap around is disabled

**Actual behavior**
No marking if cursor at last position.

**Screenshots**
Add a screenshot if it helps explain the problem.

**Java version**
jdk-17.0.6.10

**Additional context**
Just call `markAllImpl()` before `getFindInText()`.
