### PR TITLE
chore(demo): Fix remaining Java 11 deprecations in demo app

### DIFF
--- a/RSyntaxTextAreaDemo/src/main/java/org/fife/ui/rsyntaxtextarea/demo/DemoRootPane.java
+++ b/RSyntaxTextAreaDemo/src/main/java/org/fife/ui/rsyntaxtextarea/demo/DemoRootPane.java
@@ -606,7 +606,7 @@ public class DemoRootPane extends JRootPane implements HyperlinkListener,
 
 		ToggleAntiAliasingAction() {
 			putValue(NAME, "Anti-Aliasing");
-			int defaultModifier = getToolkit().getMenuShortcutKeyMask() | InputEvent.SHIFT_DOWN_MASK;
+			int defaultModifier = getToolkit().getMenuShortcutKeyMaskEx() | InputEvent.SHIFT_DOWN_MASK;
 			putValue(ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_A, defaultModifier));
 		}
 
@@ -624,7 +624,7 @@ public class DemoRootPane extends JRootPane implements HyperlinkListener,
 
 		ToggleFractionalFontMetricsAction() {
 			putValue(NAME, "Fractional Font Metrics");
-			int defaultModifier = getToolkit().getMenuShortcutKeyMask() | InputEvent.SHIFT_DOWN_MASK;
+			int defaultModifier = getToolkit().getMenuShortcutKeyMaskEx() | InputEvent.SHIFT_DOWN_MASK;
 			putValue(ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_F, defaultModifier));
 		}
 
@@ -642,7 +642,7 @@ public class DemoRootPane extends JRootPane implements HyperlinkListener,
 
 		ToggleKerningAction() {
 			putValue(NAME, "Kerning");
-			int defaultModifier = getToolkit().getMenuShortcutKeyMask() | InputEvent.SHIFT_DOWN_MASK;
+			int defaultModifier = getToolkit().getMenuShortcutKeyMaskEx() | InputEvent.SHIFT_DOWN_MASK;
 			putValue(ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_1, defaultModifier));
 		}
 
@@ -665,7 +665,7 @@ public class DemoRootPane extends JRootPane implements HyperlinkListener,
 
 		ToggleLigatureSupportAction() {
 			putValue(NAME, "Ligature Support");
-			int defaultModifier = getToolkit().getMenuShortcutKeyMask() | InputEvent.SHIFT_DOWN_MASK;
+			int defaultModifier = getToolkit().getMenuShortcutKeyMaskEx() | InputEvent.SHIFT_DOWN_MASK;
 			putValue(ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_2, defaultModifier));
 		}
 

--- a/RSyntaxTextAreaDemo/src/main/java/org/fife/ui/rsyntaxtextarea/demo/FindAndReplaceDemo.java
+++ b/RSyntaxTextAreaDemo/src/main/java/org/fife/ui/rsyntaxtextarea/demo/FindAndReplaceDemo.java
@@ -56,7 +56,7 @@ public final class FindAndReplaceDemo extends JFrame implements ActionListener {
 		InputMap im = searchField.getInputMap();
 		ActionMap am = searchField.getActionMap();
 		im.put(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0), "searchForward");
-		im.put(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, InputEvent.SHIFT_MASK), "searchBackward");
+		im.put(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, InputEvent.SHIFT_DOWN_MASK), "searchBackward");
 		am.put("searchForward", new AbstractAction() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -71,7 +71,7 @@ public final class FindAndReplaceDemo extends JFrame implements ActionListener {
 		});
 
 		// Make Ctrl+F/Cmd+F focus the search field
-		int defaultMod = Toolkit.getDefaultToolkit().getMenuShortcutKeyMask();
+		int defaultMod = Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx();
 		im = textArea.getInputMap();
 		am = textArea.getActionMap();
 		im.put(KeyStroke.getKeyStroke(KeyEvent.VK_F, defaultMod), "doSearch");


### PR DESCRIPTION
Fix the few remaining deprecation warnings in the `RSyntaxTextAreaDemo` submodule. These were all around `InputEvent`s now expecting the `*_DOWN_MASK` variants.