### PR TITLE
Bump version to 3.6.2-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Note that Maven- and signing-related properties are in <maven-home>/gradle.properties
 javaLanguageVersion=8
 osgiRequiredCompatibility=1.8
-version=3.6.1
+version=3.6.2-SNAPSHOT
 
 # Ugh, see https://github.com/gradle/gradle/issues/11308
 systemProp.org.gradle.internal.publish.checksums.insecure=true


### PR DESCRIPTION
Bump the version number in `gradle.properties` to start the next version's work.