### PR TITLE
chore: Use getModifiersEx in RTA mouseDragged

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextArea.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextArea.java
@@ -1746,7 +1746,7 @@ public class RTextArea extends RTextAreaBase implements Printable {
 			// WORKAROUND:  Since JTextComponent only updates the caret
 			// location on mouse clicked and released, we'll do it on dragged
 			// events when the left mouse button is clicked.
-			if ((e.getModifiers() & MouseEvent.BUTTON1_DOWN_MASK) != 0) {
+			if ((e.getModifiersEx() & MouseEvent.BUTTON1_DOWN_MASK) != 0) {
 				Caret caret = getCaret();
 				dot = caret.getDot();
 				mark = caret.getMark();


### PR DESCRIPTION
Like it says on the tin. Fixes a javac warning now that we've migrated to Java 11.