### PR TITLE
Make it possible to use Font and FontMetrics per Token rather than To…

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/DefaultTokenPainter.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/DefaultTokenPainter.java
@@ -105,8 +105,8 @@ public class DefaultTokenPainter implements TokenPainter {
 		Color fg = useSTC ? host.getSelectedTextColor() :
 			host.getForegroundForToken(token);
 		Color bg = selected ? null : host.getBackgroundForToken(token);
-		g.setFont(host.getFontForTokenType(token.getType()));
-		FontMetrics fm = host.getFontMetricsForTokenType(token.getType());
+		g.setFont(host.getFontForToken(token));
+		FontMetrics fm = host.getFontMetricsForToken(token);
 
 		for (int i=textOffs; i<end; i++) {
 			switch (text[i]) {
@@ -218,7 +218,7 @@ public class DefaultTokenPainter implements TokenPainter {
 		}
 
 		// Get the length of a tab.
-		FontMetrics fm = host.getFontMetricsForTokenType(token.getType());
+		FontMetrics fm = host.getFontMetricsForToken(token);
 		int tabSize = host.getTabSize();
 		if (tabBuf==null || tabBuf.length<tabSize) {
 			tabBuf = new char[tabSize];

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextArea.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextArea.java
@@ -1198,6 +1198,17 @@ private boolean fractionalFontMetricsEnabled;
 	/**
 	 * Returns the font for tokens of the specified type.
 	 *
+	 * @param token the token.
+	 * @return The font to use for that token type.
+	 * @see #getFontMetricsForTokenType(int)
+	 */
+	public Font getFontForToken(Token token) {
+		return getFontForTokenType(token.getType());
+	}
+
+	/**
+	 * Returns the font for tokens of the specified type.
+	 *
 	 * @param type The type of token.
 	 * @return The font to use for that token type.
 	 * @see #getFontMetricsForTokenType(int)
@@ -1207,6 +1218,16 @@ private boolean fractionalFontMetricsEnabled;
 		return f!=null ? f : getFont();
 	}
 
+	/**
+	 * Returns the font metrics for the given token.
+	 *
+	 * @param token the Token
+	 * @return The font metrics to use for that tokenx.
+	 * @see #getFontForTokenType(int)
+	 */
+	public FontMetrics getFontMetricsForToken(Token token) {
+		return getFontMetricsForTokenType(token.getType());
+	}
 
 	/**
 	 * Returns the font metrics for tokens of the specified type.
@@ -1790,7 +1811,7 @@ private boolean fractionalFontMetricsEnabled;
 				if (t.length() == 1 && t.charAt(0) == '\n') {
 					gen.appendNewline();
 				} else {
-					Font font = getFontForTokenType(t.getType());
+					Font font = getFontForToken(t);
 					Color bg = getBackgroundForToken(t);
 					boolean underline = getUnderlineForToken(t);
 					// Small optimization - don't print fg color if this

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TokenImpl.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TokenImpl.java
@@ -474,7 +474,7 @@ public class TokenImpl implements Token {
 
 		while (token != null && token.isPaintable()) {
 
-			fm = textArea.getFontMetricsForTokenType(token.getType());
+			fm = textArea.getFontMetricsForToken(token);
 			char[] text = token.text;
 			int start = token.textOffset;
 			int end = start + token.textCount;
@@ -525,7 +525,7 @@ public class TokenImpl implements Token {
 	public int getOffsetBeforeX(RSyntaxTextArea textArea, TabExpander e,
 							float startX, float endBeforeX) {
 
-		FontMetrics fm = textArea.getFontMetricsForTokenType(getType());
+	        FontMetrics fm = textArea.getFontMetricsForToken(this);
 		int i = textOffset;
 		int stop = i + textCount;
 		float x = startX;
@@ -581,7 +581,7 @@ public class TokenImpl implements Token {
 	public float getWidthUpTo(int numChars, RSyntaxTextArea textArea,
 			TabExpander e, float x0) {
 		float width = x0;
-		FontMetrics fm = textArea.getFontMetricsForTokenType(getType());
+		FontMetrics fm = textArea.getFontMetricsForToken(this);
 		if (fm != null) {
 			int w;
 			int currentStart = textOffset;
@@ -730,7 +730,7 @@ public class TokenImpl implements Token {
 
 		while (token != null && token.isPaintable()) {
 
-			fm = textArea.getFontMetricsForTokenType(token.getType());
+			fm = textArea.getFontMetricsForToken(token);
 			if (fm == null) {
 				return rect; // Don't return null as things will error.
 			}

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TokenUtils.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TokenUtils.java
@@ -234,7 +234,7 @@ public final class TokenUtils {
 
 		StringBuilder style = new StringBuilder();
 
-		Font font = textArea.getFontForTokenType(token.getType());
+		Font font = textArea.getFontForToken(token);
 		if (font.isBold()) {
 			style.append("font-weight: bold;");
 		}

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/VisibleWhitespaceTokenPainter.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/VisibleWhitespaceTokenPainter.java
@@ -64,8 +64,8 @@ public class VisibleWhitespaceTokenPainter extends DefaultTokenPainter {
 		Color fg = useSTC ? host.getSelectedTextColor() :
 			host.getForegroundForToken(token);
 		Color bg = selected ? null : host.getBackgroundForToken(token);
-		g.setFont(host.getFontForTokenType(token.getType()));
-		FontMetrics fm = host.getFontMetricsForTokenType(token.getType());
+		g.setFont(host.getFontForToken(token));
+		FontMetrics fm = host.getFontMetricsForToken(token);
 
 		int ascent = fm.getAscent();
 		int height = fm.getHeight();


### PR DESCRIPTION
This change creates the base for using fallback fonts.

RSyntaxTextArea gets two new methods getFontForToken and getFontMetricsForToken and the code is updated to call these instead of the *ForTokenType versions. By default the two new methods just calls the *ForTokenType methods, but a subclass can inspect the actual token and change the font/fontmetrics when needed. 