### PR TITLE
Java 11 - Use HiDPI API

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/print/RPrintUtilities.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/print/RPrintUtilities.java
@@ -9,10 +9,7 @@
  */
 package org.fife.print;
 
-import java.awt.Color;
-import java.awt.Font;
-import java.awt.FontMetrics;
-import java.awt.Graphics;
+import java.awt.*;
 import java.awt.print.PageFormat;
 import java.awt.print.Printable;
 
@@ -368,7 +365,7 @@ public abstract class RPrintUtilities {
 		fm = g.getFontMetrics();
 		int fontHeight = fm.getHeight();
 
-		final int lineLengthInPixels = (int)pageFormat.getImageableWidth();
+		final double lineLengthInPixels = pageFormat.getImageableWidth();
 		final int maxLinesPerPage = (int)pageFormat.getImageableHeight() / fontHeight;
 
 		final int startingLineNumber = maxLinesPerPage * pageIndex;
@@ -416,7 +413,7 @@ public abstract class RPrintUtilities {
 			currentLineSeg = removeEndingWhitespace(currentLineSeg);
 
 			// Figure out how long the line is, in pixels.
-			int currentLineLengthInPixels = Utilities.getTabbedTextWidth(currentLineSeg, fm, 0, tabExpander, 0);
+			float currentLineLengthInPixels = Utilities.getTabbedTextWidth(currentLineSeg, fm, 0f, tabExpander, 0);
 
 			//System.err.println("'" + currentLineSeg + "' - " + currentLineLengthInPixels + "/" +
 			// LINE_LENGTH_IN_PIXELS);
@@ -470,7 +467,7 @@ public abstract class RPrintUtilities {
 								return Printable.NO_SUCH_PAGE;
 							}
 							currentLineLengthInPixels = Utilities.
-								getTabbedTextWidth(currentLineSeg, fm, 0, tabExpander, 0);
+								getTabbedTextWidth(currentLineSeg, fm, 0f, tabExpander, 0);
 						} while (currentLineLengthInPixels <= lineLengthInPixels);
 						currentPos--;
 
@@ -488,7 +485,7 @@ public abstract class RPrintUtilities {
 						return Printable.NO_SUCH_PAGE;
 					}
 
-					currentLineLengthInPixels = Utilities.getTabbedTextWidth(currentLineSeg, fm, 0, tabExpander, 0);
+					currentLineLengthInPixels = Utilities.getTabbedTextWidth(currentLineSeg, fm, 0f, tabExpander, 0);
 				} // End of while (currentLineLengthInPixels > LINE_LENGTH_IN_PIXELS).
 
 				startingOffset += currentPos;	// Where to start (offset from line's start), since this line wraps.
@@ -497,8 +494,8 @@ public abstract class RPrintUtilities {
 
 			numPrintedLines++;
 			if (numPrintedLines>startingLineNumber) {
-				//g.drawString(currentLineSeg.toString(), xOffset,y);
-				Utilities.drawTabbedText(currentLineSeg, xOffset,y, g, tabExpander, 0);
+				Graphics2D g2d = (Graphics2D)g;
+				Utilities.drawTabbedText(currentLineSeg, (float)xOffset,y, g2d, tabExpander, 0);
 				y += fontHeight;
 				if (numPrintedLines==startingLineNumber+maxLinesPerPage) {
 					return Printable.PAGE_EXISTS;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/FoldingAwareIconRowHeader.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/FoldingAwareIconRowHeader.java
@@ -11,7 +11,6 @@ package org.fife.ui.rsyntaxtextarea;
 
 import java.awt.Color;
 import java.awt.Graphics;
-import java.awt.Point;
 import javax.swing.Icon;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.Document;
@@ -203,8 +202,7 @@ public class FoldingAwareIconRowHeader extends IconRowHeader {
 		//boolean currentLineHighlighted = textArea.getHighlightCurrentLine();
 		Document doc = textArea.getDocument();
 		Element root = doc.getDefaultRootElement();
-		int topPosition = textArea.viewToModel(
-								new Point(visibleRect.x,visibleRect.y));
+		int topPosition = textArea.viewToModel2D(visibleRect.getLocation());
 		int topLine = root.getElementIndex(topPosition);
 
 		int topY = visibleRect.y;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/ParserManager.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/ParserManager.java
@@ -11,10 +11,10 @@ package org.fife.ui.rsyntaxtextarea;
 
 import java.awt.Color;
 import java.awt.Point;
-import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
+import java.awt.geom.Rectangle2D;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.net.URL;
@@ -433,7 +433,7 @@ class ParserManager implements DocumentListener, ActionListener,
 		if (noticeHighlightPairs!=null) {
 
 			Point p = e.getPoint();
-			int pos = textArea.viewToModel(p);
+			int pos = textArea.viewToModel2D(p);
 
 			for (NoticeHighlightPair pair : noticeHighlightPairs) {
 				ParserNotice notice = pair.notice;
@@ -543,8 +543,7 @@ class ParserManager implements DocumentListener, ActionListener,
 	 * @return Whether the parser notice actually contains the specified point
 	 *         in the view.
 	 */
-	private boolean noticeContainsPointInView(ParserNotice notice,
-			Point p) {
+	private boolean noticeContainsPointInView(ParserNotice notice, Point p) {
 
 		try {
 
@@ -567,9 +566,9 @@ class ParserManager implements DocumentListener, ActionListener,
 				end = elem.getEndOffset() - 1;
 			}
 
-			Rectangle r1 = textArea.modelToView(start);
-			Rectangle r2 = textArea.modelToView(end);
-			if (r1.y!=r2.y) {
+			Rectangle2D r1 = textArea.modelToView2D(start);
+			Rectangle2D r2 = textArea.modelToView2D(end);
+			if (r1.getY() != r2.getY()) {
 				// If the notice spans multiple lines, give them the benefit
 				// of the doubt.  This is only "wrong" if the user is in empty
 				// space "to the right" of the error marker when it ends at the
@@ -577,10 +576,11 @@ class ParserManager implements DocumentListener, ActionListener,
 				return true;
 			}
 
-			r1.y--; // Be a tiny bit lenient.
-			r1.height += 2; // Ditto
-			return p.x>=r1.x && p.x<(r2.x+r2.width) &&
-					p.y>=r1.y && p.y<(r1.y+r1.height);
+			// Be a tiny bit lenient with y/height
+			r1.setRect(r1.getX(), r1.getY() - 1, r1.getWidth(), r1.getHeight() + 2);
+
+			return p.x >= r1.getX() && p.x < (r2.getX() + r2.getWidth()) &&
+					p.y >= r1.getY() && p.y < (r1.getY() + r1.getHeight());
 
 		} catch (BadLocationException ble) { // Never occurs
 			// Give them the benefit of the doubt, should 99% of the time be

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextArea.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextArea.java
@@ -7,6 +7,7 @@ package org.fife.ui.rsyntaxtextarea;
 import java.awt.*;
 import java.awt.datatransfer.Clipboard;
 import java.awt.event.*;
+import java.awt.geom.Point2D;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.net.MalformedURLException;
@@ -848,10 +849,10 @@ public class RSyntaxTextArea extends RTextArea implements SyntaxConstants {
 				(bracketInfo.y!=lastBracketMatchPos ||
 				 bracketInfo.x!=lastCaretBracketPos)) {
 			try {
-				match = modelToView(bracketInfo.y);
+				match = modelToView2D(bracketInfo.y).getBounds();
 				if (match!=null) { // Happens if we're not yet visible
 					if (getPaintMatchedBracketPair()) {
-						dotRect = modelToView(bracketInfo.x);
+						dotRect = modelToView2D(bracketInfo.x).getBounds();
 					}
 					else {
 						dotRect = null;
@@ -1604,7 +1605,7 @@ public class RSyntaxTextArea extends RTextArea implements SyntaxConstants {
 	boolean getPaintTokenBackgrounds(int line, float y) {
 		//System.out.println(y + ", " + getCurrentCaretY() + "-" + (getCurrentCaretY() + getLineHeight()));
 		int iy = (int)y;
-		int curCaretY = getCurrentCaretY();
+		double curCaretY = getCurrentCaretY();
 		return iy<curCaretY || iy>=curCaretY+getLineHeight() ||
 				!getHighlightCurrentLine();
 	}
@@ -2189,7 +2190,7 @@ public class RSyntaxTextArea extends RTextArea implements SyntaxConstants {
 	 * @param offs The position in the model.
 	 * @return The token, or <code>null</code> if no token is at that
 	 *         position.
-	 * @see #viewToToken(Point)
+	 * @see #viewToToken(Point2D)
 	 */
 	public Token modelToToken(int offs) {
 		if (offs>=0) {
@@ -3354,14 +3355,14 @@ public class RSyntaxTextArea extends RTextArea implements SyntaxConstants {
 	 *         position.
 	 * @see #modelToToken(int)
 	 */
-	public Token viewToToken(Point p) {
+	public Token viewToToken(Point2D p) {
 		/*
 		 * TODO: This is a little inefficient.  This should convert view
 		 * coordinates to the underlying token (if any).  The way things currently
 		 * are, we're calling getTokenListForLine() twice (once in viewToModel()
 		 * and once here).
 		 */
-		return modelToToken(viewToModel(p));
+		return modelToToken(viewToModel2D(p));
 	}
 
 	/**
@@ -3563,7 +3564,7 @@ public class RSyntaxTextArea extends RTextArea implements SyntaxConstants {
 					c2 = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR);
 				}
 				else if (t!=null && linkGenerator!=null) {
-					int offs = viewToModel(e.getPoint());
+					int offs = viewToModel2D(e.getPoint());
 					LinkGeneratorResult newResult = linkGenerator.
 							isLinkAtOffset(RSyntaxTextArea.this, offs);
 					if (newResult!=null) {

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/focusabletip/TipWindow.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/focusabletip/TipWindow.java
@@ -15,7 +15,6 @@ import java.awt.Container;
 import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.Point;
-import java.awt.Rectangle;
 import java.awt.Window;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
@@ -23,6 +22,7 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.awt.geom.Rectangle2D;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
@@ -169,11 +169,11 @@ class TipWindow extends JWindow {
 	void fixSize() {
 
 		Dimension d;
-		Rectangle r;
+		Rectangle2D r;
 		try {
 
 			// modelToView call is required for this hack, never remove!
-			r = textArea.modelToView(textArea.getDocument().getLength()-1);
+			r = textArea.modelToView2D(textArea.getDocument().getLength()-1);
 
 			// Ensure the text area doesn't start out too tall or wide.
 			d = textArea.getPreferredSize();
@@ -191,9 +191,9 @@ class TipWindow extends JWindow {
 
 			// if the new textArea width causes our text to wrap, we must
 			// compute a new preferred size to get all our physical lines.
-			r = textArea.modelToView(textArea.getDocument().getLength()-1);
-			if (r.y+r.height>d.height) {
-				d.height = r.y + r.height + 5;
+			r = textArea.modelToView2D(textArea.getDocument().getLength()-1);
+			if (r.getMaxY() > d.height) {
+				d.height = (int)r.getMaxY() + 5;
 				if (ft.getMaxSize() != null) {
 					d.height = Math.min(d.height, maxWindowH);
 				}

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/FoldIndicator.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/FoldIndicator.java
@@ -196,7 +196,7 @@ public class FoldIndicator extends AbstractGutterComponent {
 
 		RSyntaxTextArea rsta = (RSyntaxTextArea)textArea;
 		if (rsta.isCodeFoldingEnabled()) { // Should always be true
-			int offs = rsta.viewToModel(p); // TODO: Optimize me
+			int offs = rsta.viewToModel2D(p); // TODO: Optimize me
 			if (offs>-1) {
 				try {
 					int line = rsta.getLineOfOffset(offs);
@@ -357,7 +357,7 @@ public class FoldIndicator extends AbstractGutterComponent {
 		RSyntaxTextArea rsta = (RSyntaxTextArea)textArea;
 		if (rsta.isCodeFoldingEnabled()) {
 			FoldManager fm = rsta.getFoldManager();
-			int pos = rsta.viewToModel(new Point(0, e.getY()));
+			int pos = rsta.viewToModel2D(new Point(0, e.getY()));
 			if (pos>=0) { // Not -1
 				int line;
 				try {
@@ -601,8 +601,7 @@ public class FoldIndicator extends AbstractGutterComponent {
 		View v = ui.getRootView(textArea).getView(0);
 		Document doc = textArea.getDocument();
 		Element root = doc.getDefaultRootElement();
-		int topPosition = textArea.viewToModel(
-								new Point(visibleRect.x,visibleRect.y));
+		int topPosition = textArea.viewToModel2D(visibleRect.getLocation());
 		int topLine = root.getElementIndex(topPosition);
 		int cellHeight = textArea.getLineHeight();
 		FoldManager fm = ((RSyntaxTextArea)textArea).getFoldManager();
@@ -712,7 +711,7 @@ public class FoldIndicator extends AbstractGutterComponent {
 		int line = 0;
 
 		try {
-			int offs = textArea.viewToModel(p);
+			int offs = textArea.viewToModel2D(p);
 			if (offs>-1) {
 				line = textArea.getLineOfOffset(offs);
 			}

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/Gutter.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/Gutter.java
@@ -507,7 +507,7 @@ public class Gutter extends JPanel {
 	 */
 	public GutterIconInfo[] getTrackingIcons(Point p)
 			throws BadLocationException {
-		int offs = textArea.viewToModel(new Point(0, p.y));
+		int offs = textArea.viewToModel2D(new Point(0, p.y));
 		int line = textArea.getLineOfOffset(offs);
 		return iconArea.getTrackingIcons(line);
 	}

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/IconRowHeader.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/IconRowHeader.java
@@ -12,10 +12,10 @@ import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Insets;
-import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
+import java.awt.geom.Point2D;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -552,8 +552,8 @@ public class IconRowHeader extends AbstractGutterComponent implements MouseListe
 		Document doc = textArea.getDocument();
 		Element root = doc.getDefaultRootElement();
 		int lineCount = root.getElementCount();
-		int topPosition = textArea.viewToModel(
-								new Point(visibleRect.x,visibleRect.y));
+		int topPosition = textArea.viewToModel2D(
+								new Point2D.Double(visibleRect.x, visibleRect.y));
 		int topLine = root.getElementIndex(topPosition);
 
 		// Compute the y at which to begin painting text, taking into account
@@ -857,8 +857,8 @@ public class IconRowHeader extends AbstractGutterComponent implements MouseListe
 	 * @return The corresponding line in the editor.
 	 * @throws BadLocationException ble If an error occurs.
 	 */
-	private int viewToModelLine(Point p) throws BadLocationException {
-		int offs = textArea.viewToModel(p);
+	private int viewToModelLine(Point2D p) throws BadLocationException {
+		int offs = textArea.viewToModel2D(p);
 		return offs>-1 ? textArea.getLineOfOffset(offs) : -1;
 	}
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/LineNumberList.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/LineNumberList.java
@@ -293,7 +293,7 @@ public class LineNumberList extends AbstractGutterComponent
 	@Override
 	public void mouseDragged(MouseEvent e) {
 		if (mouseDragStartOffset>-1) {
-			int pos = textArea.viewToModel(new Point(0, e.getY()));
+			int pos = textArea.viewToModel2D(new Point(0, e.getY()));
 			if (pos>=0) { // Not -1
 				textArea.setCaretPosition(mouseDragStartOffset);
 				textArea.moveCaretPosition(pos);
@@ -323,7 +323,7 @@ public class LineNumberList extends AbstractGutterComponent
 			return;
 		}
 		if (e.getButton()==MouseEvent.BUTTON1) {
-			int pos = textArea.viewToModel(new Point(0, e.getY()));
+			int pos = textArea.viewToModel2D(new Point(0, e.getY()));
 			if (pos>=0) { // Not -1
 				textArea.setCaretPosition(pos);
 			}
@@ -521,8 +521,7 @@ public class LineNumberList extends AbstractGutterComponent
 		Document doc = textArea.getDocument();
 		Element root = doc.getDefaultRootElement();
 		int lineCount = root.getElementCount();
-		int topPosition = textArea.viewToModel(
-								new Point(visibleRect.x,visibleRect.y));
+		int topPosition = textArea.viewToModel2D(visibleRect.getLocation());
 		int topLine = root.getElementIndex(topPosition);
 		FoldManager fm = null;
 		if (textArea instanceof RSyntaxTextArea) {

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextAreaEditorKit.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextAreaEditorKit.java
@@ -14,6 +14,8 @@ import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Window;
 import java.awt.event.ActionEvent;
+import java.awt.geom.Point2D;
+import java.awt.geom.Rectangle2D;
 import java.io.IOException;
 import java.io.Reader;
 import java.text.BreakIterator;
@@ -2015,8 +2017,8 @@ public class RTextAreaEditorKit extends DefaultEditorKit {
 				if (magicPosition == null &&
 					(direction == SwingConstants.NORTH ||
 					direction == SwingConstants.SOUTH)) {
-					Rectangle r = textArea.modelToView(dot);
-					magicPosition = new Point(r.x, r.y);
+					Rectangle2D r = textArea.modelToView2D(dot);
+					magicPosition = new Point((int)r.getX(), (int)r.getY());
 				}
 
 				NavigationFilter filter = textArea.getNavigationFilter();
@@ -2148,11 +2150,10 @@ public class RTextAreaEditorKit extends DefaultEditorKit {
 			selectedIndex = textArea.getCaretPosition();
 			if (selectedIndex != -1) {
 				if (left) {
-					selectedIndex = textArea.viewToModel(
-									new Point(visible.x, visible.y));
+					selectedIndex = textArea.viewToModel2D(visible.getLocation());
 				}
 				else {
-					selectedIndex = textArea.viewToModel(
+					selectedIndex = textArea.viewToModel2D(
 							new Point(visible.x + visible.width - 1,
 									visible.y + visible.height - 1));
 				}
@@ -2769,37 +2770,37 @@ public class RTextAreaEditorKit extends DefaultEditorKit {
 			int initialY = visible.y;
 			Caret caret = textArea.getCaret();
 			Point magicPosition = caret.getMagicCaretPosition();
-			int yOffset;
+			double yOffset;
 
 			if (selectedIndex!=-1) {
 
 				try {
 
-					Rectangle dotBounds = textArea.modelToView(selectedIndex);
-					int x = (magicPosition != null) ? magicPosition.x :
-												dotBounds.x;
-					int h = dotBounds.height;
+					Rectangle2D dotBounds = textArea.modelToView2D(selectedIndex);
+					double x = (magicPosition != null) ? magicPosition.x :
+												dotBounds.getX();
+					double h = dotBounds.getHeight();
 					yOffset = direction *
-							((int)Math.ceil(scrollAmount/(double)h)-1)*h;
+							(Math.ceil(scrollAmount/h)-1)*h;
 					newVis.y = constrainY(textArea, initialY+yOffset, yOffset, visible.height);
 					int newIndex;
 
-					if (visible.contains(dotBounds.x, dotBounds.y)) {
+					if (visible.contains(dotBounds.getX(), dotBounds.getY())) {
 						// Dot is currently visible, base the new
 						// location off the old, or
-						newIndex = textArea.viewToModel(
-									new Point(x, constrainY(textArea,
-										dotBounds.y + yOffset, 0, 0)));
-										}
+						newIndex = textArea.viewToModel2D(
+									new Point2D.Double(x, constrainY(textArea,
+										dotBounds.getY() + yOffset, 0, 0)));
+					}
 					else {
 						// Dot isn't visible, choose the top or the bottom
 						// for the new location.
 						if (direction == -1) {
-							newIndex = textArea.viewToModel(new Point(
+							newIndex = textArea.viewToModel2D(new Point2D.Double(
 													x, newVis.y));
 						}
 						else {
-							newIndex = textArea.viewToModel(new Point(
+							newIndex = textArea.viewToModel2D(new Point2D.Double(
 									x, newVis.y + visible.height));
 						}
 					}
@@ -2834,7 +2835,7 @@ public class RTextAreaEditorKit extends DefaultEditorKit {
 			textArea.scrollRectToVisible(newVis);
 		}
 
-		private int constrainY(JTextComponent textArea, int y, int vis, int screenHeight) {
+		private int constrainY(JTextComponent textArea, double y, double vis, int screenHeight) {
 			if (y < 0) {
 				y = 0;
 			}
@@ -2842,7 +2843,7 @@ public class RTextAreaEditorKit extends DefaultEditorKit {
 				//y = Math.max(0, textArea.getHeight() - vis);
 				y = Math.max(0, textArea.getHeight()-screenHeight);
 			}
-			return y;
+			return (int)y;
 		}
 
 		private int constrainOffset(JTextComponent text, int offset) {
@@ -2860,22 +2861,22 @@ public class RTextAreaEditorKit extends DefaultEditorKit {
 									Rectangle visible, int initialY,
 									int index) {
 			try {
-				Rectangle dotBounds = text.modelToView(index);
-	                if (dotBounds.y < visible.y ||
-					(dotBounds.y > (visible.y + visible.height)) ||
-					(dotBounds.y + dotBounds.height) >
+				Rectangle2D dotBounds = text.modelToView2D(index);
+	                if (dotBounds.getY() < visible.y ||
+					(dotBounds.getY() > (visible.y + visible.height)) ||
+					(dotBounds.getY() + dotBounds.getHeight()) >
 					(visible.y + visible.height)) {
-					int y;
-					if (dotBounds.y < visible.y) {
-						y = dotBounds.y;
+					double y;
+					if (dotBounds.getY() < visible.y) {
+						y = dotBounds.getY();
 					}
 					else {
-						y = dotBounds.y + dotBounds.height - visible.height;
+						y = dotBounds.getY() + dotBounds.getHeight() - visible.height;
 					}
 					if ((direction == -1 && y < initialY) ||
 						(direction == 1 && y > initialY)) {
 						// Only adjust if it won't cause scrolling upward.
-						visible.y = y;
+						visible.y = (int)y;
 					}
 				}
 			} catch (BadLocationException ble) {}

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextAreaUI.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextAreaUI.java
@@ -10,6 +10,7 @@ package org.fife.ui.rtextarea;
 
 import java.awt.*;
 import java.awt.event.*;
+import java.awt.geom.Rectangle2D;
 
 import javax.swing.*;
 import javax.swing.text.*;
@@ -456,22 +457,22 @@ public class RTextAreaUI extends BasicTextAreaUI {
 				//int height = textArea.currentCaretRect.height);
 				int height = textArea.getLineHeight();
 
+				Graphics2D g2d = (Graphics2D)g;
 				if (textArea.getFadeCurrentLineHighlight()) {
-					Graphics2D g2d = (Graphics2D)g;
 					Color bg = textArea.getBackground();
 					GradientPaint paint = new GradientPaint(
 						visibleRect.x,0, highlight,
 						visibleRect.x+visibleRect.width,0,
 								bg==null ? Color.WHITE : bg);
 					g2d.setPaint(paint);
-					g2d.fillRect(visibleRect.x,textArea.currentCaretY,
-									visibleRect.width, height);
 				}
 				else {
-					g.setColor(highlight);
-					g.fillRect(visibleRect.x,textArea.currentCaretY,
-									visibleRect.width, height);
+					g2d.setColor(highlight);
 				}
+				g2d.fill(new Rectangle2D.Double(
+					visibleRect.x, textArea.currentCaretY,
+					visibleRect.width, height
+				));
 
 			}
 
@@ -586,8 +587,8 @@ public class RTextAreaUI extends BasicTextAreaUI {
 	 *         into the document.
 	 */
 	public int yForLineContaining(int offs) throws BadLocationException {
-		Rectangle r = modelToView(textArea, offs);
-		return r!=null ? r.y : -1;
+		Rectangle2D r = modelToView2D(textArea, offs, Position.Bias.Forward);
+		return r != null ? (int)r.getY() : -1;
 	}
 
 


### PR DESCRIPTION
This PR migrates all AWT APIs that were deprecated in Java 9 to their new HiDPI equivalents. This fixes the vast majority of compiler warnings in Java 11+ builds.

- [ ] Update API calls
- [ ] Verify no more compiler warnings in CI builds for things related to deprecated int-based rendering calls
- [ ] Manually test app in Windows
- [ ] Manualy test app in macxOS
- [ ] Release SNAPSHOT build to Sonatype
