### PR TITLE
feat(IconRowHeader): Improve IconRowHeader Mouse Handling

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/IconRowEvent.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/IconRowEvent.java
@@ -9,6 +9,7 @@
 
 package org.fife.ui.rtextarea;
 
+import javax.swing.text.BadLocationException;
 import java.util.EventObject;
 
 /**
@@ -30,6 +31,8 @@ public class IconRowEvent extends EventObject {
 	 * The line at which the event took place.
 	 */
 	protected int line;
+
+	protected boolean consumed;
 
 	public IconRowEvent(Object source, GutterIconInfo iconInfo, int line) {
 		super(source);
@@ -53,5 +56,44 @@ public class IconRowEvent extends EventObject {
 	 */
 	public int getLine() {
 		return line;
+	}
+
+	/**
+	 * Returns the event has been consumed.
+	 *
+	 * @return {@code true} if consumed, {@code false} otherwise
+	 */
+	public boolean isConsumed() {
+		return consumed;
+	}
+
+	/**
+	 * Marks this event as consumed.
+	 *
+	 * <p>Once consumed, the event will no longer be dispatched to additional
+	 * listeners, and default handling—such as toggling a bookmark on a
+	 * left‑click—will be suppressed.</p>
+	 */
+	public void consume() {
+		this.consumed = true;
+	}
+
+
+	/**
+	 * Returns all gutter icons present on the clicked line.
+	 *
+	 * @return an array of icons on the clicked line. It is always non-null
+	 */
+	public GutterIconInfo[] getIconsAtLine() {
+		if (line < 0) { // should never happen
+			return new GutterIconInfo[0];
+		}
+
+		try {
+			IconRowHeader iconRowHeader = (IconRowHeader) getSource();
+			return iconRowHeader.getTrackingIcons(getLine());
+		} catch (BadLocationException e) {
+			return new GutterIconInfo[0];
+		}
 	}
 }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/IconRowHeader.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/IconRowHeader.java
@@ -938,7 +938,7 @@ public class IconRowHeader extends AbstractGutterComponent implements MouseListe
 				}
 
 				// Notify the listener
-				((IconRowListener) listeners[i + 1]).mouseClicked(evt, mouseEvent );
+				((IconRowListener) listeners[i + 1]).mouseClicked(evt, mouseEvent);
 
 				// Stop dispatching if a listener consumed the event
 				if (evt.isConsumed()) {

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/IconRowHeader.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/IconRowHeader.java
@@ -8,28 +8,15 @@
  */
 package org.fife.ui.rtextarea;
 
-import java.awt.Color;
-import java.awt.Dimension;
-import java.awt.Graphics;
-import java.awt.Insets;
-import java.awt.Point;
-import java.awt.Rectangle;
+import javax.swing.*;
+import javax.swing.event.DocumentEvent;
+import javax.swing.text.*;
+import java.awt.*;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
-import javax.swing.Icon;
-import javax.swing.JPanel;
-import javax.swing.ToolTipManager;
-import javax.swing.UIManager;
-import javax.swing.event.DocumentEvent;
-import javax.swing.text.BadLocationException;
-import javax.swing.text.Document;
-import javax.swing.text.Element;
-import javax.swing.text.Position;
-import javax.swing.text.View;
 
 
 /**
@@ -359,6 +346,25 @@ public class IconRowHeader extends AbstractGutterComponent implements MouseListe
 
 	@Override
 	public void mouseClicked(MouseEvent e) {
+		// Notify registered listeners about the click event
+		IconRowEvent evt = fireClickEvent(e);
+		boolean consumed = evt != null && evt.isConsumed();
+
+		// Toggle bookmarks only on a left-click, and only if no listener has consumed the event
+		if (!consumed && SwingUtilities.isLeftMouseButton(e)) {
+			if (e.getClickCount() == 1) {
+				if (bookmarkingEnabled && bookmarkIcon != null) {
+					try {
+						int line = viewToModelLine(e.getPoint());
+						if (line > -1) {
+							toggleBookmark(line);
+						}
+					} catch (BadLocationException ble) {
+						ble.printStackTrace(); // Should never happen
+					}
+				}
+			}
+		}
 	}
 
 
@@ -374,16 +380,6 @@ public class IconRowHeader extends AbstractGutterComponent implements MouseListe
 
 	@Override
 	public void mousePressed(MouseEvent e) {
-		if (bookmarkingEnabled && bookmarkIcon!=null) {
-			try {
-				int line = viewToModelLine(e.getPoint());
-				if (line>-1) {
-					toggleBookmark(line);
-				}
-			} catch (BadLocationException ble) {
-				ble.printStackTrace(); // Never happens
-			}
-		}
 	}
 
 
@@ -920,7 +916,39 @@ public class IconRowHeader extends AbstractGutterComponent implements MouseListe
 		}
 	}
 
+	/**
+	 * Notifies all registered {@link IconRowListener} of a mouse click in the {@link IconRowHeader}.
+	 */
+	protected IconRowEvent fireClickEvent(MouseEvent mouseEvent) {
+		Object[] listeners = listenerList.getListenerList();
+		IconRowEvent evt = null;
 
+		for (int i = listeners.length - 2; i >= 0; i -= 2) {
+			if (listeners[i] == IconRowListener.class) {
+				// Create the event only once, when the first matching listener is found
+				if (evt == null) {
+					int line = -1;
+					try {
+						line = viewToModelLine(mouseEvent.getPoint());
+					} catch (BadLocationException ignored) {
+						// Should not happen; fallback line = -1
+					}
+
+					evt = new IconRowEvent(this, null, line);
+				}
+
+				// Notify the listener
+				((IconRowListener) listeners[i + 1]).mouseClicked(evt, mouseEvent );
+
+				// Stop dispatching if a listener consumed the event
+				if (evt.isConsumed()) {
+					break;
+				}
+			}
+		}
+
+		return evt;
+	}
 
 	/**
 	 * Adds a listener for the IconRowEvent posted after the Icon Row changes.

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/IconRowListener.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/IconRowListener.java
@@ -41,6 +41,7 @@ public interface IconRowListener extends EventListener {
 	/**
 	 * Invoked when the user clicks on a line in the icon row.
 	 *
+	 * @param e an IconRowEvent describing the changes to the IconRowHeader
 	 * @param me the event describing the click
 	 */
 	default void mouseClicked(IconRowEvent e, MouseEvent me) {

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/IconRowListener.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/IconRowListener.java
@@ -9,6 +9,7 @@
 
 package org.fife.ui.rtextarea;
 
+import java.awt.event.MouseEvent;
 import java.util.EventListener;
 
 
@@ -36,5 +37,13 @@ public interface IconRowListener extends EventListener {
 	 * @see IconRowHeader#toggleBookmark(int)
 	 */
 	void bookmarkRemoved(IconRowEvent e);
+
+	/**
+	 * Invoked when the user clicks on a line in the icon row.
+	 *
+	 * @param me the event describing the click
+	 */
+	default void mouseClicked(IconRowEvent e, MouseEvent me) {
+	}
 
 }

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/IconRowEventTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/IconRowEventTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import javax.swing.*;
+import javax.swing.text.BadLocationException;
 
 /**
  * Unit tests for the {@link IconRowEvent} class.
@@ -17,6 +18,30 @@ import javax.swing.*;
  * @version 3.5.4
  */
 public class IconRowEventTest {
+
+	@Test
+	void testMouseClicked() throws BadLocationException {
+		int line = 0;
+		ImageIcon icon = new ImageIcon();
+		RTextArea textArea = new RTextArea();
+
+		IconRowHeader h = new IconRowHeader(textArea);
+		IconRowEvent evt = new IconRowEvent(h, null, line);
+
+		Assertions.assertFalse(evt.isConsumed());
+		Assertions.assertNotNull(evt.getIconsAtLine());
+		Assertions.assertEquals(0, evt.getIconsAtLine().length);
+
+		// icons at line
+		h.addOffsetTrackingIcon(0, icon);
+		h.addOffsetTrackingIcon(0, icon);
+		Assertions.assertEquals(2, evt.getIconsAtLine().length);
+
+		Assertions.assertNull(evt.getIconInfo()); // not a bookmark event
+
+		evt.consume();
+		Assertions.assertTrue(evt.isConsumed());
+	}
 
 	@Test
 	void testIconRowEvent_verify() {

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/IconRowHeaderTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/IconRowHeaderTest.java
@@ -341,8 +341,8 @@ class IconRowHeaderTest extends AbstractRSyntaxTextAreaTest {
 
 		class IconRowListenerMouseClickedTest implements IconRowListener {
 			IconRowEvent evt;
-			boolean consume = false;
-			boolean bookmarkAdded = false;
+			boolean consume;
+			boolean bookmarkAdded;
 
 			@Override
 			public void bookmarkAdded(IconRowEvent e) {
@@ -364,7 +364,8 @@ class IconRowHeaderTest extends AbstractRSyntaxTextAreaTest {
 		}
 
 		// left-click on line 0
-		MouseEvent evt = new MouseEvent(textArea, MouseEvent.MOUSE_CLICKED, System.currentTimeMillis(), 0, 0, 0, 1, false, MouseEvent.BUTTON1);
+		MouseEvent evt = new MouseEvent(textArea, MouseEvent.MOUSE_CLICKED, System.currentTimeMillis(),
+			0, 0, 0, 1, false, MouseEvent.BUTTON1);
 		IconRowListenerMouseClickedTest test = new IconRowListenerMouseClickedTest();
 		header.addIconRowListener(test);
 

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/IconRowHeaderTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/IconRowHeaderTest.java
@@ -213,6 +213,7 @@ class IconRowHeaderTest extends AbstractRSyntaxTextAreaTest {
 			@Override
 			public void bookmarkAdded(IconRowEvent e) {
 			}
+
 			@Override
 			public void bookmarkRemoved(IconRowEvent e) {
 			}
@@ -239,6 +240,7 @@ class IconRowHeaderTest extends AbstractRSyntaxTextAreaTest {
 			public void bookmarkAdded(IconRowEvent e) {
 				added = true;
 			}
+
 			@Override
 			public void bookmarkRemoved(IconRowEvent e) {
 			}
@@ -267,9 +269,10 @@ class IconRowHeaderTest extends AbstractRSyntaxTextAreaTest {
 			public void bookmarkAdded(IconRowEvent e) {
 
 			}
+
 			@Override
 			public void bookmarkRemoved(IconRowEvent e) {
-				removed=true;
+				removed = true;
 			}
 		}
 
@@ -301,6 +304,7 @@ class IconRowHeaderTest extends AbstractRSyntaxTextAreaTest {
 			public void bookmarkAdded(IconRowEvent e) {
 				addedCount++;
 			}
+
 			@Override
 			public void bookmarkRemoved(IconRowEvent e) {
 				removedCount++;
@@ -326,5 +330,58 @@ class IconRowHeaderTest extends AbstractRSyntaxTextAreaTest {
 		Assertions.assertEquals(3, IconRowListenerBookmarkMultipleTest.addedCount);
 		Assertions.assertEquals(3, IconRowListenerBookmarkMultipleTest.removedCount);
 
+	}
+
+	@Test
+	void testAddIconRowListener_mouseClicked() {
+		RSyntaxTextArea textArea = createTextArea();
+		IconRowHeader header = new IconRowHeader(textArea);
+		header.setBookmarkingEnabled(true);
+		header.setBookmarkIcon(new ImageIcon());
+
+		class IconRowListenerMouseClickedTest implements IconRowListener {
+			IconRowEvent evt;
+			boolean consume = false;
+			boolean bookmarkAdded = false;
+
+			@Override
+			public void bookmarkAdded(IconRowEvent e) {
+				bookmarkAdded = true;
+			}
+
+			@Override
+			public void bookmarkRemoved(IconRowEvent e) {
+			}
+
+			@Override
+			public void mouseClicked(IconRowEvent e, MouseEvent me) {
+				evt = e;
+
+				if (consume) {
+					e.consume();
+				}
+			}
+		}
+
+		// left-click on line 0
+		MouseEvent evt = new MouseEvent(textArea, MouseEvent.MOUSE_CLICKED, System.currentTimeMillis(), 0, 0, 0, 1, false, MouseEvent.BUTTON1);
+		IconRowListenerMouseClickedTest test = new IconRowListenerMouseClickedTest();
+		header.addIconRowListener(test);
+
+		// event is consumed and no bookmark is added
+		test.consume = true;
+		header.mouseClicked(evt);
+		Assertions.assertNotNull(test.evt);
+		Assertions.assertTrue(test.evt.isConsumed());
+		Assertions.assertEquals(0, test.evt.getIconsAtLine().length);
+		Assertions.assertFalse(test.bookmarkAdded);
+
+		// event is handled by listeners but not consumed and a bookmark is added
+		test.consume = false;
+		header.mouseClicked(evt);
+		Assertions.assertNotNull(test.evt);
+		Assertions.assertFalse(test.evt.isConsumed());
+		Assertions.assertEquals(1, test.evt.getIconsAtLine().length);
+		Assertions.assertTrue(test.bookmarkAdded);
 	}
 }


### PR DESCRIPTION
The `IconRowHeader` previously had no mechanism to intercept `MouseEvent`s, which meant that every click—left or right—automatically toggled a bookmark. This also made it impossible to react specifically to clicks on gutter icons without triggering the bookmark logic, and right‑click interactions couldn’t be distinguished or customized.

This PR introduces a proper click‑handling mechanism for the icon row. Bookmarks are now toggled only on a left‑mouse single‑click, while other mouse buttons no longer affect bookmark state. A new `mouseClicked` method in `IconRowListener` allows consumers to receive and handle click events directly. Event dispatch also stops when a listener consumes the `IconRowEvent`, giving full control over custom behaviors.

With these changes, clients can finally react to clicks on gutter icons without interfering with bookmark toggling, enabling richer and more flexible interactions in the gutter area.