### PR TITLE
Fix #541: Line numbers resize when getting a new document

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/AbstractGutterComponent.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/AbstractGutterComponent.java
@@ -110,8 +110,24 @@ abstract class AbstractGutterComponent extends JPanel {
 	 * Implementations can take this opportunity to repaint, revalidate, etc.
 	 *
 	 * @param e The document event.
+	 * @see #handleDocumentUpdated(RDocument, RDocument)
 	 */
 	abstract void handleDocumentEvent(DocumentEvent e);
+
+
+	/**
+	 * Called when the document is updated. This happens when an application
+	 * calls {@code textArea.read(reader)}, for example.<p>
+	 *
+	 * The default implementation does nothing. Subclasses can override.
+	 *
+	 * @param oldDoc The old document, which may be {@code null}.
+	 * @param newDoc The new document, which may be {@code null}.
+	 * @see #handleDocumentEvent(DocumentEvent)
+	 */
+	void handleDocumentUpdated(RDocument oldDoc, RDocument newDoc) {
+		// Do nothing
+	}
 
 
 	/**

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/Gutter.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/Gutter.java
@@ -1260,6 +1260,11 @@ public class Gutter extends JPanel {
 				if (newDoc != null) {
 					newDoc.addDocumentListener(this);
 				}
+				for (int i=0; i<getComponentCount(); i++) {
+					AbstractGutterComponent agc =
+						(AbstractGutterComponent)getComponent(i);
+					agc.handleDocumentUpdated(old, newDoc);
+				}
 			}
 
 		}

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/LineNumberList.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/LineNumberList.java
@@ -250,6 +250,15 @@ public class LineNumberList extends AbstractGutterComponent
 	}
 
 
+	/**
+	 * Overridden to update the width of this component.
+	 */
+	@Override
+	void handleDocumentUpdated(RDocument oldDoc, RDocument newDoc) {
+		updateCellWidths();
+	}
+
+
 	@Override
 	protected void init() {
 


### PR DESCRIPTION
Gutter components should be notified when the `Document` is updated. Currently they're only notified when a `DocumentEvent` occurs, but when loading entirely new content via `JTextComponent#read()`, we create a new `RDocument` instance and swap it out with the old one for performance reasons.

This PR notifies all Gutter components when a new `Document` is set on the text area. Currently only `LineNumberList` does anything - it recalculates its preferred width.

Note: This isn't always reproducible, e.g. it isn't reproducible in RText. It is reproducible in the RSTA demo app if you add > 100 lines to one of the sample language source files, then flip back and forth between it. This triggers a `TextEditorPane.load()`, which ultimately delegates to `JTextComponent.read()`.