### PR TITLE
Build with Java 11

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,10 +37,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Set up JDK 8
+    - name: Set up JDK 11
       uses: actions/setup-java@v4
       with:
-        java-version: '8'
+        java-version: '11'
         distribution: 'temurin'
 
     # Initializes the CodeQL tools for scanning.

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        java: [ '8', '11', '17', '21']
+        java: ['11', '17', '21']
 
     steps:
     - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -25,8 +25,11 @@ all unit tests, and create the jar, run:
 
     ./gradlew build --warning-mode all
 
-RSTA 3.0 and newer requires Java 8 to compile and run.  If you need
-Java 6 compatibility, you'll need to use a 2.6.x version.
+RSTA 4.0 and newer requires Java 11 to compile and run. If you need
+to support older Java versions:
+
+* RSTA 3.x requires Java 8
+* RSTA 2.6.x supports Java 6
 
 # Demos
 

--- a/RSyntaxTextArea/build.gradle
+++ b/RSyntaxTextArea/build.gradle
@@ -2,9 +2,9 @@ import static org.gradle.api.JavaVersion.*
 
 ['base', 'jacoco', 'biz.aQute.bnd.builder', 'distribution', 'maven-publish', 'signing'].each { apply plugin: it }
 
-// We require building with JDK 8 or later.  We turn off doclint since our
+// We require building with JDK 11 or later.  We turn off doclint since our
 // generated *TokenMakers have horrible documentation (see https://github.com/jflex-de/jflex/issues/182)
-assert current().isJava8Compatible()
+assert current().isJava11Compatible()
 allprojects {
 	tasks.withType(Javadoc) {
 		options.addStringOption('Xdoclint:none', '-quiet')

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 }
 
 group 'com.fifesoft'
-// NOTE: Local Java 8:  /Library/Java/JavaVirtualMachines/jdk1.8.0_191.jdk/Contents/Home
+// NOTE: Local Java 11:  /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home
 
 allprojects {
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,9 @@
 # Note that Maven- and signing-related properties are in <maven-home>/gradle.properties
+
+# This controls source- and target-compatibility.
+# Our builds require Java 11+, but still built artifacts compatible with Java 8.
 javaVersion=1.8
-version=3.5.3-SNAPSHOT
+version=4.0.0-SNAPSHOT
 
 # Ugh, see https://github.com/gradle/gradle/issues/11308
 systemProp.org.gradle.internal.publish.checksums.insecure=true


### PR DESCRIPTION
Build with Java 11. Compiler warnings due to deprecated API usage aren't cleaned up yet.

The goal of this PR is to be the first baby step toward having Java 11 as the minimum Java version for RSTA. While temurin and corretto will continue to support Java 8 until some time in 2026, Swing support is (unfortunately) long-since dead, but Java 9+ includes important changes to ensure apps look good in HiDPI environments, such as the FPAPI.

For reference, here's the [release & support history](https://en.wikipedia.org/wiki/Java_version_history) for all Java releases.

This PR will tackle the following:

* Enforce Java 11 as the minimum JDK version you can build with
* Update CI/CD actions accordingly
* Update checkstyle, since the latest version of that plugin requires Java 11+
* Update spotbugs, since the latest version of that plugin requires Java 11+

This PR will *not* do the following:

* Fix all compiler warnings due to API deprecations.