### PR TITLE
Change to allow custom Content implementation in RDocument.

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxDocument.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxDocument.java
@@ -21,6 +21,7 @@ import javax.swing.text.Element;
 import javax.swing.text.Segment;
 
 import org.fife.ui.rsyntaxtextarea.modes.AbstractMarkupTokenMaker;
+import org.fife.ui.rtextarea.RContent;
 import org.fife.ui.rtextarea.RDocument;
 import org.fife.util.DynamicIntArray;
 
@@ -102,7 +103,13 @@ public class RSyntaxDocument extends RDocument implements Iterable<Token>,
 	 * @param syntaxStyle The syntax highlighting scheme to use.
 	 */
 	public RSyntaxDocument(TokenMakerFactory tmf, String syntaxStyle) {
-		putProperty(tabSizeAttribute, 5);
+	    this(null, tmf, syntaxStyle);
+	}
+	
+	
+	public RSyntaxDocument(RContent content, TokenMakerFactory tmf, String syntaxStyle) {
+		super(content);
+	    putProperty(tabSizeAttribute, 5);
 		lastTokensOnLines = new DynamicIntArray(400);
 		lastTokensOnLines.add(Token.NULL); // Initial (empty) line.
 		s = new Segment();

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RContent.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RContent.java
@@ -1,0 +1,19 @@
+package org.fife.ui.rtextarea;
+
+import javax.swing.text.AbstractDocument;
+import javax.swing.text.BadLocationException;
+
+/**
+ * An interface for AbstractDocument.Content implementations that can be used in
+ * {@link RDocument}'s. It defines fast direct read access to single characters in the content.
+ */
+public interface RContent extends AbstractDocument.Content {
+
+    /**
+     * Allows access to a single character in the content.
+     * @param offset    the offset of the character to be accessed.
+     * @return the character at the given offset.
+     * @throws BadLocationException in case the given offset is outside the content.
+     */
+    char charAt(int offset) throws BadLocationException;
+}

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RDocument.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RDocument.java
@@ -26,9 +26,12 @@ public class RDocument extends PlainDocument {
 	 * Constructor.
 	 */
 	public RDocument() {
-		super(new RGapContent());
+		this(new RGapContent());
 	}
 
+    public RDocument(RContent content) {
+        super(content != null ? content : new RGapContent());
+    }
 
 	/**
 	 * Returns the character in the document at the specified offset.
@@ -38,16 +41,16 @@ public class RDocument extends PlainDocument {
 	 * @throws BadLocationException If the offset is invalid.
 	 */
 	public char charAt(int offset) throws BadLocationException {
-		return ((RGapContent)getContent()).charAt(offset);
+		return ((RContent)getContent()).charAt(offset);
 	}
 
 
 	/**
 	 * Document content that provides fast access to individual characters.
 	 */
-	private static final class RGapContent extends GapContent {
+	private static final class RGapContent extends GapContent implements RContent {
 
-		protected char charAt(int offset) throws BadLocationException {
+		public char charAt(int offset) throws BadLocationException {
 			if (offset<0 || offset>=length()) {
 				throw new BadLocationException("Invalid offset", offset);
 			}


### PR DESCRIPTION
This is a change to allow custom Content implementation in RDocument.

It would be great if I can use a custom implementtaion of AbstractDocument.Content with RDocument and RSyntaxDocument. This is just a small enhancement with no real side effects. The only effect is that the Content's charAt method is now public, but this should not be an issue as the Content can anyway be asked for this data.