### PR TITLE
Fix #581: Overzealous Mark Occurrences for single characters

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/DefaultOccurrenceMarker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/DefaultOccurrenceMarker.java
@@ -39,9 +39,13 @@ class DefaultOccurrenceMarker implements OccurrenceMarker {
 				RSyntaxUtilities.isNonWordChar(t)) {
 			// Try to the "left" of the caret.
 			dot--;
+			t = null; // Clear in case it's a non-word char
 			try {
 				if (dot>=textArea.getLineStartOffset(line)) {
 					t = RSyntaxUtilities.getTokenAtOffset(tokenList, dot);
+					if (t != null && RSyntaxUtilities.isNonWordChar(t)) {
+						t = null;
+					}
 				}
 			} catch (BadLocationException ble) {
 				ble.printStackTrace(); // Never happens

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/DefaultOccurrenceMarkerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/DefaultOccurrenceMarkerTest.java
@@ -46,6 +46,42 @@ class DefaultOccurrenceMarkerTest extends AbstractRSyntaxTextAreaTest {
 
 
 	@Test
+	void testGetTokenToMark_none_atEndOfLineAfterNonWordChar() {
+
+		String origContent = "foo\n.";
+		RSyntaxTextArea textArea = createTextArea(SyntaxConstants.SYNTAX_STYLE_JAVA, origContent);
+		textArea.setCaretPosition(origContent.indexOf('.') + 1); // End of document
+
+		DefaultOccurrenceMarker marker = new DefaultOccurrenceMarker();
+		Assertions.assertNull(marker.getTokenToMark(textArea));
+	}
+
+
+	@Test
+	void testGetTokenToMark_none_betweenTwoNonWordChars() {
+
+		String origContent = "..";
+		RSyntaxTextArea textArea = createTextArea(SyntaxConstants.SYNTAX_STYLE_JAVA, origContent);
+		textArea.setCaretPosition(1); // Between the two periods
+
+		DefaultOccurrenceMarker marker = new DefaultOccurrenceMarker();
+		Assertions.assertNull(marker.getTokenToMark(textArea));
+	}
+
+
+	@Test
+	void testGetTokenToMark_none_atStartOfLinePrecedingNonWordChar() {
+
+		String origContent = "foo\n.";
+		RSyntaxTextArea textArea = createTextArea(SyntaxConstants.SYNTAX_STYLE_JAVA, origContent);
+		textArea.setCaretPosition(origContent.indexOf('.')); // Start of line before the period
+
+		DefaultOccurrenceMarker marker = new DefaultOccurrenceMarker();
+		Assertions.assertNull(marker.getTokenToMark(textArea));
+	}
+
+
+	@Test
 	void testIsValidType_validType() {
 
 		String origContent = "public int foo() {}";


### PR DESCRIPTION
Discussed as part of the issue in #575. The "Mark Occurrences" support usually highlights all instances of any token of type "identifier." Unfortunately many `TokenMaker` implementations style the characters `,`, `;`, and `.` (and possibly others) as identifiers for aesthetic purposes only. This has the side effect of the Mark Occurrences support highlighting all instances of them if the caret pauses near them.

At bets, this is visually surprising. At worst, it can cause the editor to hang for very large files with many instances of the character at the caret.

We should skip marking occurrences of non-word characters at any location. In 4.0.0 we can look at a more robust solution.