### PR TITLE
Add fold indicator background

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxUtilities.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxUtilities.java
@@ -183,6 +183,20 @@ public final class RSyntaxUtilities implements SwingConstants {
 				getDesktopProperty("awt.font.desktophints");
 	}
 
+	/**
+	 * Returns the color to use for the background of a folded region.
+	 *
+	 * @param textArea The text area.
+	 * @return The color to use.
+	 */
+	public static Color getFoldedIndicatorBackground(RSyntaxTextArea textArea) {
+		Color color = null;
+		Gutter gutter = RSyntaxUtilities.getGutter(textArea);
+		if (gutter != null) {
+			color = gutter.getFoldIndicatorBackground();
+		}
+		return color;
+	}
 
 	/**
 	 * Returns the color to use for the line underneath a folded region line.

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/SyntaxView.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/SyntaxView.java
@@ -761,6 +761,17 @@ public class SyntaxView extends View implements TabExpander,
 		while (y<clip.y+clip.height+ascent && line<lineCount) {
 
 			Fold fold = fm.getFoldForLine(line);
+			boolean isFoldCollapsed = fold != null && fold.isCollapsed();
+
+			// Paint indicator of collapsed background
+			if (isFoldCollapsed) {
+				Color c = RSyntaxUtilities.getFoldedIndicatorBackground(host);
+				if (c != null) {
+					g.setColor(c);
+					g.fillRect(x, y - ascent, host.getWidth(), lineHeight);
+				}
+			}
+
 			Element lineElement = map.getElement(line);
 			int startOffset = lineElement.getStartOffset();
 			//int endOffset = (line==lineCount ? lineElement.getEndOffset()-1 :
@@ -784,7 +795,7 @@ public class SyntaxView extends View implements TabExpander,
 			h.paintParserHighlights(g2d, startOffset, endOffset,
 				a, host, this);
 
-			if (fold!=null && fold.isCollapsed()) {
+			if (isFoldCollapsed) {
 
 				// Visible indicator of collapsed lines
 				Color c = RSyntaxUtilities.getFoldedLineBottomColor(host);

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/Theme.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/Theme.java
@@ -101,6 +101,7 @@ public class Theme {
 	public Color currentLineNumberColor;
 	public String lineNumberFont;
 	public int lineNumberFontSize;
+	public Color foldIndicatorBG;
 	public Color foldIndicatorFG;
 	public Color foldIndicatorArmedFG;
 	public Color foldBG;
@@ -168,6 +169,7 @@ public class Theme {
 			currentLineNumberColor = gutter.getCurrentLineNumberColor();
 			lineNumberFont = gutter.getLineNumberFont().getFamily();
 			lineNumberFontSize = gutter.getLineNumberFont().getSize();
+			foldIndicatorBG = gutter.getFoldIndicatorBackground();
 			foldIndicatorFG = gutter.getFoldIndicatorForeground();
 			foldIndicatorArmedFG = gutter.getFoldIndicatorArmedForeground();
 			foldBG = gutter.getFoldBackground();
@@ -224,6 +226,7 @@ public class Theme {
 				this.lineNumberFontSize : null;
 			Font font = FontUtil.deriveFont(baseFont, lineNumberFontFamily, null, lineNumberFontSize);
 			gutter.setLineNumberFont(font);
+			gutter.setFoldIndicatorBackground(foldIndicatorBG);
 			gutter.setFoldIndicatorForeground(foldIndicatorFG);
 			gutter.setFoldIndicatorArmedForeground(foldIndicatorArmedFG);
 			gutter.setFoldBackground(foldBG);
@@ -456,6 +459,9 @@ public class Theme {
 			root.appendChild(elem);
 
 			elem = doc.createElement("foldIndicator");
+			if (foldIndicatorBG != null) {
+				elem.setAttribute("bg", colorToString(foldIndicatorBG));
+			}
 			elem.setAttribute("fg", colorToString(foldIndicatorFG));
 			if (foldIndicatorArmedFG != null) {
 				elem.setAttribute("armedFg", colorToString(foldIndicatorArmedFG));
@@ -698,7 +704,9 @@ public class Theme {
 			}
 
 			else if ("foldIndicator".equals(qName)) {
-				String color = attrs.getValue("fg");
+				String color = attrs.getValue("bg");
+				theme.foldIndicatorBG = stringToColor(color);
+				color = attrs.getValue("fg");
 				theme.foldIndicatorFG = stringToColor(color);
 				color = attrs.getValue("armedFg");
 				// This field must have a value for downstream consumers to

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/WrappedSyntaxView.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/WrappedSyntaxView.java
@@ -862,8 +862,20 @@ public class WrappedSyntaxView extends BoxView implements TabExpander,
 			tempRect.height = getSpan(Y_AXIS, i);
 			//System.err.println("For line " + i + ": tempRect==" + tempRect);
 
+			Fold possibleFold = fm.getFoldForLine(i);
+			boolean isFoldCollapsed = possibleFold != null && possibleFold.isCollapsed();
+
 			if (tempRect.intersects(clip)) {
 				Element lineElement = root.getElement(i);
+				// Paint indicator of collapsed background
+				if (isFoldCollapsed) {
+					Color c = RSyntaxUtilities.getFoldedIndicatorBackground(host);
+					if (c != null) {
+						g.setColor(c);
+						g.fillRect(x, tempRect.y, host.getWidth(), tempRect.height);
+					}
+				}
+
 				int startOffset = lineElement.getStartOffset();
 				int endOffset = lineElement.getEndOffset()-1; // Why always "-1"?
 				View view = getView(i);
@@ -881,8 +893,7 @@ public class WrappedSyntaxView extends BoxView implements TabExpander,
 
 			tempRect.y += tempRect.height;
 
-			Fold possibleFold = fm.getFoldForLine(i);
-			if (possibleFold!=null && possibleFold.isCollapsed()) {
+			if (isFoldCollapsed) {
 				i += possibleFold.getCollapsedLineCount();
 				// Visible indicator of collapsed lines
 				Color c = RSyntaxUtilities.getFoldedLineBottomColor(host);

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/FoldIndicator.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/FoldIndicator.java
@@ -63,6 +63,11 @@ public class FoldIndicator extends AbstractGutterComponent {
 	 */
 	private Color armedForeground;
 
+	/**
+	 * The color used for fold indicator background.
+	 * are used.  This may be {@code null}.
+	 */
+	private Color foldIndicatorBackground;
 
 	/**
 	 * The color to use for fold icon backgrounds, if the default icons
@@ -228,6 +233,18 @@ public class FoldIndicator extends AbstractGutterComponent {
 	 */
 	public Color getArmedForeground() {
 		return armedForeground;
+	}
+
+
+	/**
+	 * Returns the background color used for fold indicator.
+	 *
+	 * @return The background color used for fold indicator. If this is {@code null}, there is no
+	 * 		   special color for fold indicator background.
+	 * @see #setFoldIndicatorBackground(Color)
+	 */
+	public Color getFoldIndicatorBackground() {
+		return foldIndicatorBackground;
 	}
 
 
@@ -756,6 +773,17 @@ public class FoldIndicator extends AbstractGutterComponent {
 			fg = FoldIndicator.DEFAULT_FOREGROUND;
 		}
 		armedForeground = fg;
+	}
+
+	/**
+	 * Sets the background color used for fold indicator.
+	 *
+	 * @param bg The new fold indicator background. If {@code null} is passed in,
+	 *           there will be no special color for fold indicator background.
+	 * @see #getFoldIndicatorBackground()
+	 */
+	public void setFoldIndicatorBackground(Color bg) {
+		this.foldIndicatorBackground = bg;
 	}
 
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/Gutter.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/Gutter.java
@@ -389,6 +389,18 @@ public class Gutter extends JPanel {
 
 
 	/**
+	 * Returns the background color of the fold indicator.
+	 *
+	 * @return The background color used for fold indicator. If this is {@code null}, there is no
+	 * 		   special color for fold indicator background.
+	 * @see #setFoldIndicatorBackground(Color)
+	 */
+	public Color getFoldIndicatorBackground() {
+		return foldIndicator.getFoldIndicatorBackground();
+	}
+
+
+	/**
 	 * Returns the foreground color of the fold indicator.
 	 *
 	 * @return The foreground color of the fold indicator.
@@ -823,6 +835,18 @@ public class Gutter extends JPanel {
 			fg = FoldIndicator.DEFAULT_FOREGROUND;
 		}
 		foldIndicator.setArmedForeground(fg);
+	}
+
+
+	/**
+	 * Sets the background color used by the fold indicator.
+	 *
+	 * @param bg The new fold indicator background. If {@code null} is passed in,
+	 *           there will be no special color for fold indicator background.
+	 * @see #getFoldIndicatorBackground()
+	 */
+	public void setFoldIndicatorBackground(Color bg) {
+		foldIndicator.setFoldIndicatorBackground(bg);
 	}
 
 

--- a/RSyntaxTextArea/src/main/resources/org/fife/ui/rsyntaxtextarea/themes/theme.dtd
+++ b/RSyntaxTextArea/src/main/resources/org/fife/ui/rsyntaxtextarea/themes/theme.dtd
@@ -70,6 +70,7 @@
       fontFamily CDATA #IMPLIED
       fontSize   CDATA #IMPLIED>
 <!ATTLIST foldIndicator
+      bg          CDATA #IMPLIED
       fg          CDATA #REQUIRED
       armedFg     CDATA #IMPLIED
       iconBg      CDATA #REQUIRED

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/FoldIndicatorTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/FoldIndicatorTest.java
@@ -50,6 +50,17 @@ class FoldIndicatorTest extends AbstractRSyntaxTextAreaTest {
 
 
 	@Test
+	void testGetSetFoldIndicatorBackground() {
+		RSyntaxTextArea textArea = createTextArea();
+		FoldIndicator fi = new FoldIndicator(textArea);
+		fi.setFoldIndicatorBackground(Color.RED);
+		Assertions.assertEquals(Color.RED, fi.getFoldIndicatorBackground());
+		fi.setFoldIndicatorBackground(Color.GREEN);
+		Assertions.assertEquals(Color.GREEN, fi.getFoldIndicatorBackground());
+	}
+
+
+	@Test
 	void testGetSetFoldIconBackground() {
 		RSyntaxTextArea textArea = createTextArea();
 		FoldIndicator fi = new FoldIndicator(textArea);


### PR DESCRIPTION
This PR adds a fold indicator background color to paint the text background when a region is collapsed. By default, it is `null`, so no background is painted.

### Example
```java
rTextScrollPane.getGutter().setFoldIndicatorBackground(new Color(198, 251, 199));
```
Using themes
```java
theme.foldIndicatorBG = new Color(198, 251, 199);
```

![2026-02-02_213902](https://github.com/user-attachments/assets/d0e3d893-73a6-4974-a50c-71d9c5cc1218)
