### PR TITLE
Add Java 23 to CI builds

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        java: [ '11', '17', '21']
+        java: [ '11', '17', '21', '23' ]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Add Java 23 to the CI builds, even though it isn't a LTS version, to be able to spot issues with the latest, greatest Java version.