### PR TITLE
Build with Java 17

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,10 +37,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
 
     # Initializes the CodeQL tools for scanning.

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -16,14 +16,14 @@ jobs:
 
     strategy:
       matrix:
-        java: [ '11', '17', '21', '23' ]
+        java: [ '17', '21', '23' ]
 
     steps:
     - uses: actions/checkout@v4
 
     - name: Verify gradle wrapper
       uses: gradle/actions/wrapper-validation@v4
-      if: matrix.java == '11'
+      if: matrix.java == '17'
 
     - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v4
@@ -41,7 +41,7 @@ jobs:
 
     - name: Submit coverage data to codecov
       uses: codecov/codecov-action@v5
-      if: matrix.java == '11'
+      if: matrix.java == '17'
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         disable_search: true

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ all unit tests, and create the jar, run:
 
     ./gradlew build --warning-mode all
 
-RSTA 3.0 and newer requires Java 8 to compile and run.  If you need
-Java 6 compatibility, you'll need to use a 2.6.x version.
+RSTA 3.0 and newer requires Java 17 to compile, but runs on Java 8.
+If you need Java 6 compatibility, you'll need to use a 2.6.x version.
 
 # Demos
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,11 @@
+import org.gradle.api.JavaVersion
+
 buildscript {
     repositories {
         mavenCentral()
     }
     dependencies {
-        classpath 'biz.aQute.bnd:biz.aQute.bnd.gradle:6.4.0'
+        classpath 'biz.aQute.bnd:biz.aQute.bnd.gradle:7.1.0'
     }
 }
 
@@ -11,12 +13,12 @@ plugins {
     id 'com.github.spotbugs' version '6.0.26'
 }
 
-// We require building with JDK 11 or later. Built artifact compatibility
+// We require building with JDK 17 or later. Built artifact compatibility
 // is controlled by javaLanguageVersion
-assert JavaVersion.current().isJava11Compatible()
+assert JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)
 
 group 'com.fifesoft'
-// NOTE: Local Java 11:  /Library/Java/JavaVirtualMachines/jdk-11.0.25+9/Contents/Home
+// NOTE: Local Java 17: /Library/Java/JavaVirtualMachines/jdk-17.0.13+11/Contents/Home
 
 allprojects {
 


### PR DESCRIPTION
Gradle 9 will require building with Java 17 or later. Update our build to no longer include JDK 11 in the build matrix, and promote artifacts built with Java 17. Built artifacts will still be runnable on Java 8 for now.