### PR TITLE
fix(RPrintUtilities): deprecation warnings from migraiton to Java 11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build
 /.settings/
 bin/
 out/
+settings.local.json

--- a/RSyntaxTextArea/src/main/java/org/fife/print/RPrintUtilities.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/print/RPrintUtilities.java
@@ -9,10 +9,7 @@
  */
 package org.fife.print;
 
-import java.awt.Color;
-import java.awt.Font;
-import java.awt.FontMetrics;
-import java.awt.Graphics;
+import java.awt.*;
 import java.awt.print.PageFormat;
 import java.awt.print.Printable;
 
@@ -46,7 +43,7 @@ public abstract class RPrintUtilities {
 	/**
 	 * The x-offset (for the page margin) when printing.
 	 */
-	private static int xOffset;
+	private static float xOffset;
 
 	/**
 	 * The length of a tab, in spaces.
@@ -102,8 +99,8 @@ public abstract class RPrintUtilities {
 	 * @return One of the constants from {@code Printable}.
 	 * @see #printDocumentMonospacedWordWrap
 	 */
-	public static int printDocumentMonospaced(Graphics g, Document doc, int fontSize, int pageIndex,
-							PageFormat pageFormat, int tabSize) {
+	public static int printDocumentMonospaced(Graphics2D g, Document doc, int fontSize, int pageIndex,
+	                                          PageFormat pageFormat, int tabSize) {
 
 		g.setColor(Color.BLACK);
 		g.setFont(new Font(Font.MONOSPACED, Font.PLAIN, fontSize));
@@ -127,8 +124,8 @@ public abstract class RPrintUtilities {
 		// The (x,y) coordinate to print at (in pixels, not characters).
 		// Since y is the baseline of where we'll start printing (not the top-left
 		// corner), we offset it by the font's ascent ( + 1 just for good measure).
-		xOffset = (int)pageFormat.getImageableX();
-		int y = (int)pageFormat.getImageableY() + fm.getAscent() + 1;
+		xOffset = (float)pageFormat.getImageableX();
+		float y = (float)pageFormat.getImageableY() + fm.getAscent() + 1;
 
 		// A counter to keep track of the number of lines that WOULD HAVE been
 		// printed if we were printing all lines.
@@ -178,7 +175,7 @@ public abstract class RPrintUtilities {
 
 				numPrintedLines++;
 				if (numPrintedLines > startingLineNumber) {
-						g.drawString(curLineString.substring(0,maxCharsPerLine), xOffset,y);
+						g.drawString(curLineString.substring(0,maxCharsPerLine), xOffset, y);
 						y += fontHeight;
 						if (numPrintedLines==startingLineNumber+maxLinesPerPage) {
 							return Printable.PAGE_EXISTS;
@@ -193,7 +190,7 @@ public abstract class RPrintUtilities {
 
 			numPrintedLines++;
 			if (numPrintedLines>startingLineNumber) {
-				g.drawString(curLineString, xOffset,y);
+				g.drawString(curLineString, xOffset, y);
 				y += fontHeight;
 				if (numPrintedLines==startingLineNumber+maxLinesPerPage) {
 					return Printable.PAGE_EXISTS;
@@ -226,7 +223,7 @@ public abstract class RPrintUtilities {
 	 * @return One of the constants from {@code Printable}.
 	 * @see #printDocumentMonospaced
 	 */
-	public static int printDocumentMonospacedWordWrap(Graphics g, Document doc,
+	public static int printDocumentMonospacedWordWrap(Graphics2D g, Document doc,
 								int fontSize, int pageIndex,
 								PageFormat pageFormat, int tabSize) {
 
@@ -252,8 +249,8 @@ public abstract class RPrintUtilities {
 		// The (x,y) coordinate to print at (in pixels, not characters).
 		// Since y is the baseline of where we'll start printing (not the top-left
 		// corner), we offset it by the font's ascent ( + 1 just for good measure).
-		xOffset = (int)pageFormat.getImageableX();
-		int y = (int)pageFormat.getImageableY() + fm.getAscent() + 1;
+		xOffset = (float)pageFormat.getImageableX();
+		float y = (float)pageFormat.getImageableY() + fm.getAscent() + 1;
 
 		// A counter to keep track of the number of lines that WOULD HAVE been
 		// printed if we were printing all lines.
@@ -305,7 +302,7 @@ public abstract class RPrintUtilities {
 
 				numPrintedLines++;
 				if (numPrintedLines > startingLineNumber) {
-						g.drawString(curLineString.substring(0,breakPoint), xOffset,y);
+						g.drawString(curLineString.substring(0,breakPoint), xOffset, y);
 						y += fontHeight;
 						if (numPrintedLines==startingLineNumber+maxLinesPerPage) {
 							return Printable.PAGE_EXISTS;
@@ -320,7 +317,7 @@ public abstract class RPrintUtilities {
 
 			numPrintedLines++;
 			if (numPrintedLines>startingLineNumber) {
-				g.drawString(curLineString, xOffset,y);
+				g.drawString(curLineString, xOffset, y);
 				y += fontHeight;
 				if (numPrintedLines==startingLineNumber+maxLinesPerPage) {
 					return Printable.PAGE_EXISTS;
@@ -354,7 +351,7 @@ public abstract class RPrintUtilities {
 	 * @param tabSize The number of spaces to convert tabs to.
 	 * @return One of the constants from {@code Printable}.
 	 */
-	public static int printDocumentWordWrap(Graphics g, JTextComponent textComponent,
+	public static int printDocumentWordWrap(Graphics2D g, JTextComponent textComponent,
 										Font font, int pageIndex,
 										PageFormat pageFormat,
 										int tabSize) {
@@ -368,7 +365,7 @@ public abstract class RPrintUtilities {
 		fm = g.getFontMetrics();
 		int fontHeight = fm.getHeight();
 
-		final int lineLengthInPixels = (int)pageFormat.getImageableWidth();
+		final float lineLengthInPixels = (float)pageFormat.getImageableWidth();
 		final int maxLinesPerPage = (int)pageFormat.getImageableHeight() / fontHeight;
 
 		final int startingLineNumber = maxLinesPerPage * pageIndex;
@@ -379,8 +376,8 @@ public abstract class RPrintUtilities {
 		// The (x,y) coordinate to print at (in pixels, not characters).
 		// Since y is the baseline of where we'll start printing (not the top-left
 		// corner), we offset it by the font's ascent ( + 1 just for good measure).
-		xOffset = (int)pageFormat.getImageableX();
-		int y = (int)pageFormat.getImageableY() + fm.getAscent() + 1;
+		xOffset = (float)pageFormat.getImageableX();
+		float y = (float)pageFormat.getImageableY() + fm.getAscent() + 1;
 
 		// A counter to keep track of the number of lines that WOULD HAVE been
 		// printed if we were printing all lines.
@@ -416,7 +413,7 @@ public abstract class RPrintUtilities {
 			currentLineSeg = removeEndingWhitespace(currentLineSeg);
 
 			// Figure out how long the line is, in pixels.
-			int currentLineLengthInPixels = Utilities.getTabbedTextWidth(currentLineSeg, fm, 0, tabExpander, 0);
+			float currentLineLengthInPixels = Utilities.getTabbedTextWidth(currentLineSeg, fm, 0f, tabExpander, 0);
 
 			//System.err.println("'" + currentLineSeg + "' - " + currentLineLengthInPixels + "/" +
 			// LINE_LENGTH_IN_PIXELS);
@@ -470,7 +467,7 @@ public abstract class RPrintUtilities {
 								return Printable.NO_SUCH_PAGE;
 							}
 							currentLineLengthInPixels = Utilities.
-								getTabbedTextWidth(currentLineSeg, fm, 0, tabExpander, 0);
+								getTabbedTextWidth(currentLineSeg, fm, 0f, tabExpander, 0);
 						} while (currentLineLengthInPixels <= lineLengthInPixels);
 						currentPos--;
 
@@ -483,7 +480,7 @@ public abstract class RPrintUtilities {
 						return Printable.NO_SUCH_PAGE;
 					}
 
-					currentLineLengthInPixels = Utilities.getTabbedTextWidth(currentLineSeg, fm, 0, tabExpander, 0);
+					currentLineLengthInPixels = Utilities.getTabbedTextWidth(currentLineSeg, fm, 0f, tabExpander, 0);
 				} // End of while (currentLineLengthInPixels > LINE_LENGTH_IN_PIXELS).
 
 				startingOffset += currentPos;	// Where to start (offset from line's start), since this line wraps.
@@ -493,7 +490,7 @@ public abstract class RPrintUtilities {
 			numPrintedLines++;
 			if (numPrintedLines>startingLineNumber) {
 				//g.drawString(currentLineSeg.toString(), xOffset,y);
-				Utilities.drawTabbedText(currentLineSeg, xOffset,y, g, tabExpander, 0);
+				Utilities.drawTabbedText(currentLineSeg, xOffset, y, g, tabExpander, 0);
 				y += fontHeight;
 				if (numPrintedLines==startingLineNumber+maxLinesPerPage) {
 					return Printable.PAGE_EXISTS;
@@ -542,7 +539,7 @@ public abstract class RPrintUtilities {
 				return x;
 			}
 			int tabSizeInPixels = tabSizeInSpaces * fm.charWidth(' ');
-			int tabCount = (((int) x) - xOffset) / tabSizeInPixels;
+			int tabCount = ((int)(x - xOffset)) / tabSizeInPixels;
 			return xOffset + ((tabCount + 1f) * tabSizeInPixels);
 		}
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextArea.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextArea.java
@@ -1033,11 +1033,12 @@ public class RTextArea extends RTextAreaBase implements Printable {
 	 *
 	 * @param g The context into which the page is drawn.
 	 * @param pageFormat The size and orientation of the page being drawn.
-	 * @param pageIndex The zero based index of the page to be drawn.
+	 * @param pageIndex The zero-based index of the page to be drawn.
 	 */
 	@Override
 	public int print(Graphics g, PageFormat pageFormat, int pageIndex) {
-		return RPrintUtilities.printDocumentWordWrap(g, this, getFont(), pageIndex, pageFormat, getTabSize());
+		Graphics2D g2d = (Graphics2D)g;
+		return RPrintUtilities.printDocumentWordWrap(g2d, this, getFont(), pageIndex, pageFormat, getTabSize());
 	}
 
 

--- a/RSyntaxTextArea/src/test/java/org/fife/print/RPrintUtilitiesTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/print/RPrintUtilitiesTest.java
@@ -42,60 +42,60 @@ class RPrintUtilitiesTest extends AbstractRSyntaxTextAreaTest {
 	@Test
 	void testPrintDocumentMonospaced_happyPath() throws BadLocationException {
 
-		Graphics g = createTestGraphics();
+		Graphics2D g2d = createTestGraphics();
 		PlainDocument doc = new PlainDocument();
 		doc.insertString(0, createContent(5000), null);
 		PageFormat pageFormat = new PageFormat();
 
-		RPrintUtilities.printDocumentMonospaced(g, doc, 10, 0, pageFormat, 4);
+		RPrintUtilities.printDocumentMonospaced(g2d, doc, 10, 0, pageFormat, 4);
 	}
 
 
 	@Test
 	void testPrintDocumentMonospaced_happyPath_tabSizeZero() throws BadLocationException {
 
-		Graphics g = createTestGraphics();
+		Graphics2D g2d = createTestGraphics();
 		PlainDocument doc = new PlainDocument();
 		doc.insertString(0, createContent(5000), null);
 		PageFormat pageFormat = new PageFormat();
 
-		RPrintUtilities.printDocumentMonospaced(g, doc, 10, 0, pageFormat, 0);
+		RPrintUtilities.printDocumentMonospaced(g2d, doc, 10, 0, pageFormat, 0);
 	}
 
 
 	@Test
 	void testPrintDocumentMonospaced_happyPath_empty() throws BadLocationException {
 
-		Graphics g = createTestGraphics();
+		Graphics2D g2d = createTestGraphics();
 		PlainDocument doc = new PlainDocument();
 		doc.insertString(0, createContent(0), null);
 		PageFormat pageFormat = new PageFormat();
 
-		RPrintUtilities.printDocumentMonospaced(g, doc, 10, 0, pageFormat, 4);
+		RPrintUtilities.printDocumentMonospaced(g2d, doc, 10, 0, pageFormat, 4);
 	}
 
 
 	@Test
 	void testPrintDocumentMonospacedWordWrap_happyPath() throws BadLocationException {
 
-		Graphics g = createTestGraphics();
+		Graphics2D g2d = createTestGraphics();
 		PlainDocument doc = new PlainDocument();
 		doc.insertString(0, createContent(5000), null);
 		PageFormat pageFormat = new PageFormat();
 
-		RPrintUtilities.printDocumentMonospacedWordWrap(g, doc, 10, 0, pageFormat, 4);
+		RPrintUtilities.printDocumentMonospacedWordWrap(g2d, doc, 10, 0, pageFormat, 4);
 	}
 
 
 	@Test
 	void testPrintDocumentWordWrap_happyPath() {
 
-		Graphics g = createTestGraphics();
+		Graphics2D g2d = createTestGraphics();
 		RSyntaxTextArea textArea = createTextArea();
 		textArea.setText(createContent(4000));
 		PageFormat pageFormat = new PageFormat();
 		Font font = new Font(Font.DIALOG, Font.PLAIN, 12);
 
-		RPrintUtilities.printDocumentWordWrap(g, textArea, font, 0, pageFormat, 4);
+		RPrintUtilities.printDocumentWordWrap(g2d, textArea, font, 0, pageFormat, 4);
 	}
 }


### PR DESCRIPTION
Like it says on the tin. This PR addresses some straggler warnings in `RPrintUtilities` after our move to Java 11. Specifically the changes are around moving to the FPAPI.