### PR TITLE
chore: Minor code changes for Java 11

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/print/RPrintUtilities.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/print/RPrintUtilities.java
@@ -159,12 +159,8 @@ public abstract class RPrintUtilities {
 				int tabIndex = curLineString.indexOf('\t');
 				while (tabIndex > -1) {
 					int spacesNeeded = tabSizeInSpaces - (tabIndex % tabSizeInSpaces);
-                    StringBuilder stringBuilder = new StringBuilder();
-					for (int i=0; i<spacesNeeded; i++) {
-						stringBuilder.append(" ");
-					}
 					// Note that "\t" is actually a regex for this method.
-					curLineString = curLineString.replaceFirst("\t", stringBuilder.toString());
+					curLineString = curLineString.replaceFirst("\t", " ".repeat(Math.max(0, spacesNeeded)));
 					tabIndex = curLineString.indexOf('\t');
 				}
 			}
@@ -284,12 +280,8 @@ public abstract class RPrintUtilities {
 				int tabIndex = curLineString.indexOf('\t');
 				while (tabIndex > -1) {
 					int spacesNeeded = tabSizeInSpaces - (tabIndex % tabSizeInSpaces);
-                    StringBuilder stringBuilder = new StringBuilder();
-					for (int i=0; i<spacesNeeded; i++) {
-						stringBuilder.append(" ");
-					}
 					// Note that "\t" is actually a regex for this method.
-					curLineString = curLineString.replaceFirst("\t", stringBuilder.toString());
+					curLineString = curLineString.replaceFirst("\t", " ".repeat(Math.max(0, spacesNeeded)));
 					tabIndex = curLineString.indexOf('\t');
 				}
 			}

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaEditorKit.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaEditorKit.java
@@ -1881,12 +1881,7 @@ public class RSyntaxTextAreaEditorKit extends RTextAreaEditorKit {
 				// soft tab behavior provided by RTextArea.replaceSelection().
 				String replacement = "\t";
 				if (textArea.getTabsEmulated()) {
-					StringBuilder sb = new StringBuilder();
-					int temp = textArea.getTabSize();
-					for (int i=0; i<temp; i++) {
-						sb.append(' ');
-					}
-					replacement = sb.toString();
+					replacement = " ".repeat(Math.max(0, textArea.getTabSize()));
 				}
 
 				textArea.beginAtomicEdit();

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RTfToText.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RTfToText.java
@@ -231,11 +231,9 @@ final class RtfToText {
 	 * @throws IOException If an IO error occurs.
 	 */
 	private static String getPlainText(Reader r) throws IOException {
-		try {
+		try (r) {
 			RtfToText converter = new RtfToText(r);
 			return converter.convert();
-		} finally {
-			r.close();
 		}
 	}
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TokenImpl.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TokenImpl.java
@@ -228,11 +228,7 @@ public class TokenImpl implements Token {
 					sb.append(text, lastI, i-lastI);
 					lastI = i+1;
 					if (tabsToSpaces && tabStr==null) {
-                        StringBuilder stringBuilder = new StringBuilder();
-						for (int j=0; j<textArea.getTabSize(); j++) {
-                            stringBuilder.append("&nbsp;");
-						}
-                        tabStr = stringBuilder.toString();
+						tabStr = "&nbsp;".repeat(Math.max(0, textArea.getTabSize()));
 					}
 					sb.append(tabsToSpaces ? tabStr : "&#09;");
 					lastWasSpace = false;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TokenMakerFactory.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TokenMakerFactory.java
@@ -44,12 +44,7 @@ public abstract class TokenMakerFactory {
 	 */
 	public static synchronized TokenMakerFactory getDefaultInstance() {
 		if (defaultInstance ==null) {
-			String clazz;
-			try {
-				clazz= System.getProperty(PROPERTY_DEFAULT_TOKEN_MAKER_FACTORY);
-			} catch (java.security.AccessControlException ace) {
-				clazz = null; // We're in an applet; take default.
-			}
+			String clazz = System.getProperty(PROPERTY_DEFAULT_TOKEN_MAKER_FACTORY);
 			if (clazz==null) {
 				clazz = "org.fife.ui.rsyntaxtextarea.DefaultTokenMakerFactory";
 			}

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/VisibleWhitespaceTokenPainter.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/VisibleWhitespaceTokenPainter.java
@@ -205,7 +205,7 @@ public class VisibleWhitespaceTokenPainter extends DefaultTokenPainter {
 	 */
 	protected void paintTabText(Graphics2D g, float x, float y,
 						float nextTabStop, int ascent, int height) {
-		float halfHeight = height / 2;
+		float halfHeight = height / 2f;
 		float quarterHeight = halfHeight / 2;
 		float ymid = (int)y - ascent + halfHeight;
 		SwingUtils.drawLine(g, x,ymid, nextTabStop,ymid);

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/IconGroup.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/IconGroup.java
@@ -12,7 +12,6 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
-import java.security.AccessControlException;
 import javax.imageio.ImageIO;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
@@ -239,7 +238,7 @@ public class IconGroup {
 				// URLs that are valid but simply don't exist can create -1x-1 ImageIcons
 				return icon.getIconWidth() == -1 ? null : icon;
 			}
-		} catch (AccessControlException | IOException ace) {
+		} catch (IOException ioe) {
 			return null;
 		}
 	}

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextArea.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextArea.java
@@ -527,12 +527,8 @@ public class RTextArea extends RTextAreaBase implements Printable {
 	 * @param size The number of spaces.
 	 * @return The string of spaces.
 	 */
-	private String createSpacer(int size) {
-		StringBuilder sb = new StringBuilder();
-		for (int i=0; i<size; i++) {
-			sb.append(' ');
-		}
-		return sb.toString();
+	private static String createSpacer(int size) {
+		return " ".repeat(Math.max(0, size));
 	}
 
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextAreaBase.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextAreaBase.java
@@ -226,12 +226,9 @@ public abstract class RTextAreaBase extends JTextArea {
 
 		int caretPosition = getCaretPosition();
 		int tabSize = getTabSize();
-		StringBuilder stringBuilder = new StringBuilder();
-		for (int i=0; i<tabSize; i++) {
-			stringBuilder.append(" ");
-		}
+		String stringBuilder = " ".repeat(Math.max(0, tabSize));
 		String text = getText();
-		setText(text.replaceAll(stringBuilder.toString(), "\t"));
+		setText(text.replaceAll(stringBuilder, "\t"));
 		int newDocumentLength = getDocument().getLength();
 
 		// Place the caret back in its proper position.
@@ -261,12 +258,9 @@ public abstract class RTextAreaBase extends JTextArea {
 
 		int caretPosition = getCaretPosition();
 		int tabSize = getTabSize();
-		StringBuilder tabInSpaces = new StringBuilder();
-		for (int i=0; i<tabSize; i++) {
-			tabInSpaces.append(' ');
-		}
+		String tabInSpaces = " ".repeat(Math.max(0, tabSize));
 		String text = getText();
-		setText(text.replaceAll("\t", tabInSpaces.toString()));
+		setText(text.replaceAll("\t", tabInSpaces));
 
 		// Put caret back at same place in document.
 		setCaretPosition(caretPosition);

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/FileLocationTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/FileLocationTest.java
@@ -7,6 +7,7 @@
 package org.fife.ui.rsyntaxtextarea;
 
 import java.io.File;
+import java.net.URI;
 import java.net.URL;
 
 import org.junit.jupiter.api.Assertions;
@@ -86,7 +87,7 @@ class FileLocationTest {
 
 	@Test
 	void testCreate_UrlArg_HttpsUrl() throws Exception {
-		URL url = new URL("https://google.com");
+		URL url = URI.create("https://google.com").toURL();
 		FileLocation loc = FileLocation.create(url);
 		Assertions.assertInstanceOf(URLFileLocation.class, loc);
 		Assertions.assertFalse(loc.isLocal());
@@ -96,7 +97,7 @@ class FileLocationTest {
 
 	@Test
 	void testCreate_UrlArg_FileUrl() throws Exception {
-		URL url = new URL("file:///test.txt");
+		URL url = URI.create("file:///test.txt").toURL();
 		FileLocation loc = FileLocation.create(url);
 		Assertions.assertInstanceOf(FileFileLocation.class, loc);
 		Assertions.assertTrue(loc.isLocal());

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/ParserManagerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/ParserManagerTest.java
@@ -74,7 +74,7 @@ class ParserManagerTest extends AbstractRSyntaxTextAreaTest {
 
 		manager.actionPerformed(new ActionEvent(textArea, 0, null));
 		Assertions.assertEquals(1, manager.getParserNotices().size());
-		Assertions.assertEquals("test", manager.getParserNotices().get(0).getMessage());
+		Assertions.assertEquals("test", manager.getParserNotices().getFirst().getMessage());
 	}
 
 
@@ -121,7 +121,7 @@ class ParserManagerTest extends AbstractRSyntaxTextAreaTest {
 
 		manager.actionPerformed(new ActionEvent(textArea, 0, null));
 		Assertions.assertEquals(1, manager.getParserNotices().size());
-		Assertions.assertEquals("test", manager.getParserNotices().get(0).getMessage());
+		Assertions.assertEquals("test", manager.getParserNotices().getFirst().getMessage());
 
 		manager.clearParsers();
 		Assertions.assertEquals(0, manager.getParserNotices().size());

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/ThemeTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/ThemeTest.java
@@ -479,7 +479,7 @@ class ThemeTest {
 
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		theme.save(baos);
-		String actual = new String(baos.toByteArray(), StandardCharsets.UTF_8);
+		String actual = baos.toString(StandardCharsets.UTF_8);
 		baos.close();
 
 		ByteArrayInputStream bin = new ByteArrayInputStream(actual.getBytes(StandardCharsets.UTF_8));

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/focusabletip/FocusableTipTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/focusabletip/FocusableTipTest.java
@@ -18,6 +18,7 @@ import javax.swing.event.HyperlinkListener;
 import java.awt.*;
 import java.awt.event.MouseEvent;
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 
 /**
@@ -37,7 +38,7 @@ class FocusableTipTest extends AbstractRSyntaxTextAreaTest {
 		FocusableTip tip = new TestableFocusableTip(textArea, null);
 
 		Assertions.assertNull(tip.getImageBase());
-		URL url = new URL("https://www.google.com");
+		URL url = URI.create("https://www.google.com").toURL();
 		tip.setImageBase(url);
 		Assertions.assertEquals(url, tip.getImageBase());
 	}

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/focusabletip/TipWindowTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/focusabletip/TipWindowTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import javax.swing.*;
 import java.io.IOException;
-import java.net.URL;
+import java.net.URI;
 
 
 /**
@@ -87,7 +87,7 @@ class TipWindowTest {
 		JFrame owner = new JFrame();
 		RSyntaxTextArea textArea = new RSyntaxTextArea();
 		FocusableTip focusableTip = new FocusableTipTest.TestableFocusableTip(textArea, null);
-		focusableTip.setImageBase(new URL("https://google.com"));
+		focusableTip.setImageBase(URI.create("https://google.com").toURL());
 
 		new TipWindow(owner, focusableTip, "test");
 	}
@@ -107,7 +107,7 @@ class TipWindowTest {
 		JFrame owner = new JFrame();
 		RSyntaxTextArea textArea = new RSyntaxTextArea();
 		FocusableTip focusableTip = new FocusableTipTest.TestableFocusableTip(textArea, null);
-		focusableTip.setImageBase(new URL("https://google.com"));
+		focusableTip.setImageBase(URI.create("https://google.com").toURL());
 
 		TipWindow tw = new TipWindow(owner, focusableTip, "test");
 		tw.setHyperlinkListener(e -> {});

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/folding/CurlyFoldParserTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/folding/CurlyFoldParserTest.java
@@ -36,7 +36,7 @@ class CurlyFoldParserTest {
 		List<Fold> folds = parser.getFolds(textArea);
 
 		Assertions.assertEquals(1, folds.size());
-		Fold importFold = folds.get(0);
+		Fold importFold = folds.getFirst();
 		Assertions.assertEquals(0, importFold.getStartOffset());
 		Assertions.assertEquals(code.lastIndexOf(";"), importFold.getEndOffset());
 
@@ -59,7 +59,7 @@ class CurlyFoldParserTest {
 		List<Fold> folds = parser.getFolds(textArea);
 
 		Assertions.assertEquals(1, folds.size());
-		Fold importFold = folds.get(0);
+		Fold importFold = folds.getFirst();
 		Assertions.assertEquals(0, importFold.getStartOffset());
 		Assertions.assertEquals(code.lastIndexOf(";"), importFold.getEndOffset());
 
@@ -87,7 +87,7 @@ class CurlyFoldParserTest {
 
 		Assertions.assertEquals(1, folds.size());
 
-		Fold topLevelFold = folds.get(0);
+		Fold topLevelFold = folds.getFirst();
 		Assertions.assertEquals(FoldType.CODE, topLevelFold.getFoldType());
 		int firstCurlyOffs = code.indexOf('{');
 		int lastCurlyOffs = code.lastIndexOf('}');

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/folding/FoldTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/folding/FoldTest.java
@@ -88,7 +88,7 @@ class FoldTest extends AbstractRSyntaxTextAreaTest {
 
 		RSyntaxTextArea textArea = createTextArea(CODE_WITH_CHILDREN);
 
-		Fold fold = new CurlyFoldParser().getFolds(textArea).get(0);
+		Fold fold = new CurlyFoldParser().getFolds(textArea).getFirst();
 		Assertions.assertEquals(2, fold.getChildren().size());
 	}
 

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/folding/HtmlFoldParserTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/folding/HtmlFoldParserTest.java
@@ -56,7 +56,7 @@ class HtmlFoldParserTest {
 		List<Fold> folds = parser.getFolds(textArea);
 
 		Assertions.assertEquals(1, folds.size());
-		Fold fold = folds.get(0);
+		Fold fold = folds.getFirst();
 		Assertions.assertEquals(FoldType.CODE, fold.getFoldType());
 		Assertions.assertEquals(0, fold.getChildCount());
 		Assertions.assertEquals(1, fold.getLineCount());
@@ -79,7 +79,7 @@ class HtmlFoldParserTest {
 		List<Fold> folds = parser.getFolds(textArea);
 
 		Assertions.assertEquals(1, folds.size());
-		Fold fold = folds.get(0);
+		Fold fold = folds.getFirst();
 		Assertions.assertEquals(FoldType.CODE, fold.getFoldType());
 		Assertions.assertEquals(0, fold.getChildCount());
 		Assertions.assertEquals(2, fold.getLineCount());
@@ -115,7 +115,7 @@ class HtmlFoldParserTest {
 		List<Fold> folds = parser.getFolds(textArea);
 
 		Assertions.assertEquals(1, folds.size());
-		Fold fold = folds.get(0);
+		Fold fold = folds.getFirst();
 		Assertions.assertEquals(FoldType.COMMENT, fold.getFoldType());
 		Assertions.assertEquals(0, fold.getChildCount());
 		Assertions.assertEquals(1, fold.getLineCount());
@@ -157,7 +157,7 @@ class HtmlFoldParserTest {
 		List<Fold> folds = parser.getFolds(textArea);
 
 		Assertions.assertEquals(1, folds.size());
-		Fold fold = folds.get(0);
+		Fold fold = folds.getFirst();
 		Assertions.assertEquals(FoldType.COMMENT, fold.getFoldType());
 		Assertions.assertEquals(0, fold.getChildCount());
 		Assertions.assertEquals(1, fold.getLineCount());
@@ -185,7 +185,7 @@ class HtmlFoldParserTest {
 		List<Fold> folds = parser.getFolds(textArea);
 
 		Assertions.assertEquals(1, folds.size());
-		Fold fold = folds.get(0);
+		Fold fold = folds.getFirst();
 		Assertions.assertEquals(FoldType.COMMENT, fold.getFoldType());
 		Assertions.assertEquals(0, fold.getChildCount());
 		Assertions.assertEquals(2, fold.getLineCount());
@@ -231,7 +231,7 @@ class HtmlFoldParserTest {
 		List<Fold> folds = parser.getFolds(textArea);
 
 		Assertions.assertEquals(1, folds.size());
-		Fold fold = folds.get(0);
+		Fold fold = folds.getFirst();
 		Assertions.assertEquals(FoldType.CODE, fold.getFoldType());
 		Assertions.assertEquals(0, fold.getChildCount());
 		Assertions.assertEquals(1, fold.getLineCount());
@@ -259,7 +259,7 @@ class HtmlFoldParserTest {
 		List<Fold> folds = parser.getFolds(textArea);
 
 		Assertions.assertEquals(1, folds.size());
-		Fold fold = folds.get(0);
+		Fold fold = folds.getFirst();
 		Assertions.assertEquals(FoldType.CODE, fold.getFoldType());
 		Assertions.assertEquals(0, fold.getChildCount());
 		Assertions.assertEquals(2, fold.getLineCount());

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/folding/JsonFoldParserTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/folding/JsonFoldParserTest.java
@@ -48,7 +48,7 @@ class JsonFoldParserTest {
 
 		Assertions.assertEquals(1, folds.size());
 
-		Fold firstFold = folds.get(0);
+		Fold firstFold = folds.getFirst();
 		Assertions.assertEquals(FoldType.CODE, firstFold.getFoldType());
 		Assertions.assertEquals(0, firstFold.getStartOffset());
 		Assertions.assertEquals(code.lastIndexOf('}'), firstFold.getEndOffset());

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/folding/LatexFoldParserTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/folding/LatexFoldParserTest.java
@@ -44,7 +44,7 @@ class LatexFoldParserTest {
 
 		Assertions.assertEquals(1, folds.size());
 
-		Fold firstFold = folds.get(0);
+		Fold firstFold = folds.getFirst();
 		Assertions.assertEquals(FoldType.CODE, firstFold.getFoldType());
 		Assertions.assertEquals(code.indexOf("\\begin"), firstFold.getStartOffset());
 		Assertions.assertEquals(code.lastIndexOf("\\end"), firstFold.getEndOffset());

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/folding/LinesWithContentFoldParserTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/folding/LinesWithContentFoldParserTest.java
@@ -42,7 +42,7 @@ class LinesWithContentFoldParserTest {
 
 		Assertions.assertEquals(2, folds.size());
 
-		Fold firstFold = folds.get(0);
+		Fold firstFold = folds.getFirst();
 		Assertions.assertEquals(FoldType.CODE, firstFold.getFoldType());
 		Assertions.assertEquals(0, firstFold.getStartOffset());
 		// End of fold is the end of hte last line containing content

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/folding/NsisFoldParserTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/folding/NsisFoldParserTest.java
@@ -53,7 +53,7 @@ class NsisFoldParserTest {
 
 		Assertions.assertEquals(3, folds.size());
 
-		Fold firstFold = folds.get(0);
+		Fold firstFold = folds.getFirst();
 		Assertions.assertEquals(FoldType.COMMENT, firstFold.getFoldType());
 		Assertions.assertEquals(code.indexOf("/*"), firstFold.getStartOffset());
 		Assertions.assertEquals(code.indexOf("*/") + 1, firstFold.getEndOffset());

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/folding/PythonFoldParserTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/folding/PythonFoldParserTest.java
@@ -62,7 +62,7 @@ class PythonFoldParserTest {
 		Assertions.assertEquals(2, folds.size());
 
 		// First top-level fold is def main()
-		Fold topLevelFold = folds.get(0);
+		Fold topLevelFold = folds.getFirst();
 		Assertions.assertEquals(FoldType.CODE, topLevelFold.getFoldType());
 		Assertions.assertEquals(code.indexOf("def main"), topLevelFold.getStartOffset());
 		Assertions.assertEquals(2, topLevelFold.getChildCount());

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/folding/YamlFoldParserTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/folding/YamlFoldParserTest.java
@@ -42,7 +42,7 @@ class YamlFoldParserTest {
 
 		Assertions.assertEquals(2, folds.size());
 
-		Fold firstFold = folds.get(0);
+		Fold firstFold = folds.getFirst();
 		Assertions.assertEquals(FoldType.CODE, firstFold.getFoldType());
 		Assertions.assertEquals(0, firstFold.getStartOffset());
 		Assertions.assertEquals(code.indexOf("Item"), firstFold.getEndOffset());

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/parser/DefaultParseResultTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/parser/DefaultParseResultTest.java
@@ -115,7 +115,7 @@ class DefaultParseResultTest {
 		res.addNotice(notice);
 		List<ParserNotice> notices = res.getNotices();
 		Assertions.assertEquals(1, notices.size());
-		Assertions.assertEquals(notice, notices.get(0));
+		Assertions.assertEquals(notice, notices.getFirst());
 
 	}
 

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/parser/TaskTagParserTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/parser/TaskTagParserTest.java
@@ -63,7 +63,7 @@ class TaskTagParserTest {
 		// Note that the parser does not understand EOL vs. MLC comments, so
 		// it just returns everything from the start of the task to the end of
 		// the line.
-		Assertions.assertEquals("TODO: Fix this */", notices.get(0).getToolTipText());
+		Assertions.assertEquals("TODO: Fix this */", notices.getFirst().getToolTipText());
 
 	}
 

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/parser/ToolTipInfoTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/parser/ToolTipInfoTest.java
@@ -7,6 +7,7 @@
 package org.fife.ui.rsyntaxtextarea.parser;
 
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 
 import javax.swing.event.HyperlinkEvent;
@@ -31,7 +32,7 @@ class ToolTipInfoTest {
 	@BeforeEach
 	void setUp() throws MalformedURLException {
 		mhl = new MockHyperlinkListener();
-		imageBase = new URL("file:///localhost/images");
+		imageBase = URI.create("file:///localhost/images").toURL();
 	}
 
 

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/parser/XmlParserTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/parser/XmlParserTest.java
@@ -91,7 +91,7 @@ class XmlParserTest {
 		Assertions.assertEquals(1, res.getLastLineParsed());
 		List<ParserNotice> notices = res.getNotices();
 		Assertions.assertEquals(1, notices.size());
-		ParserNotice notice = notices.get(0);
+		ParserNotice notice = notices.getFirst();
 		Assertions.assertEquals(ParserNotice.Level.ERROR, notice.getLevel());
 
 	}
@@ -115,7 +115,7 @@ class XmlParserTest {
 		Assertions.assertEquals(2, res.getLastLineParsed());
 		List<ParserNotice> notices = res.getNotices();
 		Assertions.assertEquals(1, notices.size());
-		ParserNotice notice = notices.get(0);
+		ParserNotice notice = notices.getFirst();
 		Assertions.assertEquals(ParserNotice.Level.ERROR, notice.getLevel());
 
 	}

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/LineHighlightManagerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/LineHighlightManagerTest.java
@@ -72,7 +72,7 @@ class LineHighlightManagerTest {
 		lhm.removeLineHighlight(tag1);
 		List<Object> remainingTags = lhm.getCurrentLineHighlightTags();
 		Assertions.assertEquals(1, remainingTags.size());
-		Assertions.assertSame(tag2, remainingTags.get(0));
+		Assertions.assertSame(tag2, remainingTags.getFirst());
 	}
 
 
@@ -89,7 +89,7 @@ class LineHighlightManagerTest {
 		lhm.removeLineHighlight(tag2);
 		List<Object> remainingTags = lhm.getCurrentLineHighlightTags();
 		Assertions.assertEquals(1, remainingTags.size());
-		Assertions.assertSame(tag1, remainingTags.get(0));
+		Assertions.assertSame(tag1, remainingTags.getFirst());
 	}
 
 

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/RTextAreaHighlighterTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/RTextAreaHighlighterTest.java
@@ -81,7 +81,7 @@ class RTextAreaHighlighterTest extends AbstractRTextAreaTest {
 		h.addMarkAllHighlight(1, 3, new ChangeableHighlightPainter());
 		List<DocumentRange> ranges = h.getMarkAllHighlightRanges();
 		Assertions.assertEquals(1, ranges.size());
-		DocumentRange range = ranges.get(0);
+		DocumentRange range = ranges.getFirst();
 		Assertions.assertEquals(new DocumentRange(1, 3), range);
 	}
 

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,10 @@ subprojects {
 
     tasks.withType(JavaCompile).configureEach {
         options.encoding = 'UTF-8'
+        // Only need `options.release` set for `compileJava`, not for tests
+        options.debug = true
+        options.debugOptions.debugLevel = 'source,vars,lines'
+        options.compilerArgs << '-Xlint:deprecation' << '-Xlint:unchecked'
     }
 
     test {
@@ -89,9 +93,6 @@ subprojects {
 
     compileJava {
         options.release = Integer.parseInt(javaLanguageVersion)
-        options.debug = true
-        options.debugOptions.debugLevel = 'source,vars,lines'
-        options.compilerArgs << '-Xlint:deprecation' << '-Xlint:unchecked'
     }
 }
 


### PR DESCRIPTION
This PR includes refactoring for newer APIs with our migration to building with JDK 25 and targetting Java 11 at runtime:

1. Use Java 11 APIs that simplify code where possible everywhere
2. Use newer APIs up to Java 25 in unit tests only (they run with Java 25 and are not impacted by `--release 11`)
3. Make some preemptive code changes for APIs that are deprecated post-Java 11 and can be made now (example - `new URL(String)` deprecated in Java 20)
