### PR TITLE
Forbid System.(out|err).println via checkstyle

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/print/RPrintUtilities.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/print/RPrintUtilities.java
@@ -479,11 +479,6 @@ public abstract class RPrintUtilities {
 					try {
 						doc.getText((currentLineStart+startingOffset), currentPos, currentLineSeg);
 					} catch (BadLocationException ble) {
-						System.err.println("BadLocationException in print (a):");
-						System.err.println("==> currentLineStart: " + currentLineStart +
-							"; startingOffset: " + startingOffset + "; currentPos: " + currentPos);
-						System.err.println("==> Range: " + (currentLineStart+startingOffset) + " - " +
-									(currentLineStart+startingOffset+currentPos));
 						ble.printStackTrace();
 						return Printable.NO_SUCH_PAGE;
 					}

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxDocument.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxDocument.java
@@ -78,16 +78,8 @@ public class RSyntaxDocument extends RDocument implements Iterable<Token>,
 
 	private transient int lastLine = -1;
 	private transient Token cachedTokenList;
-	private transient int useCacheCount;
-	private transient int tokenRetrievalCount;
 
 	private transient Segment s;
-
-	/**
-	 * If this is set to <code>true</code>, debug information about how much
-	 * token caching is helping is printed to stdout.
-	 */
-	private static final boolean DEBUG_TOKEN_CACHING = false;
 
 
 	/**
@@ -403,13 +395,7 @@ public class RSyntaxDocument extends RDocument implements Iterable<Token>,
 	 */
 	public Token getTokenListForLine(int line) {
 
-		tokenRetrievalCount++;
 		if (line==lastLine && cachedTokenList!=null) {
-			if (DEBUG_TOKEN_CACHING) {
-				useCacheCount++;
-				System.err.println("--- Using cached line; ratio now: " +
-						useCacheCount + "/" + tokenRetrievalCount);
-			}
 			return cachedTokenList;
 		}
 		lastLine = line;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/SyntaxScheme.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/SyntaxScheme.java
@@ -653,7 +653,7 @@ public class SyntaxScheme implements Cloneable, TokenTypes {
 				} catch (RuntimeException re) {
 					throw re; // FindBugs
 				} catch (Exception e) {
-					System.err.println("Error fetching 'getType' method for Token class");
+					e.printStackTrace();
 					return;
 				}
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/Theme.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/Theme.java
@@ -810,8 +810,8 @@ public class Theme {
 					field = Token.class.getField(type);
 				} catch (RuntimeException re) {
 					throw re; // FindBugs
-				} catch (Exception e) {
-					System.err.println("Invalid token type: " + type);
+				} catch (NoSuchFieldException e) {
+					e.printStackTrace();
 					return;
 				}
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/WrappedSyntaxView.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/WrappedSyntaxView.java
@@ -1150,7 +1150,7 @@ public class WrappedSyntaxView extends BoxView implements TabExpander,
 			} catch (BadLocationException ble) {
 				ble.printStackTrace();
 			}
-			System.err.println(">>> >>> calculated # of lines for this view (" + line + "/" + numLines + ": " + nlines);
+			//System.err.println(">> >> calculated # of lines for this view (" + line + "/" + numLines + ": " + nlines);
 			*/
 			return nlines;
 		}

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTATextTransferHandler.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTATextTransferHandler.java
@@ -502,7 +502,7 @@ public class RTATextTransferHandler extends TransferHandler {
 				stringFlavors[1] = DataFlavor.stringFlavor;
 
 			} catch (ClassNotFoundException cle) {
-				System.err.println("Error initializing org.fife.ui.RTATextTransferHandler");
+				cle.printStackTrace();
 			}
 		}
 

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/ParserManagerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/ParserManagerTest.java
@@ -8,9 +8,8 @@ import org.fife.ui.SwingRunnerExtension;
 import org.fife.ui.rsyntaxtextarea.parser.*;
 import org.fife.ui.rtextarea.RTextScrollPane;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.MouseEvent;
@@ -27,33 +26,27 @@ import java.beans.PropertyChangeListener;
 class ParserManagerTest extends AbstractRSyntaxTextAreaTest {
 
 
-	@ParameterizedTest
-	@ValueSource(strings = { "true", "false" })
-	void testConstructor_oneArg(String debugParsing) {
+	@Test
+	void testConstructor_oneArg() {
 		RSyntaxTextArea textArea = createTextArea();
 		ParserManager manager = new ParserManager(textArea);
-		manager.setDebugParsing(Boolean.parseBoolean(debugParsing));
 		Assertions.assertEquals(1250, manager.getDelay());
 	}
 
 
-	@ParameterizedTest
-	@ValueSource(strings = { "true", "false" })
-	void testConstructor_twoArg(String debugParsing) {
+	@Test
+	void testConstructor_twoArg() {
 		RSyntaxTextArea textArea = createTextArea();
 		ParserManager manager = new ParserManager(2000, textArea);
-		manager.setDebugParsing(Boolean.parseBoolean(debugParsing));
 		Assertions.assertEquals(2000, manager.getDelay());
 	}
 
 
-	@ParameterizedTest
-	@ValueSource(strings = { "true", "false" })
-	void testActionPerformed_noParsers(String debugParsing) {
+	@Test
+	void testActionPerformed_noParsers() {
 
 		RSyntaxTextArea textArea = createTextArea();
 		ParserManager manager = new ParserManager(textArea);
-		manager.setDebugParsing(Boolean.parseBoolean(debugParsing));
 		Assertions.assertEquals(0, manager.getParserNotices().size());
 
 		manager.actionPerformed(new ActionEvent(textArea, 0, null));
@@ -61,9 +54,8 @@ class ParserManagerTest extends AbstractRSyntaxTextAreaTest {
 	}
 
 
-	@ParameterizedTest
-	@ValueSource(strings = { "true", "false" })
-	void testActionPerformed_parsersFireChangeEvents(String debugParsing) {
+	@Test
+	void testActionPerformed_parsersFireChangeEvents() {
 
 		AbstractParser parser = new AbstractParser() {
 			@Override
@@ -77,7 +69,6 @@ class ParserManagerTest extends AbstractRSyntaxTextAreaTest {
 
 		RSyntaxTextArea textArea = createTextArea();
 		ParserManager manager = new ParserManager(textArea);
-		manager.setDebugParsing(Boolean.parseBoolean(debugParsing));
 		manager.addParser(parser);
 		Assertions.assertEquals(0, manager.getParserNotices().size());
 
@@ -87,13 +78,11 @@ class ParserManagerTest extends AbstractRSyntaxTextAreaTest {
 	}
 
 
-	@ParameterizedTest
-	@ValueSource(strings = { "true", "false" })
-	void testAddRemoveParser(String debugParsing) {
+	@Test
+	void testAddRemoveParser() {
 
 		RSyntaxTextArea textArea = createTextArea();
 		ParserManager manager = new ParserManager(textArea);
-		manager.setDebugParsing(Boolean.parseBoolean(debugParsing));
 
 		Assertions.assertEquals(0, manager.getParserCount());
 
@@ -112,9 +101,8 @@ class ParserManagerTest extends AbstractRSyntaxTextAreaTest {
 	}
 
 
-	@ParameterizedTest
-	@ValueSource(strings = { "true", "false" })
-	void testClearParsers(String debugParsing) {
+	@Test
+	void testClearParsers() {
 
 		AbstractParser parser = new AbstractParser() {
 			@Override
@@ -128,7 +116,6 @@ class ParserManagerTest extends AbstractRSyntaxTextAreaTest {
 
 		RSyntaxTextArea textArea = createTextArea();
 		ParserManager manager = new ParserManager(textArea);
-		manager.setDebugParsing(Boolean.parseBoolean(debugParsing));
 		manager.addParser(parser);
 		Assertions.assertEquals(1, manager.getParserCount());
 
@@ -142,9 +129,8 @@ class ParserManagerTest extends AbstractRSyntaxTextAreaTest {
 	}
 
 
-	@ParameterizedTest
-	@ValueSource(strings = { "true", "false" })
-	void testForceReparsing_parsersFireChangeEvents(String debugParsing) {
+	@Test
+	void testForceReparsing_parsersFireChangeEvents() {
 
 		boolean[] parserNoticeChangeEventFired = { false };
 
@@ -170,9 +156,8 @@ class ParserManagerTest extends AbstractRSyntaxTextAreaTest {
 	}
 
 
-	@ParameterizedTest
-	@ValueSource(strings = { "true", "false" })
-	void testForceReparsing_disabledParserClearsItsNotices(String debugParsing) {
+	@Test
+	void testForceReparsing_disabledParserClearsItsNotices() {
 
 		AbstractParser parser = new AbstractParser() {
 			@Override
@@ -200,13 +185,11 @@ class ParserManagerTest extends AbstractRSyntaxTextAreaTest {
 	}
 
 
-	@ParameterizedTest
-	@ValueSource(strings = { "true", "false" })
-	void testGetSetDelay(String debugParsing) {
+	@Test
+	void testGetSetDelay() {
 
 		RSyntaxTextArea textArea = createTextArea();
 		ParserManager manager = new ParserManager(textArea);
-		manager.setDebugParsing(Boolean.parseBoolean(debugParsing));
 
 		manager.setDelay(12345);
 		Assertions.assertEquals(12345, manager.getDelay());
@@ -221,9 +204,8 @@ class ParserManagerTest extends AbstractRSyntaxTextAreaTest {
 	}
 
 
-	@ParameterizedTest
-	@ValueSource(strings = { "true", "false" })
-	void testGetToolTipText(String debugParsing) {
+	@Test
+	void testGetToolTipText() {
 
 		AbstractParser parser = new AbstractParser() {
 			@Override
@@ -239,7 +221,6 @@ class ParserManagerTest extends AbstractRSyntaxTextAreaTest {
 		textArea.setAntiAliasingEnabled(false); // Needed to initialize font metrics cache
 		RTextScrollPane sp = new RTextScrollPane(textArea); // text area needs a parent
 		ParserManager manager = new ParserManager(textArea);
-		manager.setDebugParsing(Boolean.parseBoolean(debugParsing));
 		manager.addParser(parser);
 
 		manager.forceReparsing(0);
@@ -250,25 +231,21 @@ class ParserManagerTest extends AbstractRSyntaxTextAreaTest {
 	}
 
 
-	@ParameterizedTest
-	@ValueSource(strings = { "true", "false" })
-	void testInsertUpdate(String debugParsing) {
+	@Test
+	void testInsertUpdate() {
 
 		RSyntaxTextArea textArea = createTextArea();
 		ParserManager manager = new ParserManager(textArea);
-		manager.setDebugParsing(Boolean.parseBoolean(debugParsing));
 
 		textArea.insert("inserted text", 5);
 	}
 
 
-	@ParameterizedTest
-	@ValueSource(strings = { "true", "false" })
-	void testPropertyChange_document(String debugParsing) {
+	@Test
+	void testPropertyChange_document() {
 
 		RSyntaxTextArea textArea = createTextArea();
 		ParserManager manager = new ParserManager(textArea);
-		manager.setDebugParsing(Boolean.parseBoolean(debugParsing));
 		RSyntaxDocument origDocument = (RSyntaxDocument)textArea.getDocument();
 
 		RSyntaxDocument newDocument = new RSyntaxDocument(SyntaxConstants.SYNTAX_STYLE_C);
@@ -280,13 +257,11 @@ class ParserManagerTest extends AbstractRSyntaxTextAreaTest {
 	}
 
 
-	@ParameterizedTest
-	@ValueSource(strings = { "true", "false" })
-	void testRemoveUpdate(String debugParsing) {
+	@Test
+	void testRemoveUpdate() {
 
 		RSyntaxTextArea textArea = createTextArea();
 		ParserManager manager = new ParserManager(textArea);
-		manager.setDebugParsing(Boolean.parseBoolean(debugParsing));
 
 		textArea.replaceRange("", 5, 9);
 	}

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -83,6 +83,12 @@
         <property name="maximum" value="0"/>
         <property name="message" value="Line has trailing spaces."/>
     </module>
+    <module name="RegexpSingleline">
+        <property name="format" value="(?&lt;!//)\s*System\.(?:out|err)\.println\("/>
+        <property name="minimum" value="0"/>
+        <property name="maximum" value="0"/>
+        <property name="message" value="Do not use System.out.println or System.err.println"/>
+    </module>
 
     <!-- Checks for Headers                                               -->
     <!-- See https://checkstyle.sourceforge.io/checks/header/index.html   -->


### PR DESCRIPTION
Update checkstyle to disallow `System.out.println` and `System.err.println` unless they are commented out.