### PR TITLE
Fix some IntelliJ warnings

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/DefaultTokenFactory.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/DefaultTokenFactory.java
@@ -22,7 +22,7 @@ import javax.swing.text.Segment;
  * that users call <code>resetTokenList</code> when creating a new token list so
  * that the token maker can keep an accurate list of available tokens.<p>
  *
- * NOTE:  This class should only be used by {@link TokenMaker}; nobody else
+ * NOTE: This class should only be used by {@link TokenMaker}; nobody else
  * needs it!
  *
  * @author Robert Futrell

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/FoldingAwareIconRowHeader.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/FoldingAwareIconRowHeader.java
@@ -100,7 +100,7 @@ public class FoldingAwareIconRowHeader extends IconRowHeader {
 				int realY1 = rsta.yForLine(activeLineRangeStart);
 				if (realY1>-1) { // Not in a collapsed fold...
 
-					int  y1 = realY1;//Math.max(y, realY1);
+					int y1 = realY1;//Math.max(y, realY1);
 
 					int y2 = rsta.yForLine(activeLineRangeEnd);
 					if (y2==-1) { // In a collapsed fold

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/ParserManager.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/ParserManager.java
@@ -61,7 +61,7 @@ class ParserManager implements DocumentListener, ActionListener,
 	/**
 	 * Mapping of notices to their highlights in the editor.  Can't use a Map
 	 * since parsers could return two <code>ParserNotice</code>s that compare
-	 * equally via <code>equals()</code>.  Real-world example:  The Perl
+	 * equally via <code>equals()</code>.  Real-world example: The Perl
 	 * compiler will return 2+ identical error messages if the same error is
 	 * committed in a single line more than once.
 	 */
@@ -77,7 +77,7 @@ class ParserManager implements DocumentListener, ActionListener,
 	 * The default delay between the last key press and when the document
 	 * is parsed, in milliseconds.
 	 */
-	private static final int DEFAULT_DELAY_MS		= 1250;
+	private static final int DEFAULT_DELAY_MS = 1250;
 
 
 	/**

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxDocument.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxDocument.java
@@ -198,7 +198,7 @@ public class RSyntaxDocument extends RDocument implements Iterable<Token>,
 	@Override
 	protected void fireRemoveUpdate(DocumentEvent chng) {
 
-		cachedTokenList =  null;
+		cachedTokenList = null;
 		Element lineMap = getDefaultRootElement();
 		int numLines = lineMap.getElementCount();
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaHighlighter.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaHighlighter.java
@@ -56,7 +56,7 @@ public class RSyntaxTextAreaHighlighter extends RTextAreaHighlighter {
 	/**
 	 * The default color used for parser notices when none is specified.
 	 */
-	private static final Color DEFAULT_PARSER_NOTICE_COLOR	= Color.RED;
+	private static final Color DEFAULT_PARSER_NOTICE_COLOR = Color.RED;
 
 
 	/**

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaUI.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaUI.java
@@ -38,9 +38,9 @@ import org.fife.ui.rtextarea.RTextAreaUI;
  */
 public class RSyntaxTextAreaUI extends RTextAreaUI {
 
-	private static final String SHARED_ACTION_MAP_NAME	= "RSyntaxTextAreaUI.actionMap";
-	private static final String SHARED_INPUT_MAP_NAME		= "RSyntaxTextAreaUI.inputMap";
-	private static final EditorKit DEFAULT_KIT			= new RSyntaxTextAreaEditorKit();
+	private static final String SHARED_ACTION_MAP_NAME = "RSyntaxTextAreaUI.actionMap";
+	private static final String SHARED_INPUT_MAP_NAME = "RSyntaxTextAreaUI.inputMap";
+	private static final EditorKit DEFAULT_KIT = new RSyntaxTextAreaEditorKit();
 
 
 	/**

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RTfToText.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RTfToText.java
@@ -232,7 +232,7 @@ final class RtfToText {
 	 */
 	private static String getPlainText(Reader r) throws IOException {
 		try {
-			RtfToText  converter = new RtfToText(r);
+			RtfToText converter = new RtfToText(r);
 			return converter.convert();
 		} finally {
 			r.close();

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/SquiggleUnderlineHighlightPainter.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/SquiggleUnderlineHighlightPainter.java
@@ -35,7 +35,7 @@ import org.fife.ui.rtextarea.ChangeableHighlightPainter;
 public class SquiggleUnderlineHighlightPainter
 				extends ChangeableHighlightPainter {
 
-	private static final int AMT			= 2;
+	private static final int AMT = 2;
 
 	/**
 	 * Constructor.

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/Style.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/Style.java
@@ -34,9 +34,9 @@ import javax.swing.JPanel;
 @SuppressWarnings("checkstyle:visibilitymodifier")
 public class Style implements Cloneable {
 
-	public static final Color DEFAULT_FOREGROUND	= Color.BLACK;
-	public static final Color DEFAULT_BACKGROUND	= null;
-	public static final Font DEFAULT_FONT			= null;
+	public static final Color DEFAULT_FOREGROUND = Color.BLACK;
+	public static final Color DEFAULT_BACKGROUND = null;
+	public static final Font DEFAULT_FONT = null;
 
 	public Color foreground;
 	public Color background;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/SyntaxView.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/SyntaxView.java
@@ -143,7 +143,7 @@ public class SyntaxView extends View implements TabExpander,
 	 *        be a valid line number in the model.
 	 * @param line1 The ending line number to repaint.  This must
 	 *        be a valid line number in the model.
-	 * @param a  The region allocated for the view to render into.
+	 * @param a The region allocated for the view to render into.
 	 * @param host The component hosting the view (used to call repaint).
 	 */
 	protected void damageLineRange(int line0, int line1, Shape a,

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TextEditorPane.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TextEditorPane.java
@@ -64,22 +64,22 @@ public class TextEditorPane extends RSyntaxTextArea implements
 	 * @see #load(FileLocation, String)
 	 * @see #saveAs(FileLocation)
 	 */
-	public static final String FULL_PATH_PROPERTY	= "TextEditorPane.fileFullPath";
+	public static final String FULL_PATH_PROPERTY = "TextEditorPane.fileFullPath";
 
 	/**
 	 * Property change event fired when the text area's dirty flag changes.
 	 *
 	 * @see #setDirty(boolean)
 	 */
-	public static final String DIRTY_PROPERTY	= "TextEditorPane.dirty";
+	public static final String DIRTY_PROPERTY = "TextEditorPane.dirty";
 
 	/**
 	 * Property change event fired when the text area should be treated as
-	 * read-only, and previously it should not, or vice-versa.
+	 * read-only, and previously it should not, or vice versa.
 	 *
 	 * @see #setReadOnly(boolean)
 	 */
-	public static final String READ_ONLY_PROPERTY	= "TextEditorPane.readOnly";
+	public static final String READ_ONLY_PROPERTY = "TextEditorPane.readOnly";
 
 	/**
 	 * Property change event fired when the text area's encoding changes.
@@ -118,7 +118,7 @@ public class TextEditorPane extends RSyntaxTextArea implements
 	/**
 	 * The value returned by {@link #getLastSaveOrLoadTime()} for remote files.
 	 */
-	public static final long LAST_MODIFIED_UNKNOWN		= 0;
+	public static final long LAST_MODIFIED_UNKNOWN = 0;
 
 	/**
 	 * The default name given to files if none is specified in a constructor.
@@ -326,7 +326,7 @@ public class TextEditorPane extends RSyntaxTextArea implements
 			// Ensure that line separator always has a value, even if the file
 			// does not exist (or is the "default" file).  This makes life
 			// easier for host applications that want to display this value.
-			setLineSeparator(System.getProperty("line.separator"));
+			setLineSeparator(System.lineSeparator());
 		}
 		else {
 			load(loc, defaultEnc); // Sets this.loc

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TokenMap.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TokenMap.java
@@ -141,10 +141,10 @@ public class TokenMap {
 		mainLoop:
 			while (token!=null) {
 				if (token.length==length1) {
-					array2  = token.text;
+					array2 = token.text;
 					offset2 = token.offset;
 					offset1 = start;
-					length  = length1;
+					length = length1;
 					while (length-- > 0) {
 						if (array1[offset1++]!=array2[offset2++]) {
 							token = token.nextToken;
@@ -166,10 +166,10 @@ public class TokenMap {
 		mainLoop2:
 			while (token!=null) {
 				if (token.length==length1) {
-					array2  = token.text;
+					array2 = token.text;
 					offset2 = token.offset;
 					offset1 = start;
-					length  = length1;
+					length = length1;
 					while (length-- > 0) {
 						if (RSyntaxUtilities.toLowerCase(
 							array1[offset1++]) != array2[offset2++]) {

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/WrappedSyntaxView.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/WrappedSyntaxView.java
@@ -79,7 +79,7 @@ public class WrappedSyntaxView extends BoxView implements TabExpander,
 	 * The width of this view cannot be below this amount, as if the width
 	 * is ever 0 (really a bug), we'll go into an infinite loop.
 	 */
-	private static final int MIN_WIDTH		= 20;
+	private static final int MIN_WIDTH = 20;
 
 
 	/**

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/focusabletip/SizeGrip.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/focusabletip/SizeGrip.java
@@ -73,7 +73,7 @@ class SizeGrip extends JPanel {
 		ComponentOrientation orientation = getComponentOrientation();
 
 		if (orientation.isLeftToRight()) {
-			int width = dim.width  -= 3;
+			int width = dim.width -= 3;
 			int height = dim.height -= 3;
 			g.setColor(c1);
 			g.fillRect(width-9,height-1, 3,3);

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/parser/TaskTagParser.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/parser/TaskTagParser.java
@@ -29,7 +29,7 @@ import org.fife.ui.rsyntaxtextarea.Token;
 public class TaskTagParser extends AbstractParser {
 
 	private DefaultParseResult result;
-	private static final String DEFAULT_TASK_PATTERN	= "TODO|FIXME|HACK";
+	private static final String DEFAULT_TASK_PATTERN = "TODO|FIXME|HACK";
 	private Pattern taskPattern;
 
 	private static final Color COLOR = new Color(48, 150, 252);

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/templates/StaticCodeTemplate.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/templates/StaticCodeTemplate.java
@@ -66,7 +66,7 @@ public class StaticCodeTemplate extends AbstractCodeTemplate {
 	 */
 	private transient int firstAfterNewline;
 
-	private static final String EMPTY_STRING		= "";
+	private static final String EMPTY_STRING = "";
 
 
 	/**
@@ -215,7 +215,7 @@ public class StaticCodeTemplate extends AbstractCodeTemplate {
 	 * @throws IOException If an IO error occurs.
 	 */
 	private void readObject(ObjectInputStream in) throws ClassNotFoundException,
-											IOException  {
+											IOException {
 		in.defaultReadObject();
 		// "Resetting" before and after text to the same values will replace
 		// nulls with empty strings, and set transient "first*Newline" values.

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/ClipboardHistoryPopup.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/ClipboardHistoryPopup.java
@@ -62,7 +62,7 @@ class ClipboardHistoryPopup extends JWindow {
 	/**
 	 * The space between the caret and the completion popup.
 	 */
-	private static final int VERTICAL_SPACE			= 1;
+	private static final int VERTICAL_SPACE = 1;
 
 	private static final String MSG	= "org.fife.ui.rtextarea.RTextArea";
 
@@ -178,7 +178,7 @@ class ClipboardHistoryPopup extends JWindow {
 
 		// Try putting our stuff "below" the caret first.  We assume that the
 		// entire height of our stuff fits on the screen one way or the other.
-		int y = r.y + r.height +  VERTICAL_SPACE;
+		int y = r.y + r.height + VERTICAL_SPACE;
 		if (y+totalH>screenBounds.height) {
 			y = r.y - VERTICAL_SPACE - getHeight();
 		}

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/IconGroup.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/IconGroup.java
@@ -58,7 +58,7 @@ public class IconGroup {
 	private String name;
 	private String jarFile;
 
-	private static final String DEFAULT_EXTENSION	= "gif";
+	private static final String DEFAULT_EXTENSION = "gif";
 
 
 	/**

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/Macro.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/Macro.java
@@ -67,14 +67,14 @@ public class Macro {
 	private String name;
 	private ArrayList<MacroRecord> macroRecords;
 
-	private static final String ROOT_ELEMENT			= "macro";
-	private static final String MACRO_NAME				= "macroName";
-	private static final String ACTION					= "action";
-	private static final String ID					= "id";
+	private static final String ROOT_ELEMENT = "macro";
+	private static final String MACRO_NAME = "macroName";
+	private static final String ACTION = "action";
+	private static final String ID = "id";
 
-	private static final String UNTITLED_MACRO_NAME		= "<Untitled>";
+	private static final String UNTITLED_MACRO_NAME = "<Untitled>";
 
-	private static final String FILE_ENCODING			= "UTF-8";
+	private static final String FILE_ENCODING = "UTF-8";
 
 
 	/**
@@ -312,7 +312,7 @@ public class Macro {
 
 
 	/**
-	 * Saves this macro to a  file.  This file can later be read in by the
+	 * Saves this macro to a file.  This file can later be read in by the
 	 * constructor taking a <code>File</code> parameter; this is the mechanism
 	 * for saving macros.
 	 *

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextArea.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextArea.java
@@ -73,19 +73,19 @@ public class RTextArea extends RTextAreaBase implements Printable {
 	 *
 	 * @see #setCaretStyle(int, CaretStyle)
 	 */
-	public static final int INSERT_MODE				= 0;
+	public static final int INSERT_MODE = 0;
 
 	/**
 	 * Constant representing overwrite mode.
 	 *
 	 * @see #setCaretStyle(int, CaretStyle)
 	 */
-	public static final int OVERWRITE_MODE				= 1;
+	public static final int OVERWRITE_MODE = 1;
 
 	/**
 	 * The property fired when the "mark all" color changes.
 	 */
-	public static final String MARK_ALL_COLOR_PROPERTY	= "RTA.markAllColor";
+	public static final String MARK_ALL_COLOR_PROPERTY = "RTA.markAllColor";
 
 	/**
 	 * The property fired when the "mark all on occurrence" property changes.
@@ -102,15 +102,15 @@ public class RTextArea extends RTextAreaBase implements Printable {
 	/*
 	 * Constants for all actions.
 	 */
-	private static final int MIN_ACTION_CONSTANT	= 0;
-	public static final int COPY_ACTION				= 0;
-	public static final int CUT_ACTION				= 1;
-	public static final int DELETE_ACTION			= 2;
-	public static final int PASTE_ACTION			= 3;
-	public static final int REDO_ACTION				= 4;
-	public static final int SELECT_ALL_ACTION		= 5;
-	public static final int UNDO_ACTION				= 6;
-	private static final int MAX_ACTION_CONSTANT	= 6;
+	private static final int MIN_ACTION_CONSTANT = 0;
+	public static final int COPY_ACTION = 0;
+	public static final int CUT_ACTION = 1;
+	public static final int DELETE_ACTION = 2;
+	public static final int PASTE_ACTION = 3;
+	public static final int REDO_ACTION = 4;
+	public static final int SELECT_ALL_ACTION = 5;
+	public static final int UNDO_ACTION = 6;
+	private static final int MAX_ACTION_CONSTANT = 6;
 
 	private static final Color DEFAULT_MARK_ALL_COLOR = new Color(0xffc800);
 
@@ -170,7 +170,7 @@ public class RTextArea extends RTextAreaBase implements Printable {
 
 	private boolean markAllOnOccurrenceSearches;
 
-	private CaretStyle[] carets;	// Index 0=>insert caret, 1=>overwrite.
+	private CaretStyle[] carets; // Index 0=>insert caret, 1=>overwrite.
 
 	private static final String MSG	= "org.fife.ui.rtextarea.RTextArea";
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextAreaBase.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextAreaBase.java
@@ -44,11 +44,11 @@ import javax.swing.text.Caret;
  */
 public abstract class RTextAreaBase extends JTextArea {
 
-	public static final String BACKGROUND_IMAGE_PROPERTY			= "background.image";
-	public static final String CURRENT_LINE_HIGHLIGHT_COLOR_PROPERTY	= "RTA.currentLineHighlightColor";
-	public static final String CURRENT_LINE_HIGHLIGHT_FADE_PROPERTY	= "RTA.currentLineHighlightFade";
-	public static final String HIGHLIGHT_CURRENT_LINE_PROPERTY		= "RTA.currentLineHighlight";
-	public static final String ROUNDED_SELECTION_PROPERTY			= "RTA.roundedSelection";
+	public static final String BACKGROUND_IMAGE_PROPERTY = "background.image";
+	public static final String CURRENT_LINE_HIGHLIGHT_COLOR_PROPERTY = "RTA.currentLineHighlightColor";
+	public static final String CURRENT_LINE_HIGHLIGHT_FADE_PROPERTY = "RTA.currentLineHighlightFade";
+	public static final String HIGHLIGHT_CURRENT_LINE_PROPERTY = "RTA.currentLineHighlight";
+	public static final String ROUNDED_SELECTION_PROPERTY = "RTA.roundedSelection";
 
 	private boolean tabsEmulatedWithSpaces;		// If true, tabs will be expanded to spaces.
 
@@ -67,11 +67,11 @@ public abstract class RTextAreaBase extends JTextArea {
 
 	private RTAMouseListener mouseListener;
 
-	private static final Color DEFAULT_CARET_COLOR				= new ColorUIResource(255,51,51);
-	private static final Color DEFAULT_CURRENT_LINE_HIGHLIGHT_COLOR	= new Color(255,255,170);
-	private static final Color DEFAULT_MARGIN_LINE_COLOR			= new Color(255,224,224);
-	private static final int DEFAULT_TAB_SIZE					= 4;
-	private static final int DEFAULT_MARGIN_LINE_POSITION			= 80;
+	private static final Color DEFAULT_CARET_COLOR = new ColorUIResource(255,51,51);
+	private static final Color DEFAULT_CURRENT_LINE_HIGHLIGHT_COLOR = new Color(255,255,170);
+	private static final Color DEFAULT_MARGIN_LINE_COLOR = new Color(255,224,224);
+	private static final int DEFAULT_TAB_SIZE = 4;
+	private static final int DEFAULT_MARGIN_LINE_POSITION = 80;
 
 
 	/**

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextAreaUI.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextAreaUI.java
@@ -29,8 +29,8 @@ import javax.swing.plaf.basic.*;
  */
 public class RTextAreaUI extends BasicTextAreaUI {
 
-	private static final String SHARED_ACTION_MAP_NAME	= "RTextAreaUI.actionMap";
-	private static final String SHARED_INPUT_MAP_NAME	= "RTextAreaUI.inputMap";
+	private static final String SHARED_ACTION_MAP_NAME = "RTextAreaUI.actionMap";
+	private static final String SHARED_INPUT_MAP_NAME = "RTextAreaUI.inputMap";
 
 	protected RTextArea textArea;				// The text area for which we are the UI.
 
@@ -38,7 +38,7 @@ public class RTextAreaUI extends BasicTextAreaUI {
 	private static final TransferHandler DEFAULT_TRANSFER_HANDLER =
 										new RTATextTransferHandler();
 
-	private static final String RTEXTAREA_KEYMAP_NAME	= "RTextAreaKeymap";
+	private static final String RTEXTAREA_KEYMAP_NAME = "RTextAreaKeymap";
 
 
 	/**

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RUndoManager.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RUndoManager.java
@@ -39,7 +39,7 @@ public class RUndoManager extends UndoManager {
 
 	private int internalAtomicEditDepth;
 
-	private static final String MSG	= "org.fife.ui.rtextarea.RTextArea";
+	private static final String MSG = "org.fife.ui.rtextarea.RTextArea";
 
 
 	/**

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/SearchContext.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/SearchContext.java
@@ -27,16 +27,16 @@ import java.io.Serializable;
 public class SearchContext implements Cloneable, Serializable {
 
 	/** Fired when the "search for" property is modified. */
-	public static final String PROPERTY_SEARCH_FOR		= "Search.searchFor";
+	public static final String PROPERTY_SEARCH_FOR = "Search.searchFor";
 
 	/** Fired when the "replace with" property is modified. */
-	public static final String PROPERTY_REPLACE_WITH	= "Search.replaceWith";
+	public static final String PROPERTY_REPLACE_WITH = "Search.replaceWith";
 
 	/** Fired when the "match case" property is toggled. */
-	public static final String PROPERTY_MATCH_CASE		= "Search.MatchCase";
+	public static final String PROPERTY_MATCH_CASE = "Search.MatchCase";
 
 	/** Fired when the "whole word" property is toggled. */
-	public static final String PROPERTY_MATCH_WHOLE_WORD	= "Search.MatchWholeWord";
+	public static final String PROPERTY_MATCH_WHOLE_WORD = "Search.MatchWholeWord";
 
 	/** Fired when search direction is toggled. */
 	public static final String PROPERTY_SEARCH_FORWARD = "Search.Forward";
@@ -48,7 +48,7 @@ public class SearchContext implements Cloneable, Serializable {
 	public static final String PROPERTY_SELECTION_ONLY = "Search.SelectionOnly";
 
 	/** Fired when "use regular expressions" is toggled. */
-	public static final String PROPERTY_USE_REGEX		= "Search.UseRegex";
+	public static final String PROPERTY_USE_REGEX = "Search.UseRegex";
 
 	/** Fired when the user toggles the "Mark All" property. */
 	public static final String PROPERTY_MARK_ALL = "Search.MarkAll";

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/SearchEngine.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/SearchEngine.java
@@ -636,7 +636,7 @@ public final class SearchEngine {
 		}
 
 		try {
-			wsAfter  = !Character.isLetterOrDigit(searchIn.charAt(offset + len));
+			wsAfter = !Character.isLetterOrDigit(searchIn.charAt(offset + len));
 		} catch (IndexOutOfBoundsException e) {
 			wsAfter = true;
 		}

--- a/RSyntaxTextArea/src/test/java/org/fife/io/UnicodeWriterTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/io/UnicodeWriterTest.java
@@ -209,7 +209,7 @@ class UnicodeWriterTest {
 		// Read file back and verify contents
 		try (BufferedReader r = new BufferedReader(new UnicodeReader(file, "UTF-16BE"))) {
 			String actual = r.readLine();
-			Assertions.assertEquals(actual, testContent);
+			Assertions.assertEquals(testContent, actual);
 		}
 	}
 
@@ -247,7 +247,7 @@ class UnicodeWriterTest {
 		// Read file back and verify contents
 		try (BufferedReader r = new BufferedReader(new UnicodeReader(file, "UTF-16BE"))) {
 			String actual = r.readLine();
-			Assertions.assertEquals(actual, testContent);
+			Assertions.assertEquals(testContent, actual);
 		}
 	}
 }

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaEditorKitDecreaseFontSizeActionTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaEditorKitDecreaseFontSizeActionTest.java
@@ -88,7 +88,7 @@ class RSyntaxTextAreaEditorKitDecreaseFontSizeActionTest extends AbstractRSyntax
 				break;
 			}
 		}
-		Assertions.assertEquals(newFontSize, 2f);
+		Assertions.assertEquals(2f, newFontSize);
 	}
 
 	@Test
@@ -112,7 +112,7 @@ class RSyntaxTextAreaEditorKitDecreaseFontSizeActionTest extends AbstractRSyntax
 				break;
 			}
 		}
-		Assertions.assertEquals(newFontSize, minSize);
+		Assertions.assertEquals(minSize, newFontSize);
 	}
 
 	@Test

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/CsvTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/CsvTokenMakerTest.java
@@ -125,7 +125,7 @@ class CsvTokenMakerTest extends AbstractJFlexTokenMakerTest {
 		Assertions.assertTrue(token.is(TokenTypes.DATA_TYPE, "\"unfinished-two"));
 
 		token = token.getNextToken();
-		Assertions.assertEquals(token.getType(), CsvTokenMaker.INTERNAL_STRING | 1);
+		Assertions.assertEquals(CsvTokenMaker.INTERNAL_STRING | 1, token.getType());
 	}
 
 

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/DTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/DTokenMakerTest.java
@@ -624,7 +624,7 @@ class DTokenMakerTest extends AbstractCDerivedTokenMakerTest {
 			token = token.getNextToken();
 		}
 
-		Assertions.assertEquals(token.getType(), TokenTypes.NULL);
+		Assertions.assertEquals(TokenTypes.NULL, token.getType());
 
 	}
 

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/GoTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/GoTokenMakerTest.java
@@ -92,7 +92,7 @@ class GoTokenMakerTest extends AbstractCDerivedTokenMakerTest {
 			token = token.getNextToken();
 		}
 
-		Assertions.assertEquals(token.getType(), TokenTypes.NULL);
+		Assertions.assertEquals(TokenTypes.NULL, token.getType());
 
 	}
 
@@ -161,7 +161,7 @@ class GoTokenMakerTest extends AbstractCDerivedTokenMakerTest {
 			token = token.getNextToken();
 		}
 
-		Assertions.assertEquals(token.getType(), TokenTypes.NULL);
+		Assertions.assertEquals(TokenTypes.NULL, token.getType());
 
 	}
 
@@ -187,7 +187,7 @@ class GoTokenMakerTest extends AbstractCDerivedTokenMakerTest {
 			token = token.getNextToken();
 		}
 
-		Assertions.assertEquals(token.getType(), TokenTypes.NULL);
+		Assertions.assertEquals(TokenTypes.NULL, token.getType());
 
 	}
 
@@ -293,14 +293,14 @@ class GoTokenMakerTest extends AbstractCDerivedTokenMakerTest {
 			token = token.getNextToken();
 		}
 
-		Assertions.assertEquals(token.getType(), TokenTypes.NULL);
+		Assertions.assertEquals(TokenTypes.NULL, token.getType());
 
 		segment = createSegment("return");
 		token = tm.getTokenList(segment, TokenTypes.NULL, 0);
 		Assertions.assertEquals("return", token.getLexeme());
 		Assertions.assertEquals(TokenTypes.RESERVED_WORD_2, token.getType());
 		token = token.getNextToken();
-		Assertions.assertEquals(token.getType(), TokenTypes.NULL);
+		Assertions.assertEquals(TokenTypes.NULL, token.getType());
 
 	}
 
@@ -376,7 +376,7 @@ class GoTokenMakerTest extends AbstractCDerivedTokenMakerTest {
 			token = token.getNextToken();
 		}
 
-		Assertions.assertEquals(token.getType(), TokenTypes.NULL);
+		Assertions.assertEquals(TokenTypes.NULL, token.getType());
 
 	}
 
@@ -404,7 +404,7 @@ class GoTokenMakerTest extends AbstractCDerivedTokenMakerTest {
 			token = token.getNextToken();
 		}
 
-		Assertions.assertEquals(token.getType(), TokenTypes.NULL);
+		Assertions.assertEquals(TokenTypes.NULL, token.getType());
 
 	}
 

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/HTMLTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/HTMLTokenMakerTest.java
@@ -1168,7 +1168,7 @@ class HTMLTokenMakerTest extends AbstractJFlexTokenMakerTest {
 				Token token = tm.getTokenList(segment, TokenTypes.NULL, 0);
 				Assertions.assertTrue(token.isSingleChar(TokenTypes.MARKUP_TAG_DELIMITER, '<'));
 				token = token.getNextToken();
-				Assertions.assertEquals(token.getType(), TokenTypes.MARKUP_TAG_NAME);
+				Assertions.assertEquals(TokenTypes.MARKUP_TAG_NAME, token.getType());
 
 			}
 

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/HandlebarsTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/HandlebarsTokenMakerTest.java
@@ -1563,7 +1563,7 @@ class HandlebarsTokenMakerTest extends AbstractJFlexTokenMakerTest {
 				Token token = tm.getTokenList(segment, TokenTypes.NULL, 0);
 				Assertions.assertTrue(token.isSingleChar(TokenTypes.MARKUP_TAG_DELIMITER, '<'));
 				token = token.getNextToken();
-				Assertions.assertEquals(token.getType(), TokenTypes.MARKUP_TAG_NAME);
+				Assertions.assertEquals(TokenTypes.MARKUP_TAG_NAME, token.getType());
 
 			}
 

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/JSPTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/JSPTokenMakerTest.java
@@ -1152,7 +1152,7 @@ class JSPTokenMakerTest extends AbstractJFlexTokenMakerTest {
 				Token token = tm.getTokenList(segment, TokenTypes.NULL, 0);
 				Assertions.assertTrue(token.isSingleChar(TokenTypes.MARKUP_TAG_DELIMITER, '<'));
 				token = token.getNextToken();
-				Assertions.assertEquals(token.getType(), TokenTypes.MARKUP_TAG_NAME);
+				Assertions.assertEquals(TokenTypes.MARKUP_TAG_NAME, token.getType());
 
 			}
 

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/JsonTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/JsonTokenMakerTest.java
@@ -93,7 +93,7 @@ class JsonTokenMakerTest extends AbstractCDerivedTokenMakerTest {
 			token = token.getNextToken();
 		}
 
-		Assertions.assertEquals(token.getType(), TokenTypes.NULL);
+		Assertions.assertEquals(TokenTypes.NULL, token.getType());
 
 	}
 
@@ -133,7 +133,7 @@ class JsonTokenMakerTest extends AbstractCDerivedTokenMakerTest {
 			token = token.getNextToken();
 		}
 
-		Assertions.assertEquals(token.getType(), TokenTypes.NULL);
+		Assertions.assertEquals(TokenTypes.NULL, token.getType());
 
 	}
 
@@ -159,7 +159,7 @@ class JsonTokenMakerTest extends AbstractCDerivedTokenMakerTest {
 			token = token.getNextToken();
 		}
 
-		Assertions.assertEquals(token.getType(), TokenTypes.NULL);
+		Assertions.assertEquals(TokenTypes.NULL, token.getType());
 
 	}
 
@@ -208,7 +208,7 @@ class JsonTokenMakerTest extends AbstractCDerivedTokenMakerTest {
 			token = token.getNextToken();
 		}
 
-		Assertions.assertEquals(token.getType(), TokenTypes.NULL);
+		Assertions.assertEquals(TokenTypes.NULL, token.getType());
 
 	}
 

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/MarkdownTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/MarkdownTokenMakerTest.java
@@ -650,7 +650,7 @@ class MarkdownTokenMakerTest extends AbstractJFlexTokenMakerTest {
 				Token token = tm.getTokenList(segment, TokenTypes.NULL, 0);
 				Assertions.assertTrue(token.isSingleChar(TokenTypes.MARKUP_TAG_DELIMITER, '<'));
 				token = token.getNextToken();
-				Assertions.assertEquals(token.getType(), TokenTypes.MARKUP_TAG_NAME);
+				Assertions.assertEquals(TokenTypes.MARKUP_TAG_NAME, token.getType());
 			}
 
 		}

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/PHPTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/PHPTokenMakerTest.java
@@ -2514,7 +2514,7 @@ class PHPTokenMakerTest extends AbstractJFlexTokenMakerTest {
 				Token token = tm.getTokenList(segment, TokenTypes.NULL, 0);
 				Assertions.assertTrue(token.isSingleChar(TokenTypes.MARKUP_TAG_DELIMITER, '<'));
 				token = token.getNextToken();
-				Assertions.assertEquals(token.getType(), TokenTypes.MARKUP_TAG_NAME);
+				Assertions.assertEquals(TokenTypes.MARKUP_TAG_NAME, token.getType());
 
 			}
 

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/templates/StaticCodeTemplateTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/templates/StaticCodeTemplateTest.java
@@ -45,7 +45,7 @@ class StaticCodeTemplateTest {
 
 		Assertions.assertEquals(id1, id1);
 		Assertions.assertEquals(id1, id2);
-		Assertions.assertNotEquals(id1, null);
+		Assertions.assertNotEquals(null, id1);
 		Assertions.assertNotEquals(id1, different);
 	}
 

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/RTextAreaEditorKitIncreaseFontSizeActionTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/RTextAreaEditorKitIncreaseFontSizeActionTest.java
@@ -71,7 +71,7 @@ class RTextAreaEditorKitIncreaseFontSizeActionTest {
 		ActionEvent e = new ActionEvent(textArea, 0, "command");
 		new RTextAreaEditorKit.IncreaseFontSizeAction().actionPerformedImpl(e, textArea);
 
-		Assertions.assertEquals(textArea.getFont().getSize(), origFontSize);
+		Assertions.assertEquals(origFontSize, textArea.getFont().getSize());
 	}
 
 

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/RTextAreaEditorKitTimeDateActionTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/RTextAreaEditorKitTimeDateActionTest.java
@@ -39,7 +39,7 @@ class RTextAreaEditorKitTimeDateActionTest {
 		ActionEvent e = new ActionEvent(textArea, 0, "command");
 		new RTextAreaEditorKit.TimeDateAction().actionPerformedImpl(e, textArea);
 
-		Assertions.assertTrue(textArea.getText().length() > 0);
+		Assertions.assertFalse(textArea.getText().isEmpty());
 	}
 
 


### PR DESCRIPTION
Mostly extra whitespaces, forced use of tabs to align initializing variables, and some incorrect ordering of "actual" and "expected" values in unit test assertions.