### PR TITLE
Clojure: double quote char literal

### DIFF
--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/ClojureTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/ClojureTokenMakerTest.java
@@ -381,4 +381,14 @@ class ClojureTokenMakerTest extends AbstractTokenMakerTest {
 	}
 
 
+	@Test
+	void testCharacters() {
+		String[] chars = {
+			"\\\"",
+			"\\a",
+			"\\s",
+			"\\d",
+		};
+		assertAllTokensOfType(TokenTypes.LITERAL_CHAR, chars);
+	}
 }


### PR DESCRIPTION
Here's a failing test for #543. I would fix it but I don't know how to regenerate the .java files from `.flex`.