### PR TITLE
Update RSyntaxTextArea.java

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextArea.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextArea.java
@@ -3388,11 +3388,12 @@ public class RSyntaxTextArea extends RTextArea implements SyntaxConstants {
 				popup.dispose();
 			}
 
-			Window window = SwingUtilities.getWindowAncestor(RSyntaxTextArea.this);
-			popup = new MatchedBracketPopup(window, RSyntaxTextArea.this, matchedBracketOffs);
-			popup.pack();
-			popup.setVisible(true);
-
+			if (RSyntaxTextArea.this.hasFocus()) {
+				Window window = SwingUtilities.getWindowAncestor(RSyntaxTextArea.this);
+				popup = new MatchedBracketPopup(window, RSyntaxTextArea.this, matchedBracketOffs);
+				popup.pack();
+				popup.setVisible(true);
+			}
 		}
 
 		@Override


### PR DESCRIPTION
Avoid showing MatchBracketPopup if RSyntaxTextArea not in focus. I encountered this kind of a defect/bug that when navigating in multiple step wizard the popup bracket hint of one step appears on a different step.