### PR TITLE
build(deps): Bump minimum build JDK to Java 25

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,10 +37,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v6
 
-    - name: Set up JDK 17
+    - name: Set up JDK 25
       uses: actions/setup-java@v5
       with:
-        java-version: '17'
+        java-version: '25'
         distribution: 'temurin'
 
     # Initializes the CodeQL tools for scanning.

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -16,14 +16,14 @@ jobs:
 
     strategy:
       matrix:
-        java: [ '17', '21', '23' ]
+        java: [ '25', '26' ]
 
     steps:
     - uses: actions/checkout@v6
 
     - name: Verify gradle wrapper
       uses: gradle/actions/wrapper-validation@v6
-      if: matrix.java == '17'
+      if: matrix.java == '25'
 
     - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v5
@@ -41,7 +41,7 @@ jobs:
 
     - name: Submit coverage data to codecov
       uses: codecov/codecov-action@v7
-      if: matrix.java == '17'
+      if: matrix.java == '25'
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         disable_search: true

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Java versions, use the RSTA version specified in the following table:
 
 | RSTA Version | Required to build (JDK) | Required to run (JRE)  |
 |--------------|-------------------------|------------------------|
-| 4.x          | 17                      | 11                     |
+| 4.x          | 25                      | 11                     |
 | 3.x          | 17                      | 8                      |
 | 2.6.x        | 6                       | 6                      |
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,12 +14,12 @@ plugins {
 
 apply plugin: 'io.github.gradle-nexus.publish-plugin'
 
-// We require building with JDK 17 or later. Built artifact compatibility
+// We require building with JDK 25 or later. Built artifact compatibility
 // is controlled by javaLanguageVersion
-assert JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)
+assert JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_25)
 
 group = 'com.fifesoft'
-// NOTE: Local Java 17: /Library/Java/JavaVirtualMachines/jdk-17.0.13+11/Contents/Home
+// NOTE: Local Java 25: /Library/Java/JavaVirtualMachines/jdk-25.0.1+8/Contents/Home
 
 allprojects {
 


### PR DESCRIPTION
There's no reason not to require the latest LTS release for builds to sniff out new deprecation warnings, etc., since Swing in particular is so old. The runtime requirement will stay Java 11.

* Bump minimum build JDK to Java 25
* Update GitHub actions to build with 25 and 26 (latest version, though non-LTS)
