### PR TITLE
refactor(DocumentRange)!: DocumentRange to the rtextarea package

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/ErrorStrip.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/ErrorStrip.java
@@ -41,6 +41,7 @@ import javax.swing.text.BadLocationException;
 import org.fife.ui.rsyntaxtextarea.parser.Parser;
 import org.fife.ui.rsyntaxtextarea.parser.ParserNotice;
 import org.fife.ui.rsyntaxtextarea.parser.TaskTagParser.TaskNotice;
+import org.fife.ui.rtextarea.DocumentRange;
 import org.fife.ui.rtextarea.RTextArea;
 
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaHighlighter.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaHighlighter.java
@@ -24,6 +24,7 @@ import javax.swing.text.View;
 
 import org.fife.ui.rsyntaxtextarea.parser.Parser;
 import org.fife.ui.rsyntaxtextarea.parser.ParserNotice;
+import org.fife.ui.rtextarea.DocumentRange;
 import org.fife.ui.rtextarea.RTextAreaHighlighter;
 import org.fife.ui.rtextarea.SmartHighlightPainter;
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxUtilities.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxUtilities.java
@@ -32,6 +32,7 @@ import javax.swing.text.View;
 
 import org.fife.ui.rsyntaxtextarea.TokenUtils.TokenSubList;
 import org.fife.ui.rsyntaxtextarea.folding.FoldManager;
+import org.fife.ui.rtextarea.DocumentRange;
 import org.fife.ui.rtextarea.Gutter;
 import org.fife.ui.rtextarea.RTextArea;
 import org.fife.ui.rtextarea.RTextScrollPane;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/DocumentRange.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/DocumentRange.java
@@ -6,7 +6,7 @@
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */
-package org.fife.ui.rsyntaxtextarea;
+package org.fife.ui.rtextarea;
 
 
 /**

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextArea.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextArea.java
@@ -34,7 +34,6 @@ import javax.swing.undo.CannotRedoException;
 import javax.swing.undo.CannotUndoException;
 
 import org.fife.print.RPrintUtilities;
-import org.fife.ui.rsyntaxtextarea.DocumentRange;
 import org.fife.ui.rtextarea.Macro.MacroRecord;
 
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextAreaHighlighter.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextAreaHighlighter.java
@@ -25,8 +25,6 @@ import javax.swing.text.LayeredHighlighter;
 import javax.swing.text.Position;
 import javax.swing.text.View;
 
-import org.fife.ui.rsyntaxtextarea.DocumentRange;
-
 
 /**
  * The highlighter implementation used by {@link RTextArea}s.  It knows to

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/SearchEngine.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/SearchEngine.java
@@ -20,7 +20,6 @@ import javax.swing.JTextArea;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.Caret;
 
-import org.fife.ui.rsyntaxtextarea.DocumentRange;
 import org.fife.ui.rsyntaxtextarea.RSyntaxUtilities;
 
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/SearchResult.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/SearchResult.java
@@ -8,8 +8,6 @@
  */
 package org.fife.ui.rtextarea;
 
-import org.fife.ui.rsyntaxtextarea.DocumentRange;
-
 
 /**
  * The result of a find, replace, or "mark all" operation.

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxUtilitiesTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxUtilitiesTest.java
@@ -6,6 +6,7 @@
  */
 package org.fife.ui.rsyntaxtextarea;
 
+import org.fife.ui.rtextarea.DocumentRange;
 import org.fife.ui.rtextarea.RTextScrollPane;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/DocumentRangeTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/DocumentRangeTest.java
@@ -4,7 +4,7 @@
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */
-package org.fife.ui.rsyntaxtextarea;
+package org.fife.ui.rtextarea;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/RTextAreaHighlighterTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/RTextAreaHighlighterTest.java
@@ -5,7 +5,6 @@
 package org.fife.ui.rtextarea;
 
 
-import org.fife.ui.rsyntaxtextarea.DocumentRange;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/SearchEngineTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/SearchEngineTest.java
@@ -12,7 +12,6 @@ import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 
-import org.fife.ui.rsyntaxtextarea.DocumentRange;
 import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea;
 import static org.junit.jupiter.api.Assertions.*;
 


### PR DESCRIPTION
## Summary
- `DocumentRange` lived in `org.fife.ui.rsyntaxtextarea` but is used extensively by the sister `rtextarea` package (`SearchEngine`, `SearchResult`, `RTextAreaHighlighter`, `RTextArea`), creating an unwanted circular dependency between the two packages.
- Moves `DocumentRange` (and its unit test) to `org.fife.ui.rtextarea`, updating all references accordingly.

Closes #437