### PR TITLE
Security Fix: Potential XXE Vulnerability in load function

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/Theme.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/Theme.java
@@ -609,9 +609,15 @@ public class Theme {
 			throw e;
 		}
 
-	    public static void load(Theme theme, InputStream in) throws IOException {
+		public static void load(Theme theme, InputStream in) throws IOException {
 			SAXParserFactory spf = SAXParserFactory.newInstance();
 			spf.setValidating(true);
+
+			// Disable external entity resolution to prevent XXE attacks
+			spf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+			spf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+			spf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+
 			try {
 				SAXParser parser = spf.newSAXParser();
 				XMLReader reader = parser.getXMLReader();
@@ -624,8 +630,8 @@ public class Theme {
 				InputSource is = new InputSource(in);
 				is.setEncoding("UTF-8");
 				reader.parse(is);
-			} catch (/*SAX|ParserConfiguration*/Exception se) {
-				throw new IOException(se.toString());
+			} catch (SAXException | ParserConfigurationException se) {
+				throw new IOException("Error parsing XML: " + se.getMessage(), se);
 			}
 		}
 


### PR DESCRIPTION
This PR addresses a potential vulnerability in the load() function in Theme.java that could lead to XML External Entity (XXE) attacks because it uses an SAXParserFactory without explicitly disabling external entity resolution. This issue was originally reported and resolved in the repository via this commit https://github.com/eclipse/tm4e/commit/146bfc99abb4b6427a07799a2085ad98bffc9227.

**Fix**

- **Disabling External Entities**
     - The setFeature calls ensure that external entities and DTDs are not loaded, mitigating the risk of XXE attacks

- **Improved Exception Handling**
     - The updated exception handling provides more meaningful error messages and preserves the original exception for debugging


**References**
CWE-611: Improper Restriction of XML External Entity Reference
https://github.com/eclipse/tm4e/commit/146bfc99abb4b6427a07799a2085ad98bffc9227