### PR TITLE
Bump checkstyle and spotbugs

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/io/DocumentReader.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/io/DocumentReader.java
@@ -93,7 +93,7 @@ public class DocumentReader extends Reader {
 	 */
 	@Override
 	public int read() {
-		if(position>=document.getLength()) {
+		if (position>=document.getLength()) {
 			return -1;      // Read past end of document.
 		}
 		try {
@@ -133,14 +133,14 @@ public class DocumentReader extends Reader {
 	@Override
 	public int read(char[] cbuf, int off, int len) {
 		int k;
-		if(position>=document.getLength()) {
+		if (position>=document.getLength()) {
 			return -1;      // Read past end of document.
 		}
 		k = len;
-		if((position+k)>=document.getLength()) {
+		if ((position+k)>=document.getLength()) {
 			k = document.getLength() - (int)position;
 		}
-		if(off + k >= cbuf.length) {
+		if (off + k >= cbuf.length) {
 			k = cbuf.length - off;
 		}
 		try {
@@ -178,7 +178,7 @@ public class DocumentReader extends Reader {
 	 */
 	@Override
 	public void reset() {
-		if(mark==-1) {
+		if (mark==-1) {
 			position = 0;
 		}
 		else {

--- a/RSyntaxTextArea/src/main/java/org/fife/print/RPrintUtilities.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/print/RPrintUtilities.java
@@ -539,7 +539,7 @@ public abstract class RPrintUtilities {
 	 * A tab expander for the document currently being printed with the
 	 * font being used for the printing.
 	 */
-	private static class RPrintTabExpander implements TabExpander {
+	private static final class RPrintTabExpander implements TabExpander {
 
 		@Override
 		public float nextTabStop(float x, int tabOffset) {

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/CodeTemplateManager.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/CodeTemplateManager.java
@@ -340,7 +340,7 @@ public class CodeTemplateManager {
 	 * parameter and a <code>Segment</code> as its second, and knows
 	 * to compare the template's ID to the segment's text.
 	 */
-	private static class TemplateComparator implements Comparator<Object>,
+	private static final class TemplateComparator implements Comparator<Object>,
 			Serializable{
 
 		@Override
@@ -382,7 +382,7 @@ public class CodeTemplateManager {
 	/**
 	 * A file filter that accepts only XML files.
 	 */
-	private static class XMLFileFilter implements FileFilter {
+	private static final class XMLFileFilter implements FileFilter {
 		@Override
 		public boolean accept(File f) {
 			return f.getName().toLowerCase().endsWith(".xml");

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/ErrorStrip.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/ErrorStrip.java
@@ -699,7 +699,7 @@ public class ErrorStrip extends JPanel {
 	 *
 	 * @author predi
 	 */
-	private static class DefaultErrorStripMarkerToolTipProvider
+	private static final class DefaultErrorStripMarkerToolTipProvider
 			implements ErrorStripMarkerToolTipProvider {
 
 		@Override
@@ -753,7 +753,7 @@ public class ErrorStrip extends JPanel {
 	/**
 	 * Listens for events in the error strip and its markers.
 	 */
-	private class Listener extends MouseAdapter
+	private final class Listener extends MouseAdapter
 					implements PropertyChangeListener, CaretListener {
 
 		private final Rectangle r = new Rectangle();

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/MatchedBracketPopup.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/MatchedBracketPopup.java
@@ -184,7 +184,7 @@ public class MatchedBracketPopup extends JWindow {
 	/**
 	 * Action performed when Escape is pressed in this popup.
 	 */
-	private class EscapeAction extends AbstractAction {
+	private final class EscapeAction extends AbstractAction {
 
 		@Override
 		public void actionPerformed(ActionEvent e) {

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaHighlighter.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaHighlighter.java
@@ -284,7 +284,7 @@ public class RSyntaxTextAreaHighlighter extends RTextAreaHighlighter {
 	 * Highlight info implementation used for parser notices and marked
 	 * occurrences.
 	 */
-	private static class SyntaxLayeredHighlightInfoImpl extends
+	private static final class SyntaxLayeredHighlightInfoImpl extends
 			LayeredHighlightInfoImpl {
 
 		private ParserNotice notice;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxUtilities.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxUtilities.java
@@ -711,7 +711,7 @@ public final class RSyntaxUtilities implements SwingConstants {
 
 			case WEST:
 				int endOffs = view.getEndOffset();
-				if(pos == -1) {
+				if (pos == -1) {
 					pos = Math.max(0, endOffs - 1);
 				}
 				else {
@@ -732,7 +732,7 @@ public final class RSyntaxUtilities implements SwingConstants {
 				break;
 
 			case EAST:
-				if(pos == -1) {
+				if (pos == -1) {
 					pos = view.getStartOffset();
 				}
 				else {
@@ -1144,7 +1144,7 @@ return c.getLineStartOffset(line);
 
 		int endOffs = Math.min(offs+1, doc.getLength());
 		String s = doc.getText(lineStart, endOffs-lineStart);
-		if(s != null && !s.isEmpty()) {
+		if (s != null && !s.isEmpty()) {
 			int i = s.length() - 1;
 			char ch = s.charAt(i);
 			if (Character.isWhitespace(ch)) {

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/Theme.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/Theme.java
@@ -595,7 +595,7 @@ public class Theme {
 	/**
 	 * Loads a <code>SyntaxScheme</code> from an XML file.
 	 */
-	private static class XmlHandler extends DefaultHandler {
+	private static final class XmlHandler extends DefaultHandler {
 
 		private Theme theme;
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/WrappedSyntaxView.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/WrappedSyntaxView.java
@@ -689,14 +689,14 @@ public class WrappedSyntaxView extends BoxView implements TabExpander,
 
 		boolean isBackward = (b == Position.Bias.Backward);
 		int testPos = (isBackward) ? Math.max(0, pos - 1) : pos;
-		if(isBackward && testPos < getStartOffset()) {
+		if (isBackward && testPos < getStartOffset()) {
 			return null;
 		}
 
 		int vIndex = getViewIndexAtPosition(testPos);
 		if ((vIndex != -1) && (vIndex < getViewCount())) {
 			View v = getView(vIndex);
-			if(v != null && testPos >= v.getStartOffset() &&
+			if (v != null && testPos >= v.getStartOffset() &&
 					testPos < v.getEndOffset()) {
 				Shape childShape = getChildAllocation(vIndex, a);
 				if (childShape == null) {
@@ -704,8 +704,8 @@ public class WrappedSyntaxView extends BoxView implements TabExpander,
 					return null;
 				}
 				Shape retShape = v.modelToView(pos, childShape, b);
-				if(retShape == null && v.getEndOffset() == pos) {
-					if(++vIndex < getViewCount()) {
+				if (retShape == null && v.getEndOffset() == pos) {
+					if (++vIndex < getViewCount()) {
 						v = getView(vIndex);
 						retShape = v.modelToView(pos, getChildAllocation(vIndex, a), b);
 					}

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/focusabletip/FocusableTip.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/focusabletip/FocusableTip.java
@@ -304,7 +304,7 @@ public class FocusableTip {
 	/**
 	 * Listens for events in a text area.
 	 */
-	private class TextAreaListener extends MouseInputAdapter implements
+	private final class TextAreaListener extends MouseInputAdapter implements
 			CaretListener, ComponentListener, FocusListener, KeyListener {
 
 		@Override

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/focusabletip/SizeGrip.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/focusabletip/SizeGrip.java
@@ -132,7 +132,7 @@ class SizeGrip extends JPanel {
 	 * Listens for mouse events on this panel and resizes the parent window
 	 * appropriately.
 	 */
-	private class MouseHandler extends MouseInputAdapter {
+	private final class MouseHandler extends MouseInputAdapter {
 
 		/*
 		 * NOTE: We use SwingUtilities.convertPointToScreen() instead of just using

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/focusabletip/TipWindow.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/focusabletip/TipWindow.java
@@ -194,7 +194,7 @@ class TipWindow extends JWindow {
 			r = textArea.modelToView(textArea.getDocument().getLength()-1);
 			if (r.y+r.height>d.height) {
 				d.height = r.y + r.height + 5;
-				if(ft.getMaxSize() != null) {
+				if (ft.getMaxSize() != null) {
 					d.height = Math.min(d.height, maxWindowH);
 				}
 				textArea.setPreferredSize(d);

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/DefaultFoldManager.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/DefaultFoldManager.java
@@ -510,7 +510,7 @@ private Fold getFoldForLineImpl(Fold parent, List<Fold> folds, int line) {
 	/**
 	 * Listens for events in the text editor.
 	 */
-	private class Listener implements DocumentListener, PropertyChangeListener {
+	private final class Listener implements DocumentListener, PropertyChangeListener {
 
 		@Override
 		public void changedUpdate(DocumentEvent e) {

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/HtmlFoldParser.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/HtmlFoldParser.java
@@ -386,7 +386,7 @@ public class HtmlFoldParser implements FoldParser {
 	 * A simple wrapper for the token denoting the closing of a tag (i.e.
 	 * "<code>&gt;</code>" or "<code>/&gt;</code>").
 	 */
-	private static class TagCloseInfo {
+	private static final class TagCloseInfo {
 
 		private Token closeToken;
 		private int line;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/ClipboardHistoryPopup.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/ClipboardHistoryPopup.java
@@ -246,7 +246,7 @@ class ClipboardHistoryPopup extends JWindow {
 	/**
 	 * Action performed when Escape is pressed in this popup.
 	 */
-	private class EscapeAction extends AbstractAction {
+	private final class EscapeAction extends AbstractAction {
 
 		@Override
 		public void actionPerformed(ActionEvent e) {

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/ConfigurableCaret.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/ConfigurableCaret.java
@@ -712,7 +712,7 @@ public class ConfigurableCaret extends DefaultCaret {
 	 *
 	 * Common cases: backspacing to visible line of collapsed region.
 	 */
-	private class FoldAwareNavigationFilter extends NavigationFilter {
+	private final class FoldAwareNavigationFilter extends NavigationFilter {
 
 		@Override
 	    public void setDot(FilterBypass fb, int dot, Position.Bias bias) {

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/FoldIndicator.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/FoldIndicator.java
@@ -913,7 +913,7 @@ public class FoldIndicator extends AbstractGutterComponent {
 	 * Updates the alpha used for this component's "collapsed" fold icons, if
 	 * necessary.
 	 */
-	private class AlphaRunnable implements ActionListener {
+	private final class AlphaRunnable implements ActionListener {
 
 		private float delta;
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/Gutter.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/Gutter.java
@@ -1153,7 +1153,7 @@ public class Gutter extends JPanel {
 	/**
 	 * Listens for the text area resizing.
 	 */
-	private class TextAreaListener extends ComponentAdapter
+	private final class TextAreaListener extends ComponentAdapter
 						implements DocumentListener, PropertyChangeListener,
 						ActiveLineRangeListener {
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/LineHighlightManager.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/LineHighlightManager.java
@@ -227,7 +227,7 @@ class LineHighlightManager {
 	 * distinguished from one another.  See:
 	 * https://github.com/bobbylight/RSyntaxTextArea/issues/161
 	 */
-	private static class LineHighlightInfoComparator
+	private static final class LineHighlightInfoComparator
 			implements Comparator<LineHighlightInfo> {
 
 		@Override

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/LineNumberList.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/LineNumberList.java
@@ -776,7 +776,7 @@ public class LineNumberList extends AbstractGutterComponent
 	/**
 	 * Listens for events in the text area we're interested in.
 	 */
-	private class Listener implements CaretListener, PropertyChangeListener {
+	private final class Listener implements CaretListener, PropertyChangeListener {
 
 		private boolean installed;
 
@@ -853,7 +853,7 @@ public class LineNumberList extends AbstractGutterComponent
 	}
 
 
-	private static class SimpleLineNumberFormatter implements LineNumberFormatter {
+	private static final class SimpleLineNumberFormatter implements LineNumberFormatter {
 		@Override
 		public String format(int lineNumber) {
 			return Integer.toString(lineNumber);

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RDocument.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RDocument.java
@@ -45,7 +45,7 @@ public class RDocument extends PlainDocument {
 	/**
 	 * Document content that provides fast access to individual characters.
 	 */
-	private static class RGapContent extends GapContent {
+	private static final class RGapContent extends GapContent {
 
 		protected char charAt(int offset) throws BadLocationException {
 			if (offset<0 || offset>=length()) {

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextAreaEditorKit.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextAreaEditorKit.java
@@ -428,7 +428,7 @@ public class RTextAreaEditorKit extends DefaultEditorKit {
 			} // End of for (int counter = 0; counter < nch; counter++).
 
 			if (last < nch) {
-				if(lastWasCR) {
+				if (lastWasCR) {
 					if (last < (nch - 1)) {
 						doc.insertString(pos, new String(buff, last,
 										nch - last - 1), null);
@@ -2012,7 +2012,7 @@ public class RTextAreaEditorKit extends DefaultEditorKit {
 
 			try {
 
-				if(magicPosition == null &&
+				if (magicPosition == null &&
 					(direction == SwingConstants.NORTH ||
 					direction == SwingConstants.SOUTH)) {
 					Rectangle r = textArea.modelToView(dot);
@@ -2037,7 +2037,7 @@ public class RTextAreaEditorKit extends DefaultEditorKit {
 					caret.setDot(dot);
 				}
 
-				if(magicPosition != null &&
+				if (magicPosition != null &&
 					(direction == SwingConstants.NORTH ||
 					direction == SwingConstants.SOUTH)) {
 						caret.setMagicCaretPosition(magicPosition);
@@ -2078,7 +2078,7 @@ public class RTextAreaEditorKit extends DefaultEditorKit {
 
 			try {
 				offs = getNextWord(textArea, offs);
-				if(offs >= curPara.getEndOffset() &&
+				if (offs >= curPara.getEndOffset() &&
 							oldOffs != curPara.getEndOffset() - 1) {
 					// we should first move to the end of current paragraph
 					// https://bugs.java.com/bugdatabase/view_bug.do?bug_id=4278839
@@ -2087,7 +2087,7 @@ public class RTextAreaEditorKit extends DefaultEditorKit {
 			} catch (BadLocationException ble) {
 				int end = textArea.getDocument().getLength();
 				if (offs != end) {
-					if(oldOffs != curPara.getEndOffset() - 1) {
+					if (oldOffs != curPara.getEndOffset() - 1) {
 						offs = curPara.getEndOffset() - 1;
 					}
 					else {
@@ -2146,7 +2146,7 @@ public class RTextAreaEditorKit extends DefaultEditorKit {
 			}
 
 			selectedIndex = textArea.getCaretPosition();
-			if(selectedIndex != -1) {
+			if (selectedIndex != -1) {
 				if (left) {
 					selectedIndex = textArea.viewToModel(
 									new Point(visible.x, visible.y));
@@ -2161,7 +2161,7 @@ public class RTextAreaEditorKit extends DefaultEditorKit {
 					(selectedIndex  > (doc.getLength()-1))) {
 					selectedIndex = doc.getLength()-1;
 				}
-				else if(selectedIndex  < 0) {
+				else if (selectedIndex  < 0) {
 					selectedIndex = 0;
 				}
 				if (select) {
@@ -2301,7 +2301,7 @@ public class RTextAreaEditorKit extends DefaultEditorKit {
 
 				Element curPara = Utilities.getParagraphElement(textArea, offs);
 				offs = getPreviousWord(textArea, offs);
-				if(offs < curPara.getStartOffset()) {
+				if (offs < curPara.getStartOffset()) {
 					offs = Utilities.getParagraphElement(textArea, offs).
 												getEndOffset() - 1;
 				}

--- a/RSyntaxTextAreaDemo/src/main/java/org/fife/ui/rsyntaxtextarea/demo/DemoRootPane.java
+++ b/RSyntaxTextAreaDemo/src/main/java/org/fife/ui/rsyntaxtextarea/demo/DemoRootPane.java
@@ -680,7 +680,7 @@ public class DemoRootPane extends JRootPane implements HyperlinkListener,
 	/**
 	 * Formats line numbers into Hindu-Arabic numerals.
 	 */
-	private static class HinduArabicLineNumberFormatter implements LineNumberFormatter {
+	private static final class HinduArabicLineNumberFormatter implements LineNumberFormatter {
 		private static final String[] NUMERALS = {
 			"٠", "١", "٢", "٣", "٤", "٥", "٦", "٧", "٨", "٩"
 		};

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 }
 
 plugins {
-    id 'com.github.spotbugs' version '5.2.5'
+    id 'com.github.spotbugs' version '6.0.26'
 }
 
 // We require building with JDK 11 or later. Built artifact compatibility
@@ -47,7 +47,7 @@ subprojects {
     }
 
     checkstyle {
-        toolVersion = '9.3'
+        toolVersion = '10.20.1'
         configDirectory = file("$rootProject.projectDir/config/checkstyle")
     }
 

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -75,8 +75,8 @@
     <!-- See https://checkstyle.sourceforge.io/config_whitespace.html -->
     <!--<module name="FileTabCharacter"/>-->
 
-    <!-- Miscellaneous other checks.                            -->
-    <!-- See https://checkstyle.sourceforge.io/config_misc.html -->
+    <!-- Miscellaneous other checks.                                               -->
+    <!-- See https://checkstyle.sourceforge.io/checks/regexp/regexpsingleline.html -->
     <module name="RegexpSingleline">
         <property name="format" value="\s+$"/>
         <property name="minimum" value="0"/>
@@ -84,8 +84,8 @@
         <property name="message" value="Line has trailing spaces."/>
     </module>
 
-    <!-- Checks for Headers                                         -->
-    <!-- See https://checkstyle.sourceforge.io/config_header.html   -->
+    <!-- Checks for Headers                                               -->
+    <!-- See https://checkstyle.sourceforge.io/checks/header/index.html   -->
      <module name="Header">
        <property name="headerFile" value="${config_loc}/javaHeader.txt"/>
        <property name="fileExtensions" value="java"/>
@@ -97,9 +97,9 @@
         <!-- https://stackoverflow.com/questions/5761188/checkstyle-suppressioncommentfilter-not-ignoring-specified-rule/5764666#5764666 -->
         <module name="SuppressWarningsHolder" />
 
-        <!-- Checks for Javadoc comments.                              -->
-        <!-- See https://checkstyle.sourceforge.io/config_javadoc.html -->
-        <!--<module name="JavadocMethod"/> This is just too whiny for now. -->
+        <!-- Checks for Javadoc comments.                                    -->
+        <!-- See https://checkstyle.sourceforge.io/checks/javadoc/index.html -->
+        <!--<module name="JavadocMethod"/> This is just too whiny for now.   -->
         <module name="JavadocType"/>
         <!--
         <module name="JavadocVariable">
@@ -127,8 +127,8 @@
 
         <module name="JavadocContentLocationCheck"/>
 
-        <!-- Checks for Naming Conventions.                           -->
-        <!-- See https://checkstyle.sourceforge.io/config_naming.html -->
+        <!-- Checks for Naming Conventions.                                 -->
+        <!-- See https://checkstyle.sourceforge.io/checks/naming/index.html -->
         <module name="ConstantName"/>
         <module name="LocalFinalVariableName"/>
         <module name="LocalVariableName"/>
@@ -139,23 +139,23 @@
         <module name="StaticVariableName"/>
         <module name="TypeName"/>
 
-        <!-- Checks for annotations.                                      -->
-        <!-- See https://checkstyle.sourceforge.io/config_annotation.html -->
+        <!-- Checks for annotations.                                            -->
+        <!-- See https://checkstyle.sourceforge.io/checks/annotation/index.html -->
         <module name="AnnotationLocation"/>
         <module name="AnnotationUseStyle"/>
         <module name="MissingDeprecated"/>
         <module name="MissingOverride"/>
 
-        <!-- Checks for imports                                        -->
-        <!-- See https://checkstyle.sourceforge.io/config_imports.html -->
+        <!-- Checks for imports                                              -->
+        <!-- See https://checkstyle.sourceforge.io/checks/imports/index.html -->
         <!--<module name="AvoidStarImport"/>-->
         <module name="IllegalImport"/> <!-- defaults to sun.* packages -->
         <module name="RedundantImport"/>
         <module name="UnusedImports"/>
 
 
-        <!-- Checks for Size Violations.                             -->
-        <!-- See https://checkstyle.sourceforge.io/config_sizes.html -->
+        <!-- Checks for Size Violations.                                   -->
+        <!-- See https://checkstyle.sourceforge.io/checks/sizes/index.html -->
         <module name="MethodLength">
             <property name="max" value="300"/>
         </module>
@@ -165,8 +165,8 @@
         </module>
 
 
-        <!-- Checks for whitespace                                        -->
-        <!-- See https://checkstyle.sourceforge.io/config_whitespace.html -->
+        <!-- Checks for whitespace                                              -->
+        <!-- See https://checkstyle.sourceforge.io/checks/whitespace/index.html -->
         <module name="EmptyForIteratorPad"/>
         <module name="GenericWhitespace"/>
         <module name="MethodParamPad"/>
@@ -177,17 +177,23 @@
         </module>
         <module name="ParenPad"/>
         <module name="TypecastParenPad"/>
+        <module name="WhitespaceAfter">
+            <!-- TODO: Add COMMA and possibly SEMI, but it'll be a big diff -->
+            <property name="tokens" value="LITERAL_IF, LITERAL_ELSE, LITERAL_WHILE, LITERAL_DO, LITERAL_FOR,
+                LITERAL_FINALLY, LITERAL_CATCH, DO_WHILE, LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY,
+                LITERAL_CASE, LAMBDA, LITERAL_WHEN"/>
+        </module>
         <!--<module name="WhitespaceAround"/>-->
 
 
-        <!-- Modifier Checks                                            -->
-        <!-- See https://checkstyle.sourceforge.io/config_modifier.html -->
+        <!-- Modifier Checks                                                  -->
+        <!-- See https://checkstyle.sourceforge.io/checks/modifier/index.html -->
         <module name="ModifierOrder"/>
         <module name="RedundantModifier"/>
 
 
-        <!-- Checks for blocks. You know, those {}'s                  -->
-        <!-- See https://checkstyle.sourceforge.io/config_blocks.html -->
+        <!-- Checks for blocks. You know, those {}'s                        -->
+        <!-- See https://checkstyle.sourceforge.io/checks/blocks/index.html -->
         <module name="AvoidNestedBlocks"/>
         <module name="EmptyBlock"/>
         <module name="LeftCurly"/>
@@ -196,13 +202,14 @@
         </module>
         <module name="RightCurly"> <!-- Right curlies should be alone in if/else -->
             <property name="option" value="alone"/>
-            <property name="tokens" value="LITERAL_ELSE, METHOD_DEF"/>
+            <property name="tokens" value="CLASS_DEF, ENUM_DEF, LITERAL_ELSE, LITERAL_SWITCH, METHOD_DEF"/>
         </module>
 
-        <!-- Checks for common coding problems                        -->
-        <!-- See https://checkstyle.sourceforge.io/config_coding.html -->
+        <!-- Checks for common coding problems                              -->
+        <!-- See https://checkstyle.sourceforge.io/checks/coding/index.html -->
         <!--<module name="AvoidInlineConditionals"/>-->
         <!--<module name="EmptyStatement"/> Removed to allow "while (doSomething());" -->
+        <module name="ConstructorsDeclarationGrouping"/>
         <module name="EqualsAvoidNull"/>
         <module name="EqualsHashCode"/>
         <module name="ExplicitInitialization"/>
@@ -229,8 +236,8 @@
         <module name="UnnecessarySemicolonInTryWithResources"/>
         <module name="UnusedLocalVariable"/>
 
-        <!-- Checks for class design                                  -->
-        <!-- See https://checkstyle.sourceforge.io/config_design.html -->
+        <!-- Checks for class design                                        -->
+        <!-- See https://checkstyle.sourceforge.io/checks/design/index.html -->
         <!--<module name="DesignForExtension"/>-->
         <module name="FinalClass"/>
         <module name="HideUtilityClassConstructor"/>
@@ -241,8 +248,8 @@
         </module>
 
 
-        <!-- Miscellaneous other checks.                            -->
-        <!-- See https://checkstyle.sourceforge.io/config_misc.html -->
+        <!-- Miscellaneous other checks.                                  -->
+        <!-- See https://checkstyle.sourceforge.io/checks/misc/index.html -->
         <module name="ArrayTypeStyle"/>
         <!--<module name="AvoidEscapedUnicodeCharacters">
             <property name="allowByTailComment" value="true"/>
@@ -253,7 +260,7 @@
         <module name="UpperEll"/>
 
         <!-- Checks for metrics.                                       -->
-        <!-- See https://checkstyle.sourceforge.io/config_metrics.html -->
+        <!-- See https://checkstyle.sourceforge.io/checks/metrics/index.html -->
         <!--        <module name="CyclomaticComplexity"/>-->
 
     </module>


### PR DESCRIPTION
Now that we're building with Java 11 (but still generating artifacts for Java 8+), we can bump our Checkstyle and Spotbugs dependencies.

I'm taking the opportunity to add a couple of new rules and options to Checkstyle as well. This isn't a full formatting/prettifier sweep though, just low-hanging fruit.