### PR TITLE
Get publishing to gradle working with gradle-nexus/publish-plugin

### DIFF
--- a/RSyntaxTextArea/build.gradle
+++ b/RSyntaxTextArea/build.gradle
@@ -50,18 +50,6 @@ test {
 }
 
 publishing {
-    repositories {
-        maven {
-            def releasesRepoUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
-            def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
-            url = isReleaseVersion ? releasesRepoUrl : snapshotsRepoUrl
-            credentials { // Credentials usually kept in user's .gradle/gradle.properties
-                // We must defensively check for these properties so CI builds work
-                username = project.hasProperty('ossrhToken') ? ossrhToken : 'unknown'
-                password = project.hasProperty('ossrhTokenPassword') ? ossrhTokenPassword : 'unknown'
-            }
-        }
-    }
     publications {
         maven(MavenPublication) {
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/Theme.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/Theme.java
@@ -21,10 +21,7 @@ import java.lang.reflect.Field;
 
 import javax.swing.UIManager;
 import javax.swing.plaf.ColorUIResource;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.SAXParser;
-import javax.xml.parsers.SAXParserFactory;
+import javax.xml.parsers.*;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
@@ -613,12 +610,12 @@ public class Theme {
 			SAXParserFactory spf = SAXParserFactory.newInstance();
 			spf.setValidating(true);
 
-			// Disable external entity resolution to prevent XXE attacks
-			spf.setFeature("http://xml.org/sax/features/external-general-entities", false);
-			spf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-			spf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-
 			try {
+				// Disable external entity resolution to prevent XXE attacks
+				spf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+				spf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+				spf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+
 				SAXParser parser = spf.newSAXParser();
 				XMLReader reader = parser.getXMLReader();
 				XmlHandler handler = new XmlHandler();

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,10 @@ buildscript {
 
 plugins {
     id 'com.github.spotbugs' version '6.1.7'
+    id 'io.github.gradle-nexus.publish-plugin' version '2.0.0'
 }
+
+apply plugin: 'io.github.gradle-nexus.publish-plugin'
 
 // We require building with JDK 17 or later. Built artifact compatibility
 // is controlled by javaLanguageVersion
@@ -89,5 +92,17 @@ subprojects {
         options.debug = true
         options.debugOptions.debugLevel = 'source,vars,lines'
         options.compilerArgs << '-Xlint:deprecation' << '-Xlint:unchecked'
+    }
+}
+
+nexusPublishing {
+    repositories {
+        sonatype {
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+            // We must defensively check for these properties so CI builds work
+            username.set(project.hasProperty('sonatypeUsername') ? sonatypeUsername : 'unknown')
+            password.set(project.hasProperty('sonatypePassword') ? sonatypePassword : 'unknown')
+        }
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,9 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+    }
+}
+
 rootProject.name = 'RSyntaxTextArea'
 
 include 'RSyntaxTextArea', 'RSyntaxTextAreaDemo'


### PR DESCRIPTION
Switch to [gradle-nexus/publish-plugin](https://github.com/gradle-nexus/publish-plugin?tab=readme-ov-file) to get publishing to Gradle working again.

Publishing SNAPSHOT builds is just 1 step:

```shell
./gradlew publishToSonatype
```

Publishing a release build:

```shell
./gradlew publishToSonatype
./gradlew closeAndReleaseSonatypeRepository
```
