### PR TITLE
fix(MarkdownTokenMaker) rendering bug when '#' is not in a header

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/MarkdownTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/MarkdownTokenMaker.flex
@@ -451,7 +451,7 @@ EmailAddress            = ([^@]+@[^@]+\.[^@]+)
                                     // If for some reason it isn't, highlight it as an identifier and continue on
                                     else {
                                         int count = yylength();
-                                        addToken(zzStartRead, zzStartRead + 1, Token.IDENTIFIER);
+                                        addToken(zzStartRead, zzStartRead, Token.IDENTIFIER);
                                         zzMarkedPos -= (count - 1);
                                     }
                                 }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/MarkdownTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/MarkdownTokenMaker.java
@@ -1575,7 +1575,7 @@ public class MarkdownTokenMaker extends AbstractMarkupTokenMaker {
                                     // If for some reason it isn't, highlight it as an identifier and continue on
                                     else {
                                         int count = yylength();
-                                        addToken(zzStartRead, zzStartRead + 1, Token.IDENTIFIER);
+                                        addToken(zzStartRead, zzStartRead, Token.IDENTIFIER);
                                         zzMarkedPos -= (count - 1);
                                     }
           }


### PR DESCRIPTION
Fixes #664.

When `#` is in a markdown file, but *not* part of a header, it causes the next char on the line to be rendered twice..