### PR TITLE
Fix #593: Folded code preview should use proper default FG color

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TokenImpl.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TokenImpl.java
@@ -146,7 +146,7 @@ public class TokenImpl implements Token {
 
 		SyntaxScheme colorScheme = textArea.getSyntaxScheme();
 		Style scheme = colorScheme.getStyle(getType());
-		Font font = textArea.getFontForTokenType(getType());//scheme.font;
+		Font font = textArea.getFontForTokenType(getType());
 
 		if (font.isBold()) {
 			sb.append("<b>");
@@ -165,8 +165,10 @@ public class TokenImpl implements Token {
 				sb.append(" face=\"").append(font.getFamily()).append('"');
 			}
 			if (!isWhitespace()) {
+				Color fg = scheme.foreground != null ?
+					scheme.foreground : textArea.getForeground();
 				sb.append(" color=\"").append(
-						getHTMLFormatForColor(scheme.foreground)).append('"');
+						HtmlUtil.getHexString(fg)).append('"');
 			}
 			sb.append('>');
 		}
@@ -363,34 +365,6 @@ public class TokenImpl implements Token {
 	@Override
 	public int getEndOffset() {
 		return offset + textCount;
-	}
-
-
-	/**
-	 * Returns a <code>String</code> of the form "#xxxxxx" good for use
-	 * in HTML, representing the given color.
-	 *
-	 * @param color The color to get a string for.
-	 * @return The HTML form of the color.  If <code>color</code> is
-	 *         <code>null</code>, <code>#000000</code> is returned.
-	 */
-	private static String getHTMLFormatForColor(Color color) {
-		if (color==null) {
-			return "black";
-		}
-		String hexRed = Integer.toHexString(color.getRed());
-		if (hexRed.length()==1) {
-			hexRed = "0" + hexRed;
-		}
-		String hexGreen = Integer.toHexString(color.getGreen());
-		if (hexGreen.length()==1) {
-			hexGreen = "0" + hexGreen;
-		}
-		String hexBlue = Integer.toHexString(color.getBlue());
-		if (hexBlue.length()==1) {
-			hexBlue = "0" + hexBlue;
-		}
-		return "#" + hexRed + hexGreen + hexBlue;
 	}
 
 

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/TokenImplTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/TokenImplTest.java
@@ -9,6 +9,8 @@ package org.fife.ui.rsyntaxtextarea;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.awt.*;
+
 
 /**
  * Unit tests for the {@link TokenImpl} class.
@@ -81,6 +83,27 @@ class TokenImplTest {
 		TokenImpl token = new TokenImpl(ch, 0, 2, 0, TokenTypes.IDENTIFIER, 0);
 
 		Assertions.assertTrue(token.endsWith("".toCharArray()));
+	}
+
+
+	@Test
+	void testGetHTMLRepresentation_fallsBackToTextAreaFont() {
+
+		RSyntaxTextArea textArea = new RSyntaxTextArea();
+		textArea.setForeground(new Color(0xfcfcfc));
+
+		// Ensure identifier tokens have no theme FG so the fallback is used
+		Style style = textArea.getSyntaxScheme().getStyle(
+			TokenTypes.IDENTIFIER);
+		style.foreground = null;
+
+		char[] ch = "for".toCharArray();
+		TokenImpl token = new TokenImpl(ch, 0, 2, 0, TokenTypes.IDENTIFIER, 0);
+
+		// Don't bother checking font and other styles since it may be host-specific
+		String actual = token.getHTMLRepresentation(textArea);
+		Assertions.assertTrue(actual.contains("color=\"#fcfcfc\""));
+
 	}
 
 

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/FoldIndicatorTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/FoldIndicatorTest.java
@@ -216,11 +216,11 @@ class FoldIndicatorTest extends AbstractRSyntaxTextAreaTest {
 		// varies depending on the OS
 		String expected = "<html><nobr><font face=\"[\\w ]+\" color=\"#ff0000\">\\{" +
 			"</font><br><font face=\"[\\w ]+\"> &nbsp;</font>" +
-			"<font face=\"[\\w ]+\" color=\"black\">println</font>" +
+			"<font face=\"[\\w ]+\" color=\"#000000\">println</font>" +
 			"<font face=\"[\\w ]+\" color=\"#ff0000\">\\(</font>" +
 			"<font face=\"[\\w ]+\" color=\"#dc009c\">&#34;hi&#34;</font>" +
 			"<font face=\"[\\w ]+\" color=\"#ff0000\">\\)</font>" +
-			"<font face=\"[\\w ]+\" color=\"black\">;</font><br>" +
+			"<font face=\"[\\w ]+\" color=\"#000000\">;</font><br>" +
 			"<font face=\"[\\w ]+\" color=\"#ff0000\">}</font><br>";
 		Assertions.assertTrue(fi.getToolTipText(e).matches(expected));
 	}


### PR DESCRIPTION
Fix for #593. The preview tooltips displayed by collapsed folds should follow RSTA's logic, and fall back to the text area's foreground color for any token types without a specific FG color, rather than black.

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/b47e3075-81ae-42b3-89bb-cdd321879415) | ![image](https://github.com/user-attachments/assets/cb938412-57ac-47c9-b943-41c0bac747ca) |