### PR TITLE
Fix #545: NPE in SyntaxView.viewToModel

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxDocument.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxDocument.java
@@ -424,7 +424,7 @@ public class RSyntaxDocument extends RDocument implements Iterable<Token>,
 			getText(startOffset,endOffset-startOffset, s);
 		} catch (BadLocationException ble) {
 			ble.printStackTrace();
-			return null;
+			return new TokenImpl();
 		}
 		int initialTokenType = line==0 ? Token.NULL :
 								getLastTokenTypeOnLine(line-1);


### PR DESCRIPTION
As discussed in #545, an NPE in `SyntaxView` is caused by a `null` token returned from `RSyntaxDocument` in certain unexpected circumstances. This method should always return non-`null` values.