### PR TITLE
Prepare for 3.6.1 release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Note that Maven- and signing-related properties are in <maven-home>/gradle.properties
 javaLanguageVersion=8
 osgiRequiredCompatibility=1.8
-version=3.6.1-SNAPSHOT
+version=3.6.1
 
 # Ugh, see https://github.com/gradle/gradle/issues/11308
 systemProp.org.gradle.internal.publish.checksums.insecure=true


### PR DESCRIPTION
Bump the version to 3.6.1 to prepare for our next release.