### PR TITLE
chore: Prefer TokenTypes over Token for constants

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/AbstractJFlexCTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/AbstractJFlexCTokenMaker.java
@@ -84,7 +84,7 @@ public abstract class AbstractJFlexCTokenMaker extends AbstractJFlexTokenMaker {
 
 	@Override
 	public boolean getMarkOccurrencesOfTokenType(int type) {
-		return type==Token.IDENTIFIER || type==Token.FUNCTION;
+		return type==TokenTypes.IDENTIFIER || type==TokenTypes.FUNCTION;
 	}
 
 
@@ -146,8 +146,8 @@ public abstract class AbstractJFlexCTokenMaker extends AbstractJFlexTokenMaker {
 			}
 
 			// Only in MLC's should we try this
-			if (type==Token.COMMENT_DOCUMENTATION ||
-					type==Token.COMMENT_MULTILINE) {
+			if (type==TokenTypes.COMMENT_DOCUMENTATION ||
+					type==TokenTypes.COMMENT_MULTILINE) {
 				insertBreakInMLC(e, rsta, line);
 			}
 			else {

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/AbstractTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/AbstractTokenMaker.java
@@ -25,8 +25,8 @@ public abstract class AbstractTokenMaker extends TokenMakerBase {
 	/**
 	 * Hash table of words to highlight and what token type they are.
 	 * The keys are the words to highlight, and their values are the
-	 * token types, for example, <code>Token.RESERVED_WORD</code> or
-	 * <code>Token.FUNCTION</code>.
+	 * token types, for example, <code>TokenTypes.RESERVED_WORD</code> or
+	 * <code>TokenTypes.FUNCTION</code>.
 	 */
 	protected TokenMap wordsToHighlight;
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/DefaultTokenFactory.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/DefaultTokenFactory.java
@@ -89,7 +89,7 @@ class DefaultTokenFactory implements TokenFactory {
 	public TokenImpl createToken() {
 		TokenImpl token = tokenList[currentFreeToken];
 		token.text = null;
-		token.setType(Token.NULL);
+		token.setType(TokenTypes.NULL);
 		token.setOffset(-1);
 		token.setNextToken(null);
 		currentFreeToken++;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/DefaultTokenPainter.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/DefaultTokenPainter.java
@@ -183,7 +183,7 @@ public class DefaultTokenPainter implements TokenPainter {
 		}
 
 		// Don't check if it's whitespace - some TokenMakers may return types
-		// other than Token.WHITESPACE for spaces (such as Token.IDENTIFIER).
+		// other than TokenTypes.WHITESPACE for spaces (such as TokenTypes.IDENTIFIER).
 		// This also allows us to paint tab lines for MLC's.
 		if (host.getPaintTabLines() && origX==host.getMargin().left) {// && isWhitespace()) {
 			paintTabLines(token, origX, y, nextX, g, e, host);
@@ -227,12 +227,12 @@ public class DefaultTokenPainter implements TokenPainter {
 	protected void paintTabLines(Token token, float x, float y, float endX,
 				Graphics2D g, TabExpander e, RSyntaxTextArea host) {
 
-		// We allow tab lines to be painted in more than just Token.WHITESPACE,
-		// i.e. for MLC's and Token.IDENTIFIERS (for TokenMakers that return
+		// We allow tab lines to be painted in more than just TokenTypes.WHITESPACE,
+		// i.e. for MLC's and TokenTypes.IDENTIFIERs (for TokenMakers that return
 		// whitespace as identifiers for performance).  But we only paint tab
 		// lines for the leading whitespace in the token.  So, if this isn't a
 		// WHITESPACE token, figure out the leading whitespace's length.
-		if (token.getType()!=Token.WHITESPACE) {
+		if (token.getType()!=TokenTypes.WHITESPACE) {
 			int offs = 0;
 			for (; offs<token.length(); offs++) {
 				if (!RSyntaxUtilities.isWhitespace(token.charAt(offs))) {

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/HtmlOccurrenceMarker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/HtmlOccurrenceMarker.java
@@ -168,7 +168,7 @@ public class HtmlOccurrenceMarker implements OccurrenceMarker {
 		Token toMark = null;
 
 		while (t!=null && t.isPaintable()) {
-			if (t.getType()==Token.MARKUP_TAG_NAME) {
+			if (t.getType()==TokenTypes.MARKUP_TAG_NAME) {
 				toMark = t;
 			}
 			// Check for the token containing the caret before checking
@@ -177,14 +177,14 @@ public class HtmlOccurrenceMarker implements OccurrenceMarker {
 				// Some languages, like PHP, mark functions/variables (PHP,
 				// JavaScirpt) as well as HTML tags.
 				if (occurrenceMarker.isValidType(textArea, t) &&
-						t.getType()!=Token.MARKUP_TAG_NAME) {
+						t.getType()!=TokenTypes.MARKUP_TAG_NAME) {
 					return t;
 				}
 				if (t.containsPosition(dot)) {
 					break;
 				}
 			}
-			if (t.getType()==Token.MARKUP_TAG_DELIMITER) {
+			if (t.getType()==TokenTypes.MARKUP_TAG_DELIMITER) {
 				if (t.isSingleChar('>') || t.is(TAG_SELF_CLOSE)) {
 					toMark = null;
 				}
@@ -213,7 +213,7 @@ public class HtmlOccurrenceMarker implements OccurrenceMarker {
 	public void markOccurrences(RSyntaxDocument doc, Token t,
 			RSyntaxTextAreaHighlighter h, SmartHighlightPainter p) {
 
-		if (t.getType()!=Token.MARKUP_TAG_NAME) {
+		if (t.getType()!=TokenTypes.MARKUP_TAG_NAME) {
 			DefaultOccurrenceMarker.markOccurrencesOfToken(doc, t, h, p);
 			return;
 		}
@@ -233,7 +233,7 @@ public class HtmlOccurrenceMarker implements OccurrenceMarker {
 		boolean forward = true;
 		t = doc.getTokenListForLine(curLine);
 		while (t!=null && t.isPaintable()) {
-			if (t.getType()==Token.MARKUP_TAG_DELIMITER) {
+			if (t.getType()==TokenTypes.MARKUP_TAG_DELIMITER) {
 				if (t.isSingleChar('<') && t.getOffset()+1==tokenOffs) {
 					// Don't try to match a tag that is optionally closed (or
 					// closing is forbidden entirely).
@@ -264,7 +264,7 @@ public class HtmlOccurrenceMarker implements OccurrenceMarker {
 			do {
 
 				while (t!=null && t.isPaintable()) {
-					if (t.getType()==Token.MARKUP_TAG_DELIMITER) {
+					if (t.getType()==TokenTypes.MARKUP_TAG_DELIMITER) {
 						if (t.is(CLOSE_TAG_START)) {
 							Token match = t.getNextToken();
 							if (match!=null && match.is(lexeme)) {
@@ -318,7 +318,7 @@ public class HtmlOccurrenceMarker implements OccurrenceMarker {
 			do {
 
 				while (t!=null && t.getOffset()<endBefore && t.isPaintable()) {
-					if (t.getType()==Token.MARKUP_TAG_DELIMITER) {
+					if (t.getType()==TokenTypes.MARKUP_TAG_DELIMITER) {
 						if (t.isSingleChar('<')) {
 							Token next = t.getNextToken();
 							if (next!=null) {

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxDocument.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxDocument.java
@@ -104,7 +104,7 @@ public class RSyntaxDocument extends RDocument implements Iterable<Token>,
 	public RSyntaxDocument(TokenMakerFactory tmf, String syntaxStyle) {
 		putProperty(tabSizeAttribute, 5);
 		lastTokensOnLines = new DynamicIntArray(400);
-		lastTokensOnLines.add(Token.NULL); // Initial (empty) line.
+		lastTokensOnLines.add(TokenTypes.NULL); // Initial (empty) line.
 		s = new Segment();
 		setTokenMakerFactory(tmf);
 		setSyntaxStyle(syntaxStyle);
@@ -139,7 +139,7 @@ public class RSyntaxDocument extends RDocument implements Iterable<Token>,
 		int line = lineMap.getElementIndex(e.getOffset());
 		int previousLine = line - 1;
 		int previousTokenType = (previousLine>-1 ?
-					lastTokensOnLines.get(previousLine) : Token.NULL);
+					lastTokensOnLines.get(previousLine) : TokenTypes.NULL);
 
 		// If entire lines were added...
 		if (added!=null && added.length>0) {
@@ -211,7 +211,7 @@ public class RSyntaxDocument extends RDocument implements Iterable<Token>,
 			int line = change.getIndex();	// First line entirely removed.
 			int previousLine = line - 1;	// Line before that.
 			int previousTokenType = (previousLine>-1 ?
-					lastTokensOnLines.get(previousLine) : Token.NULL);
+					lastTokensOnLines.get(previousLine) : TokenTypes.NULL);
 
 			Element[] added = change.getChildrenAdded();
 			int numAdded = added==null ? 0 : added.length;
@@ -239,7 +239,7 @@ public class RSyntaxDocument extends RDocument implements Iterable<Token>,
 
 			int previousLine = line - 1;
 			int previousTokenType = (previousLine>-1 ?
-					lastTokensOnLines.get(previousLine) : Token.NULL);
+					lastTokensOnLines.get(previousLine) : TokenTypes.NULL);
 			//System.err.println("previousTokenType for line : " + previousLine + " is " + previousTokenType);
 			// Update last tokens for lines below until they've stopped changing.
 			updateLastTokensBelow(line, numLines, previousTokenType);
@@ -412,7 +412,7 @@ public class RSyntaxDocument extends RDocument implements Iterable<Token>,
 			ble.printStackTrace();
 			return new TokenImpl();
 		}
-		int initialTokenType = line==0 ? Token.NULL :
+		int initialTokenType = line==0 ? TokenTypes.NULL :
 								getLastTokenTypeOnLine(line-1);
 
 		//return tokenMaker.getTokenList(s, initialTokenType, startOffset);
@@ -648,7 +648,7 @@ public class RSyntaxDocument extends RDocument implements Iterable<Token>,
 		// is the same.
 		Element map = getDefaultRootElement();
 		int numLines = map.getElementCount();
-		int lastTokenType = Token.NULL;
+		int lastTokenType = TokenTypes.NULL;
 		for (int i=0; i<numLines; i++) {
 			setSharedSegment(i);
 			lastTokenType = tokenMaker.getLastTokenTypeOnLine(s, lastTokenType);

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextArea.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextArea.java
@@ -1881,7 +1881,7 @@ public class RSyntaxTextArea extends RTextArea implements SyntaxConstants {
 				// in getTokenListFor()
 				int docOffs = map.getElement(line).getEndOffset()-1;
 				t = new TokenImpl(new char[] { '\n' }, 0,0, docOffs,
-								Token.WHITESPACE, 0);
+								TokenTypes.WHITESPACE, 0);
 				lastToken.setNextToken(t);
 				lastToken = t;
 			}

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaEditorKit.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaEditorKit.java
@@ -461,7 +461,7 @@ public class RSyntaxTextAreaEditorKit extends RTextAreaEditorKit {
 						Token t = doc.getTokenListForLine(
 							rsta.getCaretLineNumber());
 						t = RSyntaxUtilities.getTokenAtOffset(t, dot-1);
-						if (t!=null && t.getType()==Token.MARKUP_TAG_DELIMITER) { // Closing tag
+						if (t!=null && t.getType()==TokenTypes.MARKUP_TAG_DELIMITER) { // Closing tag
 							String tagName = discoverTagName(doc, dot);
 							if (tagName!=null) {
 								rsta.replaceSelection(tagName + (char)(ch+2));
@@ -502,16 +502,16 @@ public class RSyntaxTextAreaEditorKit extends RTextAreaEditorKit {
 				Token t = doc.getTokenListForLine(i);
 				while (t!=null && t.isPaintable()) {
 
-					if (t.getType()==Token.MARKUP_TAG_DELIMITER) {
+					if (t.getType()==TokenTypes.MARKUP_TAG_DELIMITER) {
 						if (t.isSingleChar('<') || t.isSingleChar('[')) {
 							t = t.getNextToken();
 							while (t!=null && t.isPaintable()) {
-								if (t.getType()==Token.MARKUP_TAG_NAME ||
+								if (t.getType()==TokenTypes.MARKUP_TAG_NAME ||
 									// Being lenient here and also checking
 									// for attributes, in case they
 									// (incorrectly) have whitespace between
 									// the '<' char and the element name.
-									t.getType()==Token.MARKUP_TAG_ATTRIBUTE) {
+									t.getType()==TokenTypes.MARKUP_TAG_ATTRIBUTE) {
 									stack.push(t.getLexeme());
 									break;
 								}
@@ -1529,7 +1529,7 @@ public class RSyntaxTextAreaEditorKit extends RTextAreaEditorKit {
 											 int languageIndex) {
 			int openCount = 0;
 			for (Token t : doc) {
-				if (t.getType()==Token.SEPARATOR && t.length()==1 &&
+				if (t.getType()==TokenTypes.SEPARATOR && t.length()==1 &&
 					t.getLanguageIndex()==languageIndex) {
 					char ch = t.charAt(0);
 					if (ch=='{') {

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxUtilities.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxUtilities.java
@@ -445,7 +445,7 @@ public final class RSyntaxUtilities implements SwingConstants {
 			Token token = doc.getTokenListForLine(curLine);
 			token = RSyntaxUtilities.getTokenAtOffset(token, caretPosition);
 			// All brackets are always returned as "separators."
-			if (token.getType()!=Token.SEPARATOR) {
+			if (token.getType()!=TokenTypes.SEPARATOR) {
 				return input;
 			}
 			int languageIndex = token.getLanguageIndex();
@@ -484,7 +484,7 @@ public final class RSyntaxUtilities implements SwingConstants {
 							}
 							int offset = start + (i-segOffset);
 							token = RSyntaxUtilities.getTokenAtOffset(token, offset);
-							if (token.getType()==Token.SEPARATOR &&
+							if (token.getType()==TokenTypes.SEPARATOR &&
 									token.getLanguageIndex()==languageIndex) {
 								numEmbedded++;
 							}
@@ -497,7 +497,7 @@ public final class RSyntaxUtilities implements SwingConstants {
 							}
 							int offset = start + (i-segOffset);
 							token = RSyntaxUtilities.getTokenAtOffset(token, offset);
-							if (token.getType()==Token.SEPARATOR &&
+							if (token.getType()==TokenTypes.SEPARATOR &&
 									token.getLanguageIndex()==languageIndex) {
 								if (numEmbedded==0) {
 									if (textArea.isCodeFoldingEnabled() &&
@@ -558,7 +558,7 @@ public final class RSyntaxUtilities implements SwingConstants {
 							}
 							int offset = start + (i-segOffset);
 							t2 = RSyntaxUtilities.getTokenAtOffset(token, offset);
-							if (t2.getType()==Token.SEPARATOR &&
+							if (t2.getType()==TokenTypes.SEPARATOR &&
 									token.getLanguageIndex()==languageIndex) {
 								numEmbedded++;
 							}
@@ -571,7 +571,7 @@ public final class RSyntaxUtilities implements SwingConstants {
 							}
 							int offset = start + (i-segOffset);
 							t2 = RSyntaxUtilities.getTokenAtOffset(token, offset);
-							if (t2.getType()==Token.SEPARATOR &&
+							if (t2.getType()==TokenTypes.SEPARATOR &&
 									token.getLanguageIndex()==languageIndex) {
 								if (numEmbedded==0) {
 									input.setLocation(caretPosition, offset);
@@ -846,7 +846,7 @@ public final class RSyntaxUtilities implements SwingConstants {
 		if (token==null) {
 			return 0;
 		}
-		else if (token.getType()==Token.NULL) {
+		else if (token.getType()==TokenTypes.NULL) {
 			int line = c.getLineOfOffset(offs);	// Sure to be >0 ??
 			return c.getLineStartOffset(line-1);
 		}
@@ -880,7 +880,7 @@ public final class RSyntaxUtilities implements SwingConstants {
 		if (token==null) {
 			return c.getDocument().getLength();
 		}
-		else if (token.getType()==Token.NULL) {
+		else if (token.getType()==TokenTypes.NULL) {
 			int line = c.getLineOfOffset(offs);	// Sure to be > c.getLineCount()-1 ??
 //			return c.getLineStartOffset(line+1);
 FoldManager fm = c.getFoldManager();
@@ -1257,10 +1257,10 @@ return c.getLineStartOffset(line);
 					ch=='&'
 				)) ||
 				/* Operators "==", "===", "!=", "!==", "&&", "||" */
-				(t.getType()==Token.OPERATOR &&
+				(t.getType()==TokenTypes.OPERATOR &&
 					(t.charAt(t.length()-1)=='=' ||
 					t.is(JS_AND) || t.is(JS_OR))) ||
-				t.is(Token.RESERVED_WORD_2, JS_KEYWORD_RETURN);
+				t.is(TokenTypes.RESERVED_WORD_2, JS_KEYWORD_RETURN);
 	}
 
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/SyntaxView.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/SyntaxView.java
@@ -174,8 +174,8 @@ public class SyntaxView extends View implements TabExpander,
 	 * @param y The y-coordinate at which to render.
 	 */
 	static void drawEOLMarker(RSyntaxTextArea textArea, Graphics2D g, float x, float y) {
-		g.setColor(textArea.getForegroundForTokenType(Token.WHITESPACE));
-		g.setFont(textArea.getFontForTokenType(Token.WHITESPACE));
+		g.setColor(textArea.getForegroundForTokenType(TokenTypes.WHITESPACE));
+		g.setFont(textArea.getFontForTokenType(TokenTypes.WHITESPACE));
 		g.drawString(EOL_MARKER, x, y);
 	}
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/Token.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/Token.java
@@ -218,7 +218,7 @@ public interface Token extends TokenTypes {
 	 *        offset.
 	 * @return The position (in the document, NOT into the token list!) that
 	 *         covers the pixel location.  If <code>tokenList</code> is
-	 *         <code>null</code> or has type <code>Token.NULL</code>, then
+	 *         <code>null</code> or has type <code>TokenTypes.NULL</code>, then
 	 *         <code>-1</code> is returned; the caller should recognize this and
 	 *         return the actual end position of the (empty) line.
 	 */
@@ -439,7 +439,7 @@ public interface Token extends TokenTypes {
 	 * Returns whether this token is "paintable;" i.e., whether
 	 * the type of this token is one such that it has an associated syntax
 	 * style.  What this boils down to is whether the token type is greater
-	 * than <code>Token.NULL</code>.
+	 * than <code>TokenTypes.NULL</code>.
 	 *
 	 * @return Whether this token is paintable.
 	 */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TokenImpl.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TokenImpl.java
@@ -663,7 +663,7 @@ public class TokenImpl implements Token {
 
 	@Override
 	public boolean isPaintable() {
-		return getType()>Token.NULL;
+		return getType()>TokenTypes.NULL;
 	}
 
 
@@ -923,7 +923,7 @@ public class TokenImpl implements Token {
 	@Override
 	public String toString() {
 		return "[Token: " +
-			(getType()==Token.NULL ? "<null token>" :
+			(getType()==TokenTypes.NULL ? "<null token>" :
 				"text: '" +
 					(text==null ? "<null>" : getLexeme() + "'; " +
 	       		"offset: " + getOffset() + "; type: " + getType() + "; " +

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/VisibleWhitespaceTokenPainter.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/VisibleWhitespaceTokenPainter.java
@@ -161,7 +161,7 @@ public class VisibleWhitespaceTokenPainter extends DefaultTokenPainter {
 		}
 
 		// Don't check if it's whitespace - some TokenMakers may return types
-		// other than Token.WHITESPACE for spaces (such as Token.IDENTIFIER).
+		// other than TokenTypes.WHITESPACE for spaces (such as TokenTypes.IDENTIFIER).
 		// This also allows us to paint tab lines for MLC's.
 		if (host.getPaintTabLines() && origX==host.getMargin().left) {// && isWhitespace()) {
 			paintTabLines(token, origX, y, nextX, g, e, host);

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/WrappedSyntaxView.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/WrappedSyntaxView.java
@@ -239,7 +239,7 @@ public class WrappedSyntaxView extends BoxView implements TabExpander,
 		// If this line is an empty line, then the token list is simply a
 		// null token.  In this case, the line highlight will be skipped in
 		// the loop below, so unfortunately we must manually do it here.
-		if (token!=null && token.getType()==Token.NULL) {
+		if (token!=null && token.getType()==TokenTypes.NULL) {
 			h.paintLayeredHighlights(g, p0,p1, r, host, this);
 			return;
 		}
@@ -324,7 +324,7 @@ public class WrappedSyntaxView extends BoxView implements TabExpander,
 		// If this line is an empty line, then the token list is simply a
 		// null token.  In this case, the line highlight will be skipped in
 		// the loop below, so unfortunately we must manually do it here.
-		if (token!=null && token.getType()==Token.NULL) {
+		if (token!=null && token.getType()==TokenTypes.NULL) {
 			h.paintLayeredHighlights(g, p0,p1, r, host, this);
 			return;
 		}

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/XmlOccurrenceMarker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/XmlOccurrenceMarker.java
@@ -59,7 +59,7 @@ public class XmlOccurrenceMarker implements OccurrenceMarker {
 		boolean forward = true;
 		t = doc.getTokenListForLine(curLine);
 		while (t!=null && t.isPaintable()) {
-			if (t.getType()==Token.MARKUP_TAG_DELIMITER) {
+			if (t.getType()==TokenTypes.MARKUP_TAG_DELIMITER) {
 				if (t.isSingleChar('<') && t.getOffset()+1==tokenOffs) {
 					found = true;
 					break;
@@ -84,7 +84,7 @@ public class XmlOccurrenceMarker implements OccurrenceMarker {
 			do {
 
 				while (t!=null && t.isPaintable()) {
-					if (t.getType()==Token.MARKUP_TAG_DELIMITER) {
+					if (t.getType()==TokenTypes.MARKUP_TAG_DELIMITER) {
 						if (t.is(CLOSE_TAG_START)) {
 							Token match = t.getNextToken();
 							if (match!=null && match.is(lexeme)) {
@@ -138,7 +138,7 @@ public class XmlOccurrenceMarker implements OccurrenceMarker {
 			do {
 
 				while (t!=null && t.getOffset()<endBefore && t.isPaintable()) {
-					if (t.getType()==Token.MARKUP_TAG_DELIMITER) {
+					if (t.getType()==TokenTypes.MARKUP_TAG_DELIMITER) {
 						if (t.isSingleChar('<')) {
 							Token next = t.getNextToken();
 							if (next!=null) {

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/CurlyFoldParser.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/CurlyFoldParser.java
@@ -178,7 +178,7 @@ public class CurlyFoldParser implements FoldParser {
 						}
 						else {
 							// If we're an MLC that ends on a later line...
-							if (t.getType()!=Token.COMMENT_EOL && !t.endsWith(C_MLC_END)) {
+							if (t.getType()!=TokenTypes.COMMENT_EOL && !t.endsWith(C_MLC_END)) {
 								//System.out.println("Starting MLC at: " + t.offset);
 								inMLC = true;
 								mlcStart = t.getOffset();
@@ -264,7 +264,7 @@ public class CurlyFoldParser implements FoldParser {
 					// Java-specific folding rules
 					else if (java) {
 
-						if (t.is(Token.RESERVED_WORD, KEYWORD_IMPORT)) {
+						if (t.is(TokenTypes.RESERVED_WORD, KEYWORD_IMPORT)) {
 							if (importStartLine==-1) {
 								importStartLine = line;
 								importGroupStartOffs = t.getOffset();

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/LatexFoldParser.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/LatexFoldParser.java
@@ -15,6 +15,7 @@ import javax.swing.text.BadLocationException;
 
 import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea;
 import org.fife.ui.rsyntaxtextarea.Token;
+import org.fife.ui.rsyntaxtextarea.TokenTypes;
 
 
 /**
@@ -46,11 +47,11 @@ public class LatexFoldParser implements FoldParser {
 				Token t = textArea.getTokenListForLine(line);
 				while (t!=null && t.isPaintable()) {
 
-					if (t.is(Token.RESERVED_WORD, BEGIN)) {
+					if (t.is(TokenTypes.RESERVED_WORD, BEGIN)) {
 						Token temp = t.getNextToken();
 						if (temp!=null && temp.isLeftCurly()) {
 							temp = temp.getNextToken();
-							if (temp!=null && temp.getType()==Token.RESERVED_WORD) {
+							if (temp!=null && temp.getType()==TokenTypes.RESERVED_WORD) {
 								if (currentFold==null) {
 									currentFold = new Fold(FoldType.CODE, textArea, t.getOffset());
 									folds.add(currentFold);
@@ -64,12 +65,12 @@ public class LatexFoldParser implements FoldParser {
 						}
 					}
 
-					else if (t.is(Token.RESERVED_WORD, END) &&
+					else if (t.is(TokenTypes.RESERVED_WORD, END) &&
 							currentFold!=null && !expectedStack.isEmpty()) {
 						Token temp = t.getNextToken();
 						if (temp!=null && temp.isLeftCurly()) {
 							temp = temp.getNextToken();
-							if (temp!=null && temp.getType()==Token.RESERVED_WORD) {
+							if (temp!=null && temp.getType()==TokenTypes.RESERVED_WORD) {
 								String value = temp.getLexeme();
 								if (expectedStack.peek().equals(value)) {
 									expectedStack.pop();

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/LispFoldParser.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/LispFoldParser.java
@@ -9,6 +9,7 @@
 package org.fife.ui.rsyntaxtextarea.folding;
 
 import org.fife.ui.rsyntaxtextarea.Token;
+import org.fife.ui.rsyntaxtextarea.TokenTypes;
 
 
 /**
@@ -22,13 +23,13 @@ public class LispFoldParser extends CurlyFoldParser {
 
 	@Override
 	public boolean isLeftCurly(Token t) {
-		return t.isSingleChar(Token.SEPARATOR, '(');
+		return t.isSingleChar(TokenTypes.SEPARATOR, '(');
 	}
 
 
 	@Override
 	public boolean isRightCurly(Token t) {
-		return t.isSingleChar(Token.SEPARATOR, ')');
+		return t.isSingleChar(TokenTypes.SEPARATOR, ')');
 	}
 
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/NsisFoldParser.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/NsisFoldParser.java
@@ -16,6 +16,7 @@ import javax.swing.text.BadLocationException;
 
 import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea;
 import org.fife.ui.rsyntaxtextarea.Token;
+import org.fife.ui.rsyntaxtextarea.TokenTypes;
 
 
 /**
@@ -40,7 +41,7 @@ public class NsisFoldParser implements FoldParser {
 
 	private static boolean foundEndKeyword(char[] keyword, Token t,
 			Stack<char[]> endWordStack) {
-		return t.is(Token.RESERVED_WORD, keyword) && !endWordStack.isEmpty() &&
+		return t.is(TokenTypes.RESERVED_WORD, keyword) && !endWordStack.isEmpty() &&
 			keyword==endWordStack.peek();
 	}
 
@@ -90,7 +91,7 @@ public class NsisFoldParser implements FoldParser {
 						}
 						else {
 							// If we're an MLC that ends on a later line...
-							if (t.getType()!=Token.COMMENT_EOL && !t.endsWith(C_MLC_END)) {
+							if (t.getType()!=TokenTypes.COMMENT_EOL && !t.endsWith(C_MLC_END)) {
 								//System.out.println("Starting MLC at: " + t.offset);
 								inMLC = true;
 								mlcStart = t.getOffset();
@@ -99,7 +100,7 @@ public class NsisFoldParser implements FoldParser {
 
 					}
 
-					else if (t.is(Token.RESERVED_WORD, KEYWORD_SECTION)) {
+					else if (t.is(TokenTypes.RESERVED_WORD, KEYWORD_SECTION)) {
 						if (currentFold==null) {
 							currentFold = new Fold(FoldType.CODE, textArea, t.getOffset());
 							folds.add(currentFold);
@@ -110,7 +111,7 @@ public class NsisFoldParser implements FoldParser {
 						endWordStack.push(KEYWORD_SECTION_END);
 					}
 
-					else if (t.is(Token.RESERVED_WORD, KEYWORD_FUNCTION)) {
+					else if (t.is(TokenTypes.RESERVED_WORD, KEYWORD_FUNCTION)) {
 						if (currentFold==null) {
 							currentFold = new Fold(FoldType.CODE, textArea, t.getOffset());
 							folds.add(currentFold);

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/XmlFoldParser.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/XmlFoldParser.java
@@ -15,6 +15,7 @@ import javax.swing.text.BadLocationException;
 
 import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea;
 import org.fife.ui.rsyntaxtextarea.Token;
+import org.fife.ui.rsyntaxtextarea.TokenTypes;
 
 
 /**
@@ -76,7 +77,7 @@ public class XmlFoldParser implements FoldParser {
 
 						else {
 							// If we're an MLC that ends on a later line...
-							if (t.getType()==Token.MARKUP_COMMENT && !t.endsWith(MLC_END)) {
+							if (t.getType()==TokenTypes.MARKUP_COMMENT && !t.endsWith(MLC_END)) {
 								inMLC = true;
 								mlcStart = t.getOffset();
 							}
@@ -84,7 +85,7 @@ public class XmlFoldParser implements FoldParser {
 
 					}
 
-					else if (t.isSingleChar(Token.MARKUP_TAG_DELIMITER, '<')) {
+					else if (t.isSingleChar(TokenTypes.MARKUP_TAG_DELIMITER, '<')) {
 						if (currentFold==null) {
 							currentFold = new Fold(FoldType.CODE, textArea, t.getOffset());
 							folds.add(currentFold);
@@ -94,7 +95,7 @@ public class XmlFoldParser implements FoldParser {
 						}
 					}
 
-					else if (t.is(Token.MARKUP_TAG_DELIMITER, MARKUP_SHORT_TAG_END)) {
+					else if (t.is(TokenTypes.MARKUP_TAG_DELIMITER, MARKUP_SHORT_TAG_END)) {
 						if (currentFold!=null) {
 							Fold parentFold = currentFold.getParent();
 							removeFold(currentFold, folds);
@@ -102,7 +103,7 @@ public class XmlFoldParser implements FoldParser {
 						}
 					}
 
-					else if (t.is(Token.MARKUP_TAG_DELIMITER, MARKUP_CLOSING_TAG_START)) {
+					else if (t.is(TokenTypes.MARKUP_TAG_DELIMITER, MARKUP_CLOSING_TAG_START)) {
 						if (currentFold!=null) {
 							currentFold.setEndOffset(t.getOffset());
 							Fold parentFold = currentFold.getParent();

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/ActionScriptTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/ActionScriptTokenMaker.flex
@@ -149,14 +149,14 @@ import org.fife.ui.rsyntaxtextarea.*;
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = Token.NULL;
+		int state = TokenTypes.NULL;
 		switch (initialTokenType) {
-			case Token.COMMENT_MULTILINE:
+			case TokenTypes.COMMENT_MULTILINE:
 				state = MLC;
 				start = text.offset;
 				break;
 			default:
-				state = Token.NULL;
+				state = TokenTypes.NULL;
 		}
 
 		s = text;
@@ -346,7 +346,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"with" |
 
 	"null" |
-	"undefined"				{ addToken(Token.RESERVED_WORD); }
+	"undefined"				{ addToken(TokenTypes.RESERVED_WORD); }
 
 	/* Built-in objects (good idea not to use these names!) */
 	"Array" |
@@ -369,7 +369,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"Vector" |
 	"XML" |
 	"XMLNode" |
-	"XMLSocket"			{ addToken(Token.DATA_TYPE); }
+	"XMLSocket"			{ addToken(TokenTypes.DATA_TYPE); }
 
 	/* Global functions */
 	"call" |
@@ -420,50 +420,50 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"unescape" |
 	"unloadMovie" |
 	"unloadMovieNum" |
-	"updateAfterEvent"			{ addToken(Token.FUNCTION); }
+	"updateAfterEvent"			{ addToken(TokenTypes.FUNCTION); }
 
 	/* Booleans. */
-	{BooleanLiteral}			{ addToken(Token.LITERAL_BOOLEAN); }
+	{BooleanLiteral}			{ addToken(TokenTypes.LITERAL_BOOLEAN); }
 
 	{LineTerminator}				{ addNullToken(); return firstToken; }
 
-	{Identifier}					{ addToken(Token.IDENTIFIER); }
+	{Identifier}					{ addToken(TokenTypes.IDENTIFIER); }
 
-	{WhiteSpace}+					{ addToken(Token.WHITESPACE); }
+	{WhiteSpace}+					{ addToken(TokenTypes.WHITESPACE); }
 
 	/* String/Character literals. */
-	{CharLiteral}					{ addToken(Token.LITERAL_CHAR); }
-	{UnclosedCharLiteral}			{ addToken(Token.ERROR_CHAR); addNullToken(); return firstToken; }
-	{ErrorCharLiteral}				{ addToken(Token.ERROR_CHAR); }
-	{StringLiteral}				{ addToken(Token.LITERAL_STRING_DOUBLE_QUOTE); }
-	{UnclosedStringLiteral}			{ addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
-	{ErrorStringLiteral}			{ addToken(Token.ERROR_STRING_DOUBLE); }
+	{CharLiteral}					{ addToken(TokenTypes.LITERAL_CHAR); }
+	{UnclosedCharLiteral}			{ addToken(TokenTypes.ERROR_CHAR); addNullToken(); return firstToken; }
+	{ErrorCharLiteral}				{ addToken(TokenTypes.ERROR_CHAR); }
+	{StringLiteral}				{ addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); }
+	{UnclosedStringLiteral}			{ addToken(TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
+	{ErrorStringLiteral}			{ addToken(TokenTypes.ERROR_STRING_DOUBLE); }
 
 	/* Comment literals. */
-	"/**/"						{ addToken(Token.COMMENT_MULTILINE); }
+	"/**/"						{ addToken(TokenTypes.COMMENT_MULTILINE); }
 	{MLCBegin}					{ start = zzMarkedPos-2; yybegin(MLC); }
 	{LineCommentBegin}			{ start = zzMarkedPos-2; yybegin(EOL_COMMENT); }
 
 	/* Separators. */
-	{Separator}					{ addToken(Token.SEPARATOR); }
-	{Separator2}					{ addToken(Token.IDENTIFIER); }
+	{Separator}					{ addToken(TokenTypes.SEPARATOR); }
+	{Separator2}					{ addToken(TokenTypes.IDENTIFIER); }
 
 	/* Operators. */
-	{Operator}					{ addToken(Token.OPERATOR); }
+	{Operator}					{ addToken(TokenTypes.OPERATOR); }
 
 	/* Numbers */
-	{IntegerLiteral}				{ addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
-	{HexLiteral}					{ addToken(Token.LITERAL_NUMBER_HEXADECIMAL); }
-	{FloatLiteral}					{ addToken(Token.LITERAL_NUMBER_FLOAT); }
-	{ErrorNumberFormat}				{ addToken(Token.ERROR_NUMBER_FORMAT); }
+	{IntegerLiteral}				{ addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT); }
+	{HexLiteral}					{ addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL); }
+	{FloatLiteral}					{ addToken(TokenTypes.LITERAL_NUMBER_FLOAT); }
+	{ErrorNumberFormat}				{ addToken(TokenTypes.ERROR_NUMBER_FORMAT); }
 
-	{ErrorIdentifier}				{ addToken(Token.ERROR_IDENTIFIER); }
+	{ErrorIdentifier}				{ addToken(TokenTypes.ERROR_IDENTIFIER); }
 
 	/* Ended with a line not in a string or comment. */
 	<<EOF>>						{ addNullToken(); return firstToken; }
 
 	/* Catch any other (unhandled) characters and flag them as bad. */
-	.							{ addToken(Token.ERROR_IDENTIFIER); }
+	.							{ addToken(TokenTypes.ERROR_IDENTIFIER); }
 
 }
 
@@ -471,22 +471,22 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 <MLC> {
 
 	[^hwf\n\*]+				{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos; }
 	[hwf]					{}
 
-	\n						{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken; }
-	{MLCEnd}					{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE); }
+	\n						{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken; }
+	{MLCEnd}					{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE); }
 	\*						{}
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken; }
 
 }
 
 
 <EOL_COMMENT> {
 	[^hwf\n]+				{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos; }
 	[hwf]					{}
-	\n						{ addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken; }
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken; }
+	\n						{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken; }
 
 }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/ActionScriptTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/ActionScriptTokenMaker.java
@@ -1520,14 +1520,14 @@ public class ActionScriptTokenMaker extends AbstractJFlexCTokenMaker {
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = Token.NULL;
+		int state = TokenTypes.NULL;
 		switch (initialTokenType) {
-			case Token.COMMENT_MULTILINE:
+			case TokenTypes.COMMENT_MULTILINE:
 				state = MLC;
 				start = text.offset;
 				break;
 			default:
-				state = Token.NULL;
+				state = TokenTypes.NULL;
 		}
 
 		s = text;
@@ -1812,15 +1812,15 @@ public class ActionScriptTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 30: break;
         case 16:
-          { addToken(Token.LITERAL_CHAR);
+          { addToken(TokenTypes.LITERAL_CHAR);
           }
         case 31: break;
         case 21:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE);
           }
         case 32: break;
         case 25:
-          { addToken(Token.COMMENT_MULTILINE);
+          { addToken(TokenTypes.COMMENT_MULTILINE);
           }
         case 33: break;
         case 20:
@@ -1828,35 +1828,35 @@ public class ActionScriptTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 34: break;
         case 7:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 35: break;
         case 15:
-          { addToken(Token.LITERAL_NUMBER_HEXADECIMAL);
+          { addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL);
           }
         case 36: break;
         case 22:
-          { addToken(Token.ERROR_STRING_DOUBLE);
+          { addToken(TokenTypes.ERROR_STRING_DOUBLE);
           }
         case 37: break;
         case 14:
-          { addToken(Token.LITERAL_NUMBER_FLOAT);
+          { addToken(TokenTypes.LITERAL_NUMBER_FLOAT);
           }
         case 38: break;
         case 17:
-          { addToken(Token.RESERVED_WORD);
+          { addToken(TokenTypes.RESERVED_WORD);
           }
         case 39: break;
         case 9:
-          { addToken(Token.SEPARATOR);
+          { addToken(TokenTypes.SEPARATOR);
           }
         case 40: break;
         case 2:
-          { addToken(Token.IDENTIFIER);
+          { addToken(TokenTypes.IDENTIFIER);
           }
         case 41: break;
         case 12:
-          { addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
           }
         case 42: break;
         case 19:
@@ -1864,55 +1864,55 @@ public class ActionScriptTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 43: break;
         case 27:
-          { addToken(Token.FUNCTION);
+          { addToken(TokenTypes.FUNCTION);
           }
         case 44: break;
         case 4:
-          { addToken(Token.ERROR_CHAR); addNullToken(); return firstToken;
+          { addToken(TokenTypes.ERROR_CHAR); addNullToken(); return firstToken;
           }
         case 45: break;
         case 6:
-          { addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
+          { addToken(TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
           }
         case 46: break;
         case 23:
-          { addToken(Token.DATA_TYPE);
+          { addToken(TokenTypes.DATA_TYPE);
           }
         case 47: break;
         case 1:
-          { addToken(Token.ERROR_IDENTIFIER);
+          { addToken(TokenTypes.ERROR_IDENTIFIER);
           }
         case 48: break;
         case 24:
-          { addToken(Token.ERROR_CHAR);
+          { addToken(TokenTypes.ERROR_CHAR);
           }
         case 49: break;
         case 26:
-          { addToken(Token.LITERAL_BOOLEAN);
+          { addToken(TokenTypes.LITERAL_BOOLEAN);
           }
         case 50: break;
         case 18:
-          { addToken(Token.LITERAL_STRING_DOUBLE_QUOTE);
+          { addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
           }
         case 51: break;
         case 29:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos;
           }
         case 52: break;
         case 28:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos;
           }
         case 53: break;
         case 13:
-          { addToken(Token.ERROR_NUMBER_FORMAT);
+          { addToken(TokenTypes.ERROR_NUMBER_FORMAT);
           }
         case 54: break;
         case 3:
-          { addToken(Token.LITERAL_NUMBER_DECIMAL_INT);
+          { addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT);
           }
         case 55: break;
         case 8:
-          { addToken(Token.OPERATOR);
+          { addToken(TokenTypes.OPERATOR);
           }
         case 56: break;
         case 10:
@@ -1920,7 +1920,7 @@ public class ActionScriptTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 57: break;
         case 11:
-          { addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken;
           }
         case 58: break;
         default:
@@ -1928,7 +1928,7 @@ public class ActionScriptTokenMaker extends AbstractJFlexCTokenMaker {
             zzAtEOF = true;
             switch (zzLexicalState) {
             case EOL_COMMENT: {
-              addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
             }
             case 529: break;
             case YYINITIAL: {
@@ -1936,7 +1936,7 @@ public class ActionScriptTokenMaker extends AbstractJFlexCTokenMaker {
             }
             case 530: break;
             case MLC: {
-              addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken;
             }
             case 531: break;
             default:

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/Assembler6502TokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/Assembler6502TokenMaker.flex
@@ -305,7 +305,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
     "TSX" |
     "TXA" |
     "TXS" |
-    "TYA"       { addToken(Token.FUNCTION); }
+    "TYA"       { addToken(TokenTypes.FUNCTION); }
 
 	"DB" |
 	"DW" |
@@ -321,7 +321,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"EQU" |
 	"TEXTEQU" |
 	"TIMES" |
-	"DUP"		{ addToken(Token.FUNCTION); }
+	"DUP"		{ addToken(TokenTypes.FUNCTION); }
 
     /* 6502 illegal instructions */
     "LR" |
@@ -336,53 +336,53 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
     "RRA" |
     "SAX" |
     "SLO" |
-    "SRE"		{ addToken(Token.FUNCTION); }
+    "SRE"		{ addToken(TokenTypes.FUNCTION); }
 
     "@"{LetterOrUnderscore}+ |
-    ("#"([^ \t]+ | {StringLiteral} | {UnclosedStringLiteral})) { addToken(Token.PREPROCESSOR); }
+    ("#"([^ \t]+ | {StringLiteral} | {UnclosedStringLiteral})) { addToken(TokenTypes.PREPROCESSOR); }
 
 	{LineTerminator}				{ addNullToken(); return firstToken; }
 
-	{WhiteSpace}+					{ addToken(Token.WHITESPACE); }
+	{WhiteSpace}+					{ addToken(TokenTypes.WHITESPACE); }
 
 	/* String/Character Literals. */
-	{CharLiteral}					{ addToken(Token.LITERAL_CHAR); }
-	{UnclosedCharLiteral}			{ addToken(Token.ERROR_CHAR); /*addNullToken(); return firstToken;*/ }
-	{StringLiteral}				{ addToken(Token.LITERAL_STRING_DOUBLE_QUOTE); }
-	{UnclosedStringLiteral}			{ addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
+	{CharLiteral}					{ addToken(TokenTypes.LITERAL_CHAR); }
+	{UnclosedCharLiteral}			{ addToken(TokenTypes.ERROR_CHAR); /*addNullToken(); return firstToken;*/ }
+	{StringLiteral}				{ addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); }
+	{UnclosedStringLiteral}			{ addToken(TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
 
 	/* Labels. */
-	{Label}						{ addToken(Token.PREPROCESSOR); }
+	{Label}						{ addToken(TokenTypes.PREPROCESSOR); }
 
-	^%{LetterOrUnderscore}({LetterOrUnderscore}|{Digit})*	{ addToken(Token.FUNCTION); }
+	^%{LetterOrUnderscore}({LetterOrUnderscore}|{Digit})*	{ addToken(TokenTypes.FUNCTION); }
 
 	/* Comment Literals. */
 	{CommentBegin}			    { start = zzMarkedPos-1; yybegin(EOL_COMMENT); }
 
 	/* Operators. */
-	{Operator}					{ addToken(Token.OPERATOR); }
+	{Operator}					{ addToken(TokenTypes.OPERATOR); }
 
     /* After "Operators" because of their overlap */
-    "."{Identifier}  { addToken(Token.VARIABLE); }
+    "."{Identifier}  { addToken(TokenTypes.VARIABLE); }
 
 	/* Numbers */
-	{Number}						{ addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
+	{Number}						{ addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT); }
 
 	/* Ended with a line not in a string or comment. */
 	<<EOF>>						{ addNullToken(); return firstToken; }
 
 	/* Catch any other (unhandled) characters. */
-	{Identifier}					{ addToken(Token.IDENTIFIER); }
-	.							{ addToken(Token.IDENTIFIER); }
+	{Identifier}					{ addToken(TokenTypes.IDENTIFIER); }
+	.							{ addToken(TokenTypes.IDENTIFIER); }
 
 }
 
 
 <EOL_COMMENT> {
 	[^hwf\n]+				{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos; }
 	[hwf]					{}
-	\n						{ addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken; }
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken; }
+	\n						{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken; }
 
 }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/Assembler6502TokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/Assembler6502TokenMaker.java
@@ -992,35 +992,35 @@ public class Assembler6502TokenMaker extends AbstractJFlexTokenMaker {
 
       switch (zzAction < 0 ? zzAction : ZZ_ACTION[zzAction]) {
         case 1:
-          { addToken(Token.IDENTIFIER);
+          { addToken(TokenTypes.IDENTIFIER);
           }
         case 17: break;
         case 14:
-          { addToken(Token.FUNCTION);
+          { addToken(TokenTypes.FUNCTION);
           }
         case 18: break;
         case 12:
-          { addToken(Token.LITERAL_STRING_DOUBLE_QUOTE);
+          { addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
           }
         case 19: break;
         case 15:
-          { addToken(Token.VARIABLE);
+          { addToken(TokenTypes.VARIABLE);
           }
         case 20: break;
         case 7:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 21: break;
         case 11:
-          { addToken(Token.PREPROCESSOR);
+          { addToken(TokenTypes.PREPROCESSOR);
           }
         case 22: break;
         case 16:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos;
           }
         case 23: break;
         case 4:
-          { addToken(Token.ERROR_CHAR); /*addNullToken(); return firstToken;*/
+          { addToken(TokenTypes.ERROR_CHAR); /*addNullToken(); return firstToken;*/
           }
         case 24: break;
         case 5:
@@ -1028,19 +1028,19 @@ public class Assembler6502TokenMaker extends AbstractJFlexTokenMaker {
           }
         case 25: break;
         case 8:
-          { addToken(Token.OPERATOR);
+          { addToken(TokenTypes.OPERATOR);
           }
         case 26: break;
         case 2:
-          { addToken(Token.LITERAL_NUMBER_DECIMAL_INT);
+          { addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT);
           }
         case 27: break;
         case 13:
-          { addToken(Token.LITERAL_CHAR);
+          { addToken(TokenTypes.LITERAL_CHAR);
           }
         case 28: break;
         case 3:
-          { addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
+          { addToken(TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
           }
         case 29: break;
         case 6:
@@ -1048,7 +1048,7 @@ public class Assembler6502TokenMaker extends AbstractJFlexTokenMaker {
           }
         case 30: break;
         case 10:
-          { addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
           }
         case 31: break;
         case 9:
@@ -1060,7 +1060,7 @@ public class Assembler6502TokenMaker extends AbstractJFlexTokenMaker {
             zzAtEOF = true;
             switch (zzLexicalState) {
             case EOL_COMMENT: {
-              addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
             }
             case 151: break;
             case YYINITIAL: {

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/AssemblerX86TokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/AssemblerX86TokenMaker.flex
@@ -424,7 +424,7 @@ Operator				= ("+"|"-"|"*"|"/"|"%"|"^"|"|"|"&"|"~"|"!"|"="|"<"|">")
 	"USES" |
 	"WHILE" |
 	"WRT" |
-	"ZERO?"		{ addToken(Token.PREPROCESSOR); }
+	"ZERO?"		{ addToken(TokenTypes.PREPROCESSOR); }
 
 	"DB" |
 	"DW" |
@@ -440,7 +440,7 @@ Operator				= ("+"|"-"|"*"|"/"|"%"|"^"|"|"|"&"|"~"|"!"|"="|"<"|">")
 	"EQU" |
 	"TEXTEQU" |
 	"TIMES" |
-	"DUP"		{ addToken(Token.FUNCTION); }
+	"DUP"		{ addToken(TokenTypes.FUNCTION); }
 
 	"BYTE" |
 	"WORD" |
@@ -454,7 +454,7 @@ Operator				= ("+"|"-"|"*"|"/"|"%"|"^"|"|"|"&"|"~"|"!"|"="|"<"|">")
 	"SDWORD" |
 	"REAL4" |
 	"REAL8" |
-	"REAL10"		{ addToken(Token.DATA_TYPE); }
+	"REAL10"		{ addToken(TokenTypes.DATA_TYPE); }
 
 	/* Registers */
 	"AL" |
@@ -528,7 +528,7 @@ Operator				= ("+"|"-"|"*"|"/"|"%"|"^"|"|"|"&"|"~"|"!"|"="|"<"|">")
 	"TR4" |
 	"TR5" |
 	"TR6" |
-	"TR7"		{ addToken(Token.VARIABLE); }
+	"TR7"		{ addToken(TokenTypes.VARIABLE); }
 
 	/* Pentium III Instructions. */
 	"AAA" |
@@ -985,7 +985,7 @@ Operator				= ("+"|"-"|"*"|"/"|"%"|"^"|"|"|"&"|"~"|"!"|"="|"<"|">")
 	"XLAT" |
 	"XLATB" |
 	"XOR" |
-	"XORPS"		{ addToken(Token.RESERVED_WORD); }
+	"XORPS"		{ addToken(TokenTypes.RESERVED_WORD); }
 
 }
 
@@ -993,33 +993,33 @@ Operator				= ("+"|"-"|"*"|"/"|"%"|"^"|"|"|"&"|"~"|"!"|"="|"<"|">")
 
 	{LineTerminator}				{ addNullToken(); return firstToken; }
 
-	{WhiteSpace}+					{ addToken(Token.WHITESPACE); }
+	{WhiteSpace}+					{ addToken(TokenTypes.WHITESPACE); }
 
 	/* String/Character Literals. */
-	{CharLiteral}					{ addToken(Token.LITERAL_CHAR); }
-	{UnclosedCharLiteral}			{ addToken(Token.ERROR_CHAR); /*addNullToken(); return firstToken;*/ }
-	{StringLiteral}				{ addToken(Token.LITERAL_STRING_DOUBLE_QUOTE); }
-	{UnclosedStringLiteral}			{ addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
+	{CharLiteral}					{ addToken(TokenTypes.LITERAL_CHAR); }
+	{UnclosedCharLiteral}			{ addToken(TokenTypes.ERROR_CHAR); /*addNullToken(); return firstToken;*/ }
+	{StringLiteral}				{ addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); }
+	{UnclosedStringLiteral}			{ addToken(TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
 
 	/* Labels. */
-	{Label}						{ addToken(Token.PREPROCESSOR); }
+	{Label}						{ addToken(TokenTypes.PREPROCESSOR); }
 
-	^%({Letter}|{Digit})*			{ addToken(Token.FUNCTION); }
+	^%({Letter}|{Digit})*			{ addToken(TokenTypes.FUNCTION); }
 
 	/* Comment Literals. */
-	{CommentBegin}.*				{ addToken(Token.COMMENT_EOL); addNullToken(); return firstToken; }
+	{CommentBegin}.*				{ addToken(TokenTypes.COMMENT_EOL); addNullToken(); return firstToken; }
 
 	/* Operators. */
-	{Operator}					{ addToken(Token.OPERATOR); }
+	{Operator}					{ addToken(TokenTypes.OPERATOR); }
 
 	/* Numbers */
-	{Number}						{ addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
+	{Number}						{ addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT); }
 
 	/* Ended with a line not in a string or comment. */
 	<<EOF>>						{ addNullToken(); return firstToken; }
 
 	/* Catch any other (unhandled) characters. */
-	{Identifier}					{ addToken(Token.IDENTIFIER); }
-	.							{ addToken(Token.IDENTIFIER); }
+	{Identifier}					{ addToken(TokenTypes.IDENTIFIER); }
+	.							{ addToken(TokenTypes.IDENTIFIER); }
 
 }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/AssemblerX86TokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/AssemblerX86TokenMaker.java
@@ -1777,59 +1777,59 @@ public final void yybegin(int newState) {
 
       switch (zzAction < 0 ? zzAction : ZZ_ACTION[zzAction]) {
         case 11:
-          { addToken(Token.RESERVED_WORD);
+          { addToken(TokenTypes.RESERVED_WORD);
           }
         case 16: break;
         case 1:
-          { addToken(Token.IDENTIFIER);
+          { addToken(TokenTypes.IDENTIFIER);
           }
         case 17: break;
         case 12:
-          { addToken(Token.LITERAL_STRING_DOUBLE_QUOTE);
+          { addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
           }
         case 18: break;
         case 9:
-          { addToken(Token.FUNCTION);
+          { addToken(TokenTypes.FUNCTION);
           }
         case 19: break;
         case 5:
-          { addToken(Token.COMMENT_EOL); addNullToken(); return firstToken;
+          { addToken(TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
           }
         case 20: break;
         case 14:
-          { addToken(Token.VARIABLE);
+          { addToken(TokenTypes.VARIABLE);
           }
         case 21: break;
         case 7:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 22: break;
         case 10:
-          { addToken(Token.PREPROCESSOR);
+          { addToken(TokenTypes.PREPROCESSOR);
           }
         case 23: break;
         case 15:
-          { addToken(Token.DATA_TYPE);
+          { addToken(TokenTypes.DATA_TYPE);
           }
         case 24: break;
         case 4:
-          { addToken(Token.ERROR_CHAR); /*addNullToken(); return firstToken;*/
+          { addToken(TokenTypes.ERROR_CHAR); /*addNullToken(); return firstToken;*/
           }
         case 25: break;
         case 8:
-          { addToken(Token.OPERATOR);
+          { addToken(TokenTypes.OPERATOR);
           }
         case 26: break;
         case 2:
-          { addToken(Token.LITERAL_NUMBER_DECIMAL_INT);
+          { addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT);
           }
         case 27: break;
         case 13:
-          { addToken(Token.LITERAL_CHAR);
+          { addToken(TokenTypes.LITERAL_CHAR);
           }
         case 28: break;
         case 3:
-          { addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
+          { addToken(TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
           }
         case 29: break;
         case 6:

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/BBCodeTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/BBCodeTokenMaker.flex
@@ -164,14 +164,14 @@ import org.fife.ui.rsyntaxtextarea.*;
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = Token.NULL;
+		int state = TokenTypes.NULL;
 		switch (initialTokenType) {
 			case INTERNAL_INTAG:
 				state = INTAG;
 				start = text.offset;
 				break;
 			default:
-				state = Token.NULL;
+				state = TokenTypes.NULL;
 		}
 
 		s = text;
@@ -252,22 +252,22 @@ Tag					= ("b"|"i"|"u"|"s"|"size"|"color"|"center"|"quote"|"url"|"img"|"ul"|"li"
 %%
 
 <YYINITIAL> {
-	{Identifier}			{ addToken(Token.IDENTIFIER); }
-	{Whitespace}			{ addToken(Token.WHITESPACE); }
-	"["						{ addToken(Token.MARKUP_TAG_DELIMITER); yybegin(INTAG); }
-	"[/"					{ addToken(Token.MARKUP_TAG_DELIMITER); yybegin(INTAG); }
+	{Identifier}			{ addToken(TokenTypes.IDENTIFIER); }
+	{Whitespace}			{ addToken(TokenTypes.WHITESPACE); }
+	"["						{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(INTAG); }
+	"[/"					{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(INTAG); }
 	{LineTerminator}		{ addNullToken(); return firstToken; }
 	<<EOF>>					{ addNullToken(); return firstToken; }
 }
 
 <INTAG> {
-	"/"						{ addToken(Token.MARKUP_TAG_DELIMITER); }
-	{Tag}					{ addToken(Token.MARKUP_TAG_NAME); }
-	{InTagIdentifier}		{ addToken(Token.MARKUP_TAG_ATTRIBUTE); }
-	{Whitespace}			{ addToken(Token.WHITESPACE); }
-	"="						{ addToken(Token.OPERATOR); }
-	"/]"					{ yybegin(YYINITIAL); addToken(Token.MARKUP_TAG_DELIMITER); }
-	"]"						{ yybegin(YYINITIAL); addToken(Token.MARKUP_TAG_DELIMITER); }
-	.						{ addToken(Token.IDENTIFIER); /* Unhandled chars, not likely */ }
+	"/"						{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); }
+	{Tag}					{ addToken(TokenTypes.MARKUP_TAG_NAME); }
+	{InTagIdentifier}		{ addToken(TokenTypes.MARKUP_TAG_ATTRIBUTE); }
+	{Whitespace}			{ addToken(TokenTypes.WHITESPACE); }
+	"="						{ addToken(TokenTypes.OPERATOR); }
+	"/]"					{ yybegin(YYINITIAL); addToken(TokenTypes.MARKUP_TAG_DELIMITER); }
+	"]"						{ yybegin(YYINITIAL); addToken(TokenTypes.MARKUP_TAG_DELIMITER); }
+	.						{ addToken(TokenTypes.IDENTIFIER); /* Unhandled chars, not likely */ }
 	<<EOF>>					{ addToken(zzMarkedPos,zzMarkedPos, INTERNAL_INTAG); return firstToken; }
 }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/BBCodeTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/BBCodeTokenMaker.java
@@ -365,14 +365,14 @@ public class BBCodeTokenMaker extends AbstractMarkupTokenMaker {
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = Token.NULL;
+		int state = TokenTypes.NULL;
 		switch (initialTokenType) {
 			case INTERNAL_INTAG:
 				state = INTAG;
 				start = text.offset;
 				break;
 			default:
-				state = Token.NULL;
+				state = TokenTypes.NULL;
 		}
 
 		s = text;
@@ -664,35 +664,35 @@ public final void yybegin(int newState) {
 
       switch (zzAction < 0 ? zzAction : ZZ_ACTION[zzAction]) {
         case 1:
-          { addToken(Token.IDENTIFIER);
+          { addToken(TokenTypes.IDENTIFIER);
           }
         case 11: break;
         case 9:
-          { addToken(Token.MARKUP_TAG_DELIMITER);
+          { addToken(TokenTypes.MARKUP_TAG_DELIMITER);
           }
         case 12: break;
         case 2:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 13: break;
         case 10:
-          { addToken(Token.OPERATOR);
+          { addToken(TokenTypes.OPERATOR);
           }
         case 14: break;
         case 8:
-          { addToken(Token.MARKUP_TAG_NAME);
+          { addToken(TokenTypes.MARKUP_TAG_NAME);
           }
         case 15: break;
         case 4:
-          { addToken(Token.MARKUP_TAG_DELIMITER); yybegin(INTAG);
+          { addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(INTAG);
           }
         case 16: break;
         case 6:
-          { addToken(Token.IDENTIFIER); /* Unhandled chars, not likely */
+          { addToken(TokenTypes.IDENTIFIER); /* Unhandled chars, not likely */
           }
         case 17: break;
         case 5:
-          { addToken(Token.MARKUP_TAG_ATTRIBUTE);
+          { addToken(TokenTypes.MARKUP_TAG_ATTRIBUTE);
           }
         case 18: break;
         case 3:
@@ -700,7 +700,7 @@ public final void yybegin(int newState) {
           }
         case 19: break;
         case 7:
-          { yybegin(YYINITIAL); addToken(Token.MARKUP_TAG_DELIMITER);
+          { yybegin(YYINITIAL); addToken(TokenTypes.MARKUP_TAG_DELIMITER);
           }
         case 20: break;
         default:

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/CPlusPlusTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/CPlusPlusTokenMaker.flex
@@ -151,11 +151,11 @@ import org.fife.ui.rsyntaxtextarea.*;
 		// Start off in the proper state.
 		int state = YYINITIAL;
 		switch (initialTokenType) {
-			case Token.COMMENT_EOL:
+			case TokenTypes.COMMENT_EOL:
 				state = EOL_COMMENT;
 				start = text.offset;
 				break;
-			case Token.COMMENT_MULTILINE:
+			case TokenTypes.COMMENT_MULTILINE:
 				state = MLC;
 				start = text.offset;
 				break;
@@ -329,9 +329,9 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"using" |
 	"virtual" |
 	"volatile" |
-	"while"					{ addToken(Token.RESERVED_WORD); }
+	"while"					{ addToken(TokenTypes.RESERVED_WORD); }
 
-	"return"				{ addToken(Token.RESERVED_WORD_2); }
+	"return"				{ addToken(TokenTypes.RESERVED_WORD_2); }
 
 	/* Boolean literals. */
 	"true" |
@@ -350,7 +350,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"size_t" |
 	"unsigned" |
 	"void" |
-	"wchar_t"				{ addToken(Token.DATA_TYPE); }
+	"wchar_t"				{ addToken(TokenTypes.DATA_TYPE); }
 
 	/* Standard functions */
 	"abort" |
@@ -552,20 +552,20 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"wmemmove" |
 	"wmemset" |
 	"wprintf" |
-	"wscanf"				{ addToken(Token.FUNCTION); }
+	"wscanf"				{ addToken(TokenTypes.FUNCTION); }
 
 	/* Standard-defined macros. */
 	"__DATE__" |
 	"__TIME__" |
 	"__FILE__" |
 	"__LINE__" |
-	"__STDC__"				{ addToken(Token.PREPROCESSOR); }
+	"__STDC__"				{ addToken(TokenTypes.PREPROCESSOR); }
 
 	{LineTerminator}				{ addNullToken(); return firstToken; }
 
-	{Identifier}					{ addToken(Token.IDENTIFIER); }
+	{Identifier}					{ addToken(TokenTypes.IDENTIFIER); }
 
-	{WhiteSpace}+					{ addToken(Token.WHITESPACE); }
+	{WhiteSpace}+					{ addToken(TokenTypes.WHITESPACE); }
 
 	/* Preprocessor directives */
 	/* Special-case <includes> for uniform appearance with "string" includes "*/
@@ -589,16 +589,16 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 
                                                      addToken(end + 1, zzMarkedPos - 1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
                                                  }
-	"#"{WhiteSpace}*{PreprocessorWord}	{ addToken(Token.PREPROCESSOR); }
+	"#"{WhiteSpace}*{PreprocessorWord}	{ addToken(TokenTypes.PREPROCESSOR); }
 
 	/* String/Character Literals. */
-	{CharLiteral}					{ addToken(Token.LITERAL_CHAR); }
-	{UnclosedCharLiteral}			{ addToken(Token.ERROR_CHAR); /*addNullToken(); return firstToken;*/ }
-	{ErrorUnclosedCharLiteral}		{ addToken(Token.ERROR_CHAR); addNullToken(); return firstToken; }
-	{ErrorCharLiteral}				{ addToken(Token.ERROR_CHAR); }
-	{StringLiteral}				{ addToken(Token.LITERAL_STRING_DOUBLE_QUOTE); }
-	{UnclosedStringLiteral}			{ addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
-	{ErrorStringLiteral}			{ addToken(Token.ERROR_STRING_DOUBLE); }
+	{CharLiteral}					{ addToken(TokenTypes.LITERAL_CHAR); }
+	{UnclosedCharLiteral}			{ addToken(TokenTypes.ERROR_CHAR); /*addNullToken(); return firstToken;*/ }
+	{ErrorUnclosedCharLiteral}		{ addToken(TokenTypes.ERROR_CHAR); addNullToken(); return firstToken; }
+	{ErrorCharLiteral}				{ addToken(TokenTypes.ERROR_CHAR); }
+	{StringLiteral}				{ addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); }
+	{UnclosedStringLiteral}			{ addToken(TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
+	{ErrorStringLiteral}			{ addToken(TokenTypes.ERROR_STRING_DOUBLE); }
 
 	/* Comment Literals. */
 	{MLCBegin}					{ start = zzMarkedPos-2; yybegin(MLC); }
@@ -610,7 +610,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"[" |
 	"]" |
 	"{" |
-	"}"							{ addToken(Token.SEPARATOR); }
+	"}"							{ addToken(TokenTypes.SEPARATOR); }
 
 	/* Operators. */
 	{Trigraph} |
@@ -651,53 +651,53 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"++" |
 	"--" |
 	"." |
-	","							{ addToken(Token.OPERATOR); }
+	","							{ addToken(TokenTypes.OPERATOR); }
 
 	/* Numbers */
-	{IntegerLiteral}				{ addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
-	{HexLiteral}					{ addToken(Token.LITERAL_NUMBER_HEXADECIMAL); }
-	{FloatLiteral}					{ addToken(Token.LITERAL_NUMBER_FLOAT); }
-	{ErrorNumberFormat}				{ addToken(Token.ERROR_NUMBER_FORMAT); }
+	{IntegerLiteral}				{ addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT); }
+	{HexLiteral}					{ addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL); }
+	{FloatLiteral}					{ addToken(TokenTypes.LITERAL_NUMBER_FLOAT); }
+	{ErrorNumberFormat}				{ addToken(TokenTypes.ERROR_NUMBER_FORMAT); }
 
 	/* Some lines will end in '\' to wrap an expression. */
-	"\\"							{ addToken(Token.IDENTIFIER); }
+	"\\"							{ addToken(TokenTypes.IDENTIFIER); }
 
-	{ErrorIdentifier}				{ addToken(Token.ERROR_IDENTIFIER); }
+	{ErrorIdentifier}				{ addToken(TokenTypes.ERROR_IDENTIFIER); }
 
 	/* Other punctuation, we'll highlight it as "identifiers." */
-	";"							{ addToken(Token.IDENTIFIER); }
+	";"							{ addToken(TokenTypes.IDENTIFIER); }
 
 	/* Ended with a line not in a string or comment. */
 	<<EOF>>						{ addNullToken(); return firstToken; }
 
 	/* Catch any other (unhandled) characters and flag them as bad. */
-	.							{ addToken(Token.ERROR_IDENTIFIER); }
+	.							{ addToken(TokenTypes.ERROR_IDENTIFIER); }
 
 }
 
 <MLC> {
 
 	[^hwf\n\*]+			{}
-	{URL}				{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos; }
+	{URL}				{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos; }
 	[hwf]				{}
 
-	\n					{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken; }
-	{MLCEnd}			{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE); }
+	\n					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken; }
+	{MLCEnd}			{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE); }
 	\*					{}
-	<<EOF>>				{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken; }
+	<<EOF>>				{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken; }
 
 }
 
 <EOL_COMMENT> {
 	[^hwf\\\n]+				{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos; }
 	[hwf]					{}
 	\\.						{ /* Skip all escaped chars. */ }
 	\\						{ /* Line ending in '\' => continue to next line. */
-								addToken(start,zzStartRead, Token.COMMENT_EOL);
+								addToken(start,zzStartRead, TokenTypes.COMMENT_EOL);
 								return firstToken;
 							}
 	\n |
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken; }
 
 }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/CPlusPlusTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/CPlusPlusTokenMaker.java
@@ -1902,11 +1902,11 @@ public class CPlusPlusTokenMaker extends AbstractJFlexCTokenMaker {
 		// Start off in the proper state.
 		int state = YYINITIAL;
 		switch (initialTokenType) {
-			case Token.COMMENT_EOL:
+			case TokenTypes.COMMENT_EOL:
 				state = EOL_COMMENT;
 				start = text.offset;
 				break;
-			case Token.COMMENT_MULTILINE:
+			case TokenTypes.COMMENT_MULTILINE:
 				state = MLC;
 				start = text.offset;
 				break;
@@ -2191,7 +2191,7 @@ public class CPlusPlusTokenMaker extends AbstractJFlexCTokenMaker {
 
       switch (zzAction < 0 ? zzAction : ZZ_ACTION[zzAction]) {
         case 29:
-          { addToken(Token.PREPROCESSOR);
+          { addToken(TokenTypes.PREPROCESSOR);
           }
         case 34: break;
         case 7:
@@ -2199,11 +2199,11 @@ public class CPlusPlusTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 35: break;
         case 26:
-          { addToken(Token.LITERAL_CHAR);
+          { addToken(TokenTypes.LITERAL_CHAR);
           }
         case 36: break;
         case 22:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE);
           }
         case 37: break;
         case 33:
@@ -2232,39 +2232,39 @@ public class CPlusPlusTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 39: break;
         case 9:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 40: break;
         case 28:
-          { addToken(Token.LITERAL_NUMBER_HEXADECIMAL);
+          { addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL);
           }
         case 41: break;
         case 19:
-          { addToken(Token.ERROR_CHAR); /*addNullToken(); return firstToken;*/
+          { addToken(TokenTypes.ERROR_CHAR); /*addNullToken(); return firstToken;*/
           }
         case 42: break;
         case 27:
-          { addToken(Token.ERROR_STRING_DOUBLE);
+          { addToken(TokenTypes.ERROR_STRING_DOUBLE);
           }
         case 43: break;
         case 15:
-          { addToken(Token.LITERAL_NUMBER_FLOAT);
+          { addToken(TokenTypes.LITERAL_NUMBER_FLOAT);
           }
         case 44: break;
         case 16:
-          { addToken(Token.RESERVED_WORD);
+          { addToken(TokenTypes.RESERVED_WORD);
           }
         case 45: break;
         case 5:
-          { addToken(Token.SEPARATOR);
+          { addToken(TokenTypes.SEPARATOR);
           }
         case 46: break;
         case 2:
-          { addToken(Token.IDENTIFIER);
+          { addToken(TokenTypes.IDENTIFIER);
           }
         case 47: break;
         case 13:
-          { addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
           }
         case 48: break;
         case 17:
@@ -2272,33 +2272,33 @@ public class CPlusPlusTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 49: break;
         case 24:
-          { addToken(Token.FUNCTION);
+          { addToken(TokenTypes.FUNCTION);
           }
         case 50: break;
         case 6:
-          { addToken(Token.ERROR_CHAR); addNullToken(); return firstToken;
+          { addToken(TokenTypes.ERROR_CHAR); addNullToken(); return firstToken;
           }
         case 51: break;
         case 8:
-          { addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
+          { addToken(TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
           }
         case 52: break;
         case 25:
-          { addToken(Token.DATA_TYPE);
+          { addToken(TokenTypes.DATA_TYPE);
           }
         case 53: break;
         case 1:
-          { addToken(Token.ERROR_IDENTIFIER);
+          { addToken(TokenTypes.ERROR_IDENTIFIER);
           }
         case 54: break;
         case 12:
           { /* Line ending in '\' => continue to next line. */
-								addToken(start,zzStartRead, Token.COMMENT_EOL);
+								addToken(start,zzStartRead, TokenTypes.COMMENT_EOL);
 								return firstToken;
           }
         case 55: break;
         case 20:
-          { addToken(Token.ERROR_CHAR);
+          { addToken(TokenTypes.ERROR_CHAR);
           }
         case 56: break;
         case 23:
@@ -2306,31 +2306,31 @@ public class CPlusPlusTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 57: break;
         case 21:
-          { addToken(Token.LITERAL_STRING_DOUBLE_QUOTE);
+          { addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
           }
         case 58: break;
         case 31:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos;
           }
         case 59: break;
         case 30:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos;
           }
         case 60: break;
         case 32:
-          { addToken(Token.RESERVED_WORD_2);
+          { addToken(TokenTypes.RESERVED_WORD_2);
           }
         case 61: break;
         case 14:
-          { addToken(Token.ERROR_NUMBER_FORMAT);
+          { addToken(TokenTypes.ERROR_NUMBER_FORMAT);
           }
         case 62: break;
         case 3:
-          { addToken(Token.LITERAL_NUMBER_DECIMAL_INT);
+          { addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT);
           }
         case 63: break;
         case 4:
-          { addToken(Token.OPERATOR);
+          { addToken(TokenTypes.OPERATOR);
           }
         case 64: break;
         case 10:
@@ -2338,7 +2338,7 @@ public class CPlusPlusTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 65: break;
         case 11:
-          { addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken;
           }
         case 66: break;
         default:
@@ -2346,7 +2346,7 @@ public class CPlusPlusTokenMaker extends AbstractJFlexCTokenMaker {
             zzAtEOF = true;
             switch (zzLexicalState) {
             case EOL_COMMENT: {
-              addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
             }
             case 592: break;
             case YYINITIAL: {
@@ -2354,7 +2354,7 @@ public class CPlusPlusTokenMaker extends AbstractJFlexCTokenMaker {
             }
             case 593: break;
             case MLC: {
-              addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken;
             }
             case 594: break;
             default:

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/CSSTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/CSSTokenMaker.flex
@@ -200,7 +200,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 
 	@Override
 	public boolean getMarkOccurrencesOfTokenType(int type) {
-		return type==Token.RESERVED_WORD; // Used for CSS keys
+		return type==TokenTypes.RESERVED_WORD; // Used for CSS keys
 	}
 
 
@@ -387,21 +387,21 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 %%
 
 <YYINITIAL> {
-	{CSS_SelectorPiece}		{ addToken(Token.DATA_TYPE); }
-	{CSS_PseudoClass}		{ addToken(Token.RESERVED_WORD); }
-	":"						{ /* Unknown pseudo class */ addToken(Token.DATA_TYPE); }
-	{CSS_AtRule}			{ addToken(Token.REGEX); }
-	{CSS_Less_Var}			{ addToken(highlightingLess ? Token.VARIABLE : Token.REGEX); }
-	{CSS_Number}			{ addToken(highlightingLess ? Token.LITERAL_NUMBER_DECIMAL_INT : Token.IDENTIFIER); }
-	{CSS_Id}				{ addToken(highlightingLess ? Token.ANNOTATION : Token.VARIABLE); }
-	"{"						{ addToken(Token.SEPARATOR); yybegin(CSS_PROPERTY); }
-	[,]						{ addToken(Token.IDENTIFIER); }
+	{CSS_SelectorPiece}		{ addToken(TokenTypes.DATA_TYPE); }
+	{CSS_PseudoClass}		{ addToken(TokenTypes.RESERVED_WORD); }
+	":"						{ /* Unknown pseudo class */ addToken(TokenTypes.DATA_TYPE); }
+	{CSS_AtRule}			{ addToken(TokenTypes.REGEX); }
+	{CSS_Less_Var}			{ addToken(highlightingLess ? TokenTypes.VARIABLE : TokenTypes.REGEX); }
+	{CSS_Number}			{ addToken(highlightingLess ? TokenTypes.LITERAL_NUMBER_DECIMAL_INT : TokenTypes.IDENTIFIER); }
+	{CSS_Id}				{ addToken(highlightingLess ? TokenTypes.ANNOTATION : TokenTypes.VARIABLE); }
+	"{"						{ addToken(TokenTypes.SEPARATOR); yybegin(CSS_PROPERTY); }
+	[,]						{ addToken(TokenTypes.IDENTIFIER); }
 	\"						{ start = zzMarkedPos-1; cssPrevState = zzLexicalState; yybegin(CSS_STRING); }
 	\'						{ start = zzMarkedPos-1; cssPrevState = zzLexicalState; yybegin(CSS_CHAR_LITERAL); }
-	"}"						{ addToken(highlightingLess ? Token.SEPARATOR : Token.IDENTIFIER); }
-	[+>~\^$\|=]				{ addToken(Token.OPERATOR); }
-	{CSS_Separator}			{ addToken(Token.SEPARATOR); }
-	{WhiteSpace}			{ addToken(Token.WHITESPACE); }
+	"}"						{ addToken(highlightingLess ? TokenTypes.SEPARATOR : TokenTypes.IDENTIFIER); }
+	[+>~\^$\|=]				{ addToken(TokenTypes.OPERATOR); }
+	{CSS_Separator}			{ addToken(TokenTypes.SEPARATOR); }
+	{WhiteSpace}			{ addToken(TokenTypes.WHITESPACE); }
 	{MlcStart}				{ start = zzMarkedPos-2; cssPrevState = zzLexicalState; yybegin(CSS_C_STYLE_COMMENT); }
 	{Less_LineCommentBegin}	{
 								if (highlightingLess) {
@@ -409,35 +409,35 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 								}
 								else { // Highlight the "//" as an identifier and continue on
 									int temp = zzStartRead + 2;
-									addToken(zzStartRead, zzStartRead + 1, Token.IDENTIFIER);
+									addToken(zzStartRead, zzStartRead + 1, TokenTypes.IDENTIFIER);
 									zzStartRead = temp;
 								}
 							}
-	.						{ /*System.out.println("yyinitial: " + yytext());*/ addToken(Token.IDENTIFIER); }
+	.						{ /*System.out.println("yyinitial: " + yytext());*/ addToken(TokenTypes.IDENTIFIER); }
 	"\n" |
 	<<EOF>>					{ addNullToken(); return firstToken; }
 }
 
 <CSS_PROPERTY> {
-	{CSS_Property}			{ addToken(Token.RESERVED_WORD); }
-	{CSS_Less_Var}			{ addToken(highlightingLess ? Token.VARIABLE : Token.IDENTIFIER); }
-	{Less_Nested_Selector_With_Pseudo}	{ addToken(highlightingLess ? Token.RESERVED_WORD : Token.IDENTIFIER); }
+	{CSS_Property}			{ addToken(TokenTypes.RESERVED_WORD); }
+	{CSS_Less_Var}			{ addToken(highlightingLess ? TokenTypes.VARIABLE : TokenTypes.IDENTIFIER); }
+	{Less_Nested_Selector_With_Pseudo}	{ addToken(highlightingLess ? TokenTypes.RESERVED_WORD : TokenTypes.IDENTIFIER); }
 	{Less_Selector_ParentRef}	{
 									if (highlightingLess) {
 										// Unfortunately, as we're sharing the CSS and Less
 										// syntax highlighting, we do not color nested selectors
 										// properly.  For uniformity, color this the same as
 										// CSS_Property
-										addToken(Token.RESERVED_WORD);
+										addToken(TokenTypes.RESERVED_WORD);
 									}
 									else {
-										addToken(Token.IDENTIFIER);
+										addToken(TokenTypes.IDENTIFIER);
 									}
 								}
-	"{"						{ addToken(Token.SEPARATOR); /* helps with auto-closing curlies when editing CSS */ }
-	"}"						{ addToken(Token.SEPARATOR); yybegin(YYINITIAL); }
-	":"						{ addToken(Token.OPERATOR); yybegin(CSS_VALUE); }
-	{WhiteSpace}			{ addToken(Token.WHITESPACE); }
+	"{"						{ addToken(TokenTypes.SEPARATOR); /* helps with auto-closing curlies when editing CSS */ }
+	"}"						{ addToken(TokenTypes.SEPARATOR); yybegin(YYINITIAL); }
+	":"						{ addToken(TokenTypes.OPERATOR); yybegin(CSS_VALUE); }
+	{WhiteSpace}			{ addToken(TokenTypes.WHITESPACE); }
 	{MlcStart}				{ start = zzMarkedPos-2; cssPrevState = zzLexicalState; yybegin(CSS_C_STYLE_COMMENT); }
 	{Less_LineCommentBegin}	{
 								if (highlightingLess) {
@@ -446,11 +446,11 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 								}
 								else { // Highlight the "//" as an identifier and continue on
 									int temp = zzStartRead + 2;
-									addToken(zzStartRead, zzStartRead + 1, Token.IDENTIFIER);
+									addToken(zzStartRead, zzStartRead + 1, TokenTypes.IDENTIFIER);
 									zzStartRead = temp;
 								}
 							}
-	.						{ /*System.out.println("css_property: " + yytext());*/ addToken(Token.IDENTIFIER); }
+	.						{ /*System.out.println("css_property: " + yytext());*/ addToken(TokenTypes.IDENTIFIER); }
 	"\n" |
 	<<EOF>>					{ addEndToken(INTERNAL_CSS_PROPERTY); return firstToken; }
 }
@@ -464,28 +464,28 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 								}
 								else { // Highlight the "//" as an identifier and continue on
 									int temp = zzStartRead + 2;
-									addToken(zzStartRead, zzStartRead + 1, Token.IDENTIFIER);
+									addToken(zzStartRead, zzStartRead + 1, TokenTypes.IDENTIFIER);
 									zzStartRead = temp;
 								}
 							}
-	{CSS_Value}				{ addToken(Token.IDENTIFIER); }
-	"!important"			{ addToken(Token.PREPROCESSOR); }
+	{CSS_Value}				{ addToken(TokenTypes.IDENTIFIER); }
+	"!important"			{ addToken(TokenTypes.PREPROCESSOR); }
 	{CSS_Function}			{ int temp = zzMarkedPos - 2;
-							  addToken(zzStartRead, temp, Token.FUNCTION);
-							  addToken(zzMarkedPos-1, zzMarkedPos-1, Token.SEPARATOR);
+							  addToken(zzStartRead, temp, TokenTypes.FUNCTION);
+							  addToken(zzMarkedPos-1, zzMarkedPos-1, TokenTypes.SEPARATOR);
 							  zzStartRead = zzCurrentPos = zzMarkedPos;
 							}
-	{CSS_Number}			{ addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
-	{CSS_Less_Var}			{ addToken(highlightingLess ? Token.VARIABLE : Token.IDENTIFIER); }
+	{CSS_Number}			{ addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT); }
+	{CSS_Less_Var}			{ addToken(highlightingLess ? TokenTypes.VARIABLE : TokenTypes.IDENTIFIER); }
 	\"						{ start = zzMarkedPos-1; cssPrevState = zzLexicalState; yybegin(CSS_STRING); }
 	\'						{ start = zzMarkedPos-1; cssPrevState = zzLexicalState; yybegin(CSS_CHAR_LITERAL); }
-	")"						{ /* End of a function */ addToken(Token.SEPARATOR); }
-	[;]						{ addToken(Token.OPERATOR); yybegin(CSS_PROPERTY); }
-	[,\.]					{ addToken(Token.IDENTIFIER); }
-	"}"						{ addToken(Token.SEPARATOR); yybegin(YYINITIAL); }
-	{WhiteSpace}			{ addToken(Token.WHITESPACE); }
+	")"						{ /* End of a function */ addToken(TokenTypes.SEPARATOR); }
+	[;]						{ addToken(TokenTypes.OPERATOR); yybegin(CSS_PROPERTY); }
+	[,\.]					{ addToken(TokenTypes.IDENTIFIER); }
+	"}"						{ addToken(TokenTypes.SEPARATOR); yybegin(YYINITIAL); }
+	{WhiteSpace}			{ addToken(TokenTypes.WHITESPACE); }
 	{MlcStart}				{ start = zzMarkedPos-2; cssPrevState = zzLexicalState; yybegin(CSS_C_STYLE_COMMENT); }
-	.						{ /*System.out.println("css_value: " + yytext());*/ addToken(Token.IDENTIFIER); }
+	.						{ /*System.out.println("css_value: " + yytext());*/ addToken(TokenTypes.IDENTIFIER); }
 	"\n" |
 	<<EOF>>					{ addEndToken(INTERNAL_CSS_VALUE); return firstToken; }
 }
@@ -493,36 +493,36 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 <CSS_STRING> {
 	[^\n\\\"]+			{}
 	\\.?				{ /* Skip escaped chars. */ }
-	\"					{ addToken(start,zzStartRead, Token.LITERAL_STRING_DOUBLE_QUOTE); yybegin(cssPrevState); }
+	\"					{ addToken(start,zzStartRead, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); yybegin(cssPrevState); }
 	\n |
-	<<EOF>>				{ addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); addEndToken(INTERNAL_CSS_STRING - cssPrevState); return firstToken; }
+	<<EOF>>				{ addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); addEndToken(INTERNAL_CSS_STRING - cssPrevState); return firstToken; }
 }
 
 <CSS_CHAR_LITERAL> {
 	[^\n\\\']+			{}
 	\\.?				{ /* Skip escaped chars. */ }
-	\'					{ addToken(start,zzStartRead, Token.LITERAL_CHAR); yybegin(cssPrevState); }
+	\'					{ addToken(start,zzStartRead, TokenTypes.LITERAL_CHAR); yybegin(cssPrevState); }
 	\n |
-	<<EOF>>				{ addToken(start,zzStartRead-1, Token.LITERAL_CHAR); addEndToken(INTERNAL_CSS_CHAR - cssPrevState); return firstToken; }
+	<<EOF>>				{ addToken(start,zzStartRead-1, TokenTypes.LITERAL_CHAR); addEndToken(INTERNAL_CSS_CHAR - cssPrevState); return firstToken; }
 }
 
 <CSS_C_STYLE_COMMENT> {
 	[^hwf\n\*]+			{}
-	{URL}				{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos; }
+	{URL}				{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos; }
 	[hwf]				{}
-	{MlcEnd}			{ addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE); yybegin(cssPrevState); }
+	{MlcEnd}			{ addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE); yybegin(cssPrevState); }
 	\*					{}
 	\n |
-	<<EOF>>				{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addEndToken(INTERNAL_CSS_MLC - cssPrevState); return firstToken; }
+	<<EOF>>				{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addEndToken(INTERNAL_CSS_MLC - cssPrevState); return firstToken; }
 }
 
 <LESS_EOL_COMMENT> {
 	[^hwf\n]+				{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos; }
 	[hwf]					{}
 	\n |
 	<<EOF>>					{
-								addToken(start,zzStartRead-1, Token.COMMENT_EOL);
+								addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL);
 								switch (cssPrevState) {
 									case CSS_PROPERTY:
 										addEndToken(INTERNAL_CSS_PROPERTY);

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/CSSTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/CSSTokenMaker.java
@@ -650,7 +650,7 @@ public class CSSTokenMaker extends AbstractJFlexCTokenMaker {
 
 	@Override
 	public boolean getMarkOccurrencesOfTokenType(int type) {
-		return type==Token.RESERVED_WORD; // Used for CSS keys
+		return type==TokenTypes.RESERVED_WORD; // Used for CSS keys
 	}
 
 
@@ -1010,11 +1010,11 @@ public class CSSTokenMaker extends AbstractJFlexCTokenMaker {
 
       switch (zzAction < 0 ? zzAction : ZZ_ACTION[zzAction]) {
         case 1:
-          { addToken(Token.IDENTIFIER);
+          { addToken(TokenTypes.IDENTIFIER);
           }
         case 48: break;
         case 2:
-          { /*System.out.println("yyinitial: " + yytext());*/ addToken(Token.IDENTIFIER);
+          { /*System.out.println("yyinitial: " + yytext());*/ addToken(TokenTypes.IDENTIFIER);
           }
         case 49: break;
         case 25:
@@ -1022,7 +1022,7 @@ public class CSSTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 50: break;
         case 16:
-          { addToken(highlightingLess ? Token.RESERVED_WORD : Token.IDENTIFIER);
+          { addToken(highlightingLess ? TokenTypes.RESERVED_WORD : TokenTypes.IDENTIFIER);
           }
         case 51: break;
         case 42:
@@ -1033,21 +1033,21 @@ public class CSSTokenMaker extends AbstractJFlexCTokenMaker {
 								}
 								else { // Highlight the "//" as an identifier and continue on
 									int temp = zzStartRead + 2;
-									addToken(zzStartRead, zzStartRead + 1, Token.IDENTIFIER);
+									addToken(zzStartRead, zzStartRead + 1, TokenTypes.IDENTIFIER);
 									zzStartRead = temp;
 								}
           }
         case 52: break;
         case 9:
-          { addToken(Token.SEPARATOR); yybegin(CSS_PROPERTY);
+          { addToken(TokenTypes.SEPARATOR); yybegin(CSS_PROPERTY);
           }
         case 53: break;
         case 29:
-          { addToken(start,zzStartRead, Token.LITERAL_STRING_DOUBLE_QUOTE); yybegin(cssPrevState);
+          { addToken(start,zzStartRead, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); yybegin(cssPrevState);
           }
         case 54: break;
         case 32:
-          { addToken(start,zzStartRead-1, Token.LITERAL_CHAR); addEndToken(INTERNAL_CSS_CHAR - cssPrevState); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.LITERAL_CHAR); addEndToken(INTERNAL_CSS_CHAR - cssPrevState); return firstToken;
           }
         case 55: break;
         case 37:
@@ -1055,7 +1055,7 @@ public class CSSTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 56: break;
         case 34:
-          { addToken(start,zzStartRead-1, Token.COMMENT_EOL);
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL);
 								switch (cssPrevState) {
 									case CSS_PROPERTY:
 										addEndToken(INTERNAL_CSS_PROPERTY);
@@ -1071,15 +1071,15 @@ public class CSSTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 57: break;
         case 31:
-          { addToken(start,zzStartRead, Token.LITERAL_CHAR); yybegin(cssPrevState);
+          { addToken(start,zzStartRead, TokenTypes.LITERAL_CHAR); yybegin(cssPrevState);
           }
         case 58: break;
         case 43:
-          { addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE); yybegin(cssPrevState);
+          { addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE); yybegin(cssPrevState);
           }
         case 59: break;
         case 12:
-          { addToken(highlightingLess ? Token.SEPARATOR : Token.IDENTIFIER);
+          { addToken(highlightingLess ? TokenTypes.SEPARATOR : TokenTypes.IDENTIFIER);
           }
         case 60: break;
         case 10:
@@ -1087,15 +1087,15 @@ public class CSSTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 61: break;
         case 17:
-          { addToken(Token.OPERATOR); yybegin(CSS_VALUE);
+          { addToken(TokenTypes.OPERATOR); yybegin(CSS_VALUE);
           }
         case 62: break;
         case 5:
-          { /* Unknown pseudo class */ addToken(Token.DATA_TYPE);
+          { /* Unknown pseudo class */ addToken(TokenTypes.DATA_TYPE);
           }
         case 63: break;
         case 23:
-          { addToken(Token.OPERATOR); yybegin(CSS_PROPERTY);
+          { addToken(TokenTypes.OPERATOR); yybegin(CSS_PROPERTY);
           }
         case 64: break;
         case 28:
@@ -1103,15 +1103,15 @@ public class CSSTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 65: break;
         case 46:
-          { addToken(Token.REGEX);
+          { addToken(TokenTypes.REGEX);
           }
         case 66: break;
         case 36:
-          { addToken(highlightingLess ? Token.ANNOTATION : Token.VARIABLE);
+          { addToken(highlightingLess ? TokenTypes.ANNOTATION : TokenTypes.VARIABLE);
           }
         case 67: break;
         case 3:
-          { addToken(highlightingLess ? Token.LITERAL_NUMBER_DECIMAL_INT : Token.IDENTIFIER);
+          { addToken(highlightingLess ? TokenTypes.LITERAL_NUMBER_DECIMAL_INT : TokenTypes.IDENTIFIER);
           }
         case 68: break;
         case 20:
@@ -1119,42 +1119,42 @@ public class CSSTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 69: break;
         case 7:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 70: break;
         case 19:
-          { addToken(Token.SEPARATOR); yybegin(YYINITIAL);
+          { addToken(TokenTypes.SEPARATOR); yybegin(YYINITIAL);
           }
         case 71: break;
         case 47:
-          { addToken(Token.PREPROCESSOR);
+          { addToken(TokenTypes.PREPROCESSOR);
           }
         case 72: break;
         case 4:
-          { addToken(Token.DATA_TYPE);
+          { addToken(TokenTypes.DATA_TYPE);
           }
         case 73: break;
         case 35:
-          { addToken(highlightingLess ? Token.VARIABLE : Token.REGEX);
+          { addToken(highlightingLess ? TokenTypes.VARIABLE : TokenTypes.REGEX);
           }
         case 74: break;
         case 24:
           { int temp = zzMarkedPos - 2;
-							  addToken(zzStartRead, temp, Token.FUNCTION);
-							  addToken(zzMarkedPos-1, zzMarkedPos-1, Token.SEPARATOR);
+							  addToken(zzStartRead, temp, TokenTypes.FUNCTION);
+							  addToken(zzMarkedPos-1, zzMarkedPos-1, TokenTypes.SEPARATOR);
 							  zzStartRead = zzCurrentPos = zzMarkedPos;
           }
         case 75: break;
         case 18:
-          { addToken(Token.SEPARATOR); /* helps with auto-closing curlies when editing CSS */
+          { addToken(TokenTypes.SEPARATOR); /* helps with auto-closing curlies when editing CSS */
           }
         case 76: break;
         case 22:
-          { addToken(Token.LITERAL_NUMBER_DECIMAL_INT);
+          { addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT);
           }
         case 77: break;
         case 30:
-          { addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); addEndToken(INTERNAL_CSS_STRING - cssPrevState); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); addEndToken(INTERNAL_CSS_STRING - cssPrevState); return firstToken;
           }
         case 78: break;
         case 41:
@@ -1163,19 +1163,19 @@ public class CSSTokenMaker extends AbstractJFlexCTokenMaker {
 										// syntax highlighting, we do not color nested selectors
 										// properly.  For uniformity, color this the same as
 										// CSS_Property
-										addToken(Token.RESERVED_WORD);
+										addToken(TokenTypes.RESERVED_WORD);
 									}
 									else {
-										addToken(Token.IDENTIFIER);
+										addToken(TokenTypes.IDENTIFIER);
 									}
           }
         case 79: break;
         case 33:
-          { addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addEndToken(INTERNAL_CSS_MLC - cssPrevState); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addEndToken(INTERNAL_CSS_MLC - cssPrevState); return firstToken;
           }
         case 80: break;
         case 26:
-          { /* End of a function */ addToken(Token.SEPARATOR);
+          { /* End of a function */ addToken(TokenTypes.SEPARATOR);
           }
         case 81: break;
         case 40:
@@ -1185,25 +1185,25 @@ public class CSSTokenMaker extends AbstractJFlexCTokenMaker {
 								}
 								else { // Highlight the "//" as an identifier and continue on
 									int temp = zzStartRead + 2;
-									addToken(zzStartRead, zzStartRead + 1, Token.IDENTIFIER);
+									addToken(zzStartRead, zzStartRead + 1, TokenTypes.IDENTIFIER);
 									zzStartRead = temp;
 								}
           }
         case 82: break;
         case 39:
-          { addToken(highlightingLess ? Token.VARIABLE : Token.IDENTIFIER);
+          { addToken(highlightingLess ? TokenTypes.VARIABLE : TokenTypes.IDENTIFIER);
           }
         case 83: break;
         case 14:
-          { /*System.out.println("css_property: " + yytext());*/ addToken(Token.IDENTIFIER);
+          { /*System.out.println("css_property: " + yytext());*/ addToken(TokenTypes.IDENTIFIER);
           }
         case 84: break;
         case 15:
-          { addToken(Token.RESERVED_WORD);
+          { addToken(TokenTypes.RESERVED_WORD);
           }
         case 85: break;
         case 44:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos;
           }
         case 86: break;
         case 11:
@@ -1211,7 +1211,7 @@ public class CSSTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 87: break;
         case 6:
-          { addToken(Token.SEPARATOR);
+          { addToken(TokenTypes.SEPARATOR);
           }
         case 88: break;
         case 13:
@@ -1224,21 +1224,21 @@ public class CSSTokenMaker extends AbstractJFlexCTokenMaker {
 								}
 								else { // Highlight the "//" as an identifier and continue on
 									int temp = zzStartRead + 2;
-									addToken(zzStartRead, zzStartRead + 1, Token.IDENTIFIER);
+									addToken(zzStartRead, zzStartRead + 1, TokenTypes.IDENTIFIER);
 									zzStartRead = temp;
 								}
           }
         case 90: break;
         case 8:
-          { addToken(Token.OPERATOR);
+          { addToken(TokenTypes.OPERATOR);
           }
         case 91: break;
         case 21:
-          { /*System.out.println("css_value: " + yytext());*/ addToken(Token.IDENTIFIER);
+          { /*System.out.println("css_value: " + yytext());*/ addToken(TokenTypes.IDENTIFIER);
           }
         case 92: break;
         case 45:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos;
           }
         case 93: break;
         case 27:
@@ -1250,11 +1250,11 @@ public class CSSTokenMaker extends AbstractJFlexCTokenMaker {
             zzAtEOF = true;
             switch (zzLexicalState) {
             case CSS_C_STYLE_COMMENT: {
-              addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addEndToken(INTERNAL_CSS_MLC - cssPrevState); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addEndToken(INTERNAL_CSS_MLC - cssPrevState); return firstToken;
             }
             case 341: break;
             case LESS_EOL_COMMENT: {
-              addToken(start,zzStartRead-1, Token.COMMENT_EOL);
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL);
 								switch (cssPrevState) {
 									case CSS_PROPERTY:
 										addEndToken(INTERNAL_CSS_PROPERTY);
@@ -1274,7 +1274,7 @@ public class CSSTokenMaker extends AbstractJFlexCTokenMaker {
             }
             case 343: break;
             case CSS_STRING: {
-              addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); addEndToken(INTERNAL_CSS_STRING - cssPrevState); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); addEndToken(INTERNAL_CSS_STRING - cssPrevState); return firstToken;
             }
             case 344: break;
             case CSS_VALUE: {
@@ -1286,7 +1286,7 @@ public class CSSTokenMaker extends AbstractJFlexCTokenMaker {
             }
             case 346: break;
             case CSS_CHAR_LITERAL: {
-              addToken(start,zzStartRead-1, Token.LITERAL_CHAR); addEndToken(INTERNAL_CSS_CHAR - cssPrevState); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.LITERAL_CHAR); addEndToken(INTERNAL_CSS_CHAR - cssPrevState); return firstToken;
             }
             case 347: break;
             default:

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/CSharpTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/CSharpTokenMaker.flex
@@ -150,11 +150,11 @@ import org.fife.ui.rsyntaxtextarea.*;
 		// Start off in the proper state.
 		int state;
 		switch (initialTokenType) {
-			case Token.LITERAL_STRING_DOUBLE_QUOTE:
+			case TokenTypes.LITERAL_STRING_DOUBLE_QUOTE:
 				state = VERBATIMSTRING;
 				start = text.offset;
 				break;
-			case Token.COMMENT_MULTILINE:
+			case TokenTypes.COMMENT_MULTILINE:
 				state = DELIMITEDCOMMENT;
 				start = text.offset;
 				break;
@@ -404,7 +404,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"virtual" |
 	"void" |
 	"volatile" |
-	"while"								{ addToken(Token.RESERVED_WORD); }
+	"while"								{ addToken(TokenTypes.RESERVED_WORD); }
 
 	/* Data types. */
 	"bool" |
@@ -420,56 +420,56 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"string" |
 	"uint" |
 	"ulong" |
-	"ushort"							{ addToken(Token.DATA_TYPE); }
+	"ushort"							{ addToken(TokenTypes.DATA_TYPE); }
 
 
 	{NewlineCharacter}					{ addNullToken(); return firstToken; }
 
-	{BooleanLiteral}					{ addToken(Token.LITERAL_BOOLEAN); }
+	{BooleanLiteral}					{ addToken(TokenTypes.LITERAL_BOOLEAN); }
 
-	{Identifier}						{ addToken(Token.IDENTIFIER); }
+	{Identifier}						{ addToken(TokenTypes.IDENTIFIER); }
 
-	{Whitespace}						{ addToken(Token.WHITESPACE); }
+	{Whitespace}						{ addToken(TokenTypes.WHITESPACE); }
 
 	/* String/Character Literals. */
-	{CharacterLiteral}					{ addToken(Token.LITERAL_CHAR); }
-	{UnclosedCharacterLiteral}			{ addToken(Token.ERROR_CHAR); /*addNullToken(); return firstToken;*/ }
-	{ErrorUnclosedCharacterLiteral}		{ addToken(Token.ERROR_CHAR); addNullToken(); return firstToken; }
-	{ErrorCharacterLiteral}				{ addToken(Token.ERROR_CHAR); }
+	{CharacterLiteral}					{ addToken(TokenTypes.LITERAL_CHAR); }
+	{UnclosedCharacterLiteral}			{ addToken(TokenTypes.ERROR_CHAR); /*addNullToken(); return firstToken;*/ }
+	{ErrorUnclosedCharacterLiteral}		{ addToken(TokenTypes.ERROR_CHAR); addNullToken(); return firstToken; }
+	{ErrorCharacterLiteral}				{ addToken(TokenTypes.ERROR_CHAR); }
 	{VerbatimStringLiteralStart}			{ start = zzMarkedPos-2; yybegin(VERBATIMSTRING); }
-	{RegularStringLiteral}				{ addToken(Token.LITERAL_STRING_DOUBLE_QUOTE); }
-	{UnclosedRegularStringLiteral}		{ addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
-	{ErrorRegularStringLiteral}			{ addToken(Token.ERROR_STRING_DOUBLE); }
+	{RegularStringLiteral}				{ addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); }
+	{UnclosedRegularStringLiteral}		{ addToken(TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
+	{ErrorRegularStringLiteral}			{ addToken(TokenTypes.ERROR_STRING_DOUBLE); }
 
 	/* Comments. */
 	{DelimitedCommentStart}				{ start = zzMarkedPos-2; yybegin(DELIMITEDCOMMENT); }
 	{DocumentationCommentStart}			{ start = zzMarkedPos-3; yybegin(DOCUMENTCOMMENT); }
-	{SingleLineComment}					{ addToken(Token.COMMENT_EOL); addNullToken(); return firstToken; }
+	{SingleLineComment}					{ addToken(TokenTypes.COMMENT_EOL); addNullToken(); return firstToken; }
 
 	/* Separators. */
-	{Separator}						{ addToken(Token.SEPARATOR); }
-	{Separator2}						{ addToken(Token.IDENTIFIER); }
+	{Separator}						{ addToken(TokenTypes.SEPARATOR); }
+	{Separator2}						{ addToken(TokenTypes.IDENTIFIER); }
 
 	/* Operators. */
-	{OperatorOrPunctuator}				{ addToken(Token.OPERATOR); }
+	{OperatorOrPunctuator}				{ addToken(TokenTypes.OPERATOR); }
 
 	/* Numbers */
-	{DecimalIntegerLiteral}				{ addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
-	{HexadecimalIntegerLiteral}			{ addToken(Token.LITERAL_NUMBER_HEXADECIMAL); }
-	{RealLiteral}						{ addToken(Token.LITERAL_NUMBER_FLOAT); }
-	{ErrorNumberFormat}					{ addToken(Token.ERROR_NUMBER_FORMAT); }
+	{DecimalIntegerLiteral}				{ addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT); }
+	{HexadecimalIntegerLiteral}			{ addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL); }
+	{RealLiteral}						{ addToken(TokenTypes.LITERAL_NUMBER_FLOAT); }
+	{ErrorNumberFormat}					{ addToken(TokenTypes.ERROR_NUMBER_FORMAT); }
 
 	/* Preprocessor directives. */
-	{PPDirective}						{ addToken(Token.PREPROCESSOR); }
+	{PPDirective}						{ addToken(TokenTypes.PREPROCESSOR); }
 
 	/* Pretty-much anything else. */
-	{ErrorIdentifier}					{ addToken(Token.ERROR_IDENTIFIER); }
+	{ErrorIdentifier}					{ addToken(TokenTypes.ERROR_IDENTIFIER); }
 
 	/* Ended with a line not in a string or comment. */
 	<<EOF>>							{ addNullToken(); return firstToken; }
 
 	/* Catch any other (unhandled) characters and flag them as bad. */
-	.								{ addToken(Token.ERROR_IDENTIFIER); }
+	.								{ addToken(TokenTypes.ERROR_IDENTIFIER); }
 
 }
 
@@ -477,12 +477,12 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 <DELIMITEDCOMMENT> {
 
 	[^hwf\n\*]+						{}
-	{URL}						{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos; }
+	{URL}						{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos; }
 	[hwf]						{}
-	\n							{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken; }
-	{DelimitedCommentEnd}			{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE); }
+	\n							{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken; }
+	{DelimitedCommentEnd}			{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE); }
 	\*							{}
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken; }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken; }
 
 }
 
@@ -490,12 +490,12 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 <DOCUMENTCOMMENT> {
 
 	[^hwf\<\n]*						{}
-	{URL}						{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_DOCUMENTATION); start = zzMarkedPos; }
+	{URL}						{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_DOCUMENTATION); start = zzMarkedPos; }
 	[hwf]						{}
-	\n							{ addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addNullToken(); return firstToken; }
-	"<"[^\>]*">"					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, Token.PREPROCESSOR); start = zzMarkedPos; }
-	"<"							{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addToken(temp,zzEndRead, Token.PREPROCESSOR); addNullToken(); return firstToken; }
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addNullToken(); return firstToken; }
+	\n							{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addNullToken(); return firstToken; }
+	"<"[^\>]*">"					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, TokenTypes.PREPROCESSOR); start = zzMarkedPos; }
+	"<"							{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addToken(temp,zzEndRead, TokenTypes.PREPROCESSOR); addNullToken(); return firstToken; }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addNullToken(); return firstToken; }
 
 }
 
@@ -504,8 +504,8 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 
 	[^\"\n]*						{}
 	{QuoteEscapeSequence}			{}
-	\"							{ yybegin(YYINITIAL); addToken(start,zzStartRead, Token.LITERAL_STRING_DOUBLE_QUOTE); }
-	\n							{ addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken; }
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken; }
+	\"							{ yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); }
+	\n							{ addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken; }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken; }
 
 }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/CSharpTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/CSharpTokenMaker.java
@@ -1132,11 +1132,11 @@ public class CSharpTokenMaker extends AbstractJFlexCTokenMaker {
 		// Start off in the proper state.
 		int state;
 		switch (initialTokenType) {
-			case Token.LITERAL_STRING_DOUBLE_QUOTE:
+			case TokenTypes.LITERAL_STRING_DOUBLE_QUOTE:
 				state = VERBATIMSTRING;
 				start = text.offset;
 				break;
-			case Token.COMMENT_MULTILINE:
+			case TokenTypes.COMMENT_MULTILINE:
 				state = DELIMITEDCOMMENT;
 				start = text.offset;
 				break;
@@ -1422,11 +1422,11 @@ public final void yybegin(int newState) {
 
       switch (zzAction < 0 ? zzAction : ZZ_ACTION[zzAction]) {
         case 35:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_DOCUMENTATION); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_DOCUMENTATION); start = zzMarkedPos;
           }
         case 36: break;
         case 28:
-          { addToken(Token.PREPROCESSOR);
+          { addToken(TokenTypes.PREPROCESSOR);
           }
         case 37: break;
         case 3:
@@ -1434,75 +1434,75 @@ public final void yybegin(int newState) {
           }
         case 38: break;
         case 30:
-          { addToken(Token.LITERAL_CHAR);
+          { addToken(TokenTypes.LITERAL_CHAR);
           }
         case 39: break;
         case 25:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE);
           }
         case 40: break;
         case 4:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 41: break;
         case 29:
-          { addToken(Token.LITERAL_NUMBER_HEXADECIMAL);
+          { addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL);
           }
         case 42: break;
         case 22:
-          { addToken(Token.ERROR_CHAR); /*addNullToken(); return firstToken;*/
+          { addToken(TokenTypes.ERROR_CHAR); /*addNullToken(); return firstToken;*/
           }
         case 43: break;
         case 31:
-          { addToken(Token.ERROR_STRING_DOUBLE);
+          { addToken(TokenTypes.ERROR_STRING_DOUBLE);
           }
         case 44: break;
         case 19:
-          { addToken(Token.LITERAL_NUMBER_FLOAT);
+          { addToken(TokenTypes.LITERAL_NUMBER_FLOAT);
           }
         case 45: break;
         case 21:
-          { addToken(Token.RESERVED_WORD);
+          { addToken(TokenTypes.RESERVED_WORD);
           }
         case 46: break;
         case 10:
-          { addToken(Token.SEPARATOR);
+          { addToken(TokenTypes.SEPARATOR);
           }
         case 47: break;
         case 12:
-          { addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addNullToken(); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addNullToken(); return firstToken;
           }
         case 48: break;
         case 6:
-          { addToken(Token.IDENTIFIER);
+          { addToken(TokenTypes.IDENTIFIER);
           }
         case 49: break;
         case 13:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addToken(temp,zzEndRead, Token.PREPROCESSOR); addNullToken(); return firstToken;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addToken(temp,zzEndRead, TokenTypes.PREPROCESSOR); addNullToken(); return firstToken;
           }
         case 50: break;
         case 8:
-          { addToken(Token.ERROR_CHAR); addNullToken(); return firstToken;
+          { addToken(TokenTypes.ERROR_CHAR); addNullToken(); return firstToken;
           }
         case 51: break;
         case 9:
-          { addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
+          { addToken(TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
           }
         case 52: break;
         case 32:
-          { addToken(Token.DATA_TYPE);
+          { addToken(TokenTypes.DATA_TYPE);
           }
         case 53: break;
         case 2:
-          { addToken(Token.ERROR_IDENTIFIER);
+          { addToken(TokenTypes.ERROR_IDENTIFIER);
           }
         case 54: break;
         case 23:
-          { addToken(Token.ERROR_CHAR);
+          { addToken(TokenTypes.ERROR_CHAR);
           }
         case 55: break;
         case 33:
-          { addToken(Token.LITERAL_BOOLEAN);
+          { addToken(TokenTypes.LITERAL_BOOLEAN);
           }
         case 56: break;
         case 20:
@@ -1510,23 +1510,23 @@ public final void yybegin(int newState) {
           }
         case 57: break;
         case 24:
-          { addToken(Token.LITERAL_STRING_DOUBLE_QUOTE);
+          { addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
           }
         case 58: break;
         case 14:
-          { addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
           }
         case 59: break;
         case 34:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos;
           }
         case 60: break;
         case 16:
-          { addToken(Token.COMMENT_EOL); addNullToken(); return firstToken;
+          { addToken(TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
           }
         case 61: break;
         case 18:
-          { addToken(Token.ERROR_NUMBER_FORMAT);
+          { addToken(TokenTypes.ERROR_NUMBER_FORMAT);
           }
         case 62: break;
         case 27:
@@ -1538,19 +1538,19 @@ public final void yybegin(int newState) {
           }
         case 64: break;
         case 7:
-          { addToken(Token.LITERAL_NUMBER_DECIMAL_INT);
+          { addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT);
           }
         case 65: break;
         case 5:
-          { addToken(Token.OPERATOR);
+          { addToken(TokenTypes.OPERATOR);
           }
         case 66: break;
         case 26:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, Token.PREPROCESSOR); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, TokenTypes.PREPROCESSOR); start = zzMarkedPos;
           }
         case 67: break;
         case 15:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead, Token.LITERAL_STRING_DOUBLE_QUOTE);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
           }
         case 68: break;
         case 1:
@@ -1558,7 +1558,7 @@ public final void yybegin(int newState) {
           }
         case 69: break;
         case 11:
-          { addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken;
           }
         case 70: break;
         default:
@@ -1566,11 +1566,11 @@ public final void yybegin(int newState) {
             zzAtEOF = true;
             switch (zzLexicalState) {
             case VERBATIMSTRING: {
-              addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
             }
             case 365: break;
             case DOCUMENTCOMMENT: {
-              addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addNullToken(); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addNullToken(); return firstToken;
             }
             case 366: break;
             case YYINITIAL: {
@@ -1578,7 +1578,7 @@ public final void yybegin(int newState) {
             }
             case 367: break;
             case DELIMITEDCOMMENT: {
-              addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken;
             }
             case 368: break;
             default:

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/CTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/CTokenMaker.flex
@@ -149,14 +149,14 @@ import org.fife.ui.rsyntaxtextarea.*;
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = Token.NULL;
+		int state = TokenTypes.NULL;
 		switch (initialTokenType) {
-			case Token.COMMENT_MULTILINE:
+			case TokenTypes.COMMENT_MULTILINE:
 				state = MLC;
 				start = text.offset;
 				break;
 			default:
-				state = Token.NULL;
+				state = TokenTypes.NULL;
 		}
 
 		s = text;
@@ -300,9 +300,9 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"typedef" |
 	"union" |
 	"volatile" |
-	"while"					{ addToken(Token.RESERVED_WORD); }
+	"while"					{ addToken(TokenTypes.RESERVED_WORD); }
 
-	"return"				{ addToken(Token.RESERVED_WORD_2); }
+	"return"				{ addToken(TokenTypes.RESERVED_WORD_2); }
 
 	/* Data types. */
 	"char" |
@@ -317,7 +317,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"size_t" |
 	"unsigned" |
 	"void" |
-	"wchar_t"				{ addToken(Token.DATA_TYPE); }
+	"wchar_t"				{ addToken(TokenTypes.DATA_TYPE); }
 
 	/* Standard functions */
 	"abort" |
@@ -519,20 +519,20 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"wmemmove" |
 	"wmemset" |
 	"wprintf" |
-	"wscanf"				{ addToken(Token.FUNCTION); }
+	"wscanf"				{ addToken(TokenTypes.FUNCTION); }
 
 	/* Standard-defined macros. */
 	"__DATE__" |
 	"__TIME__" |
 	"__FILE__" |
 	"__LINE__" |
-	"__STDC__"				{ addToken(Token.PREPROCESSOR); }
+	"__STDC__"				{ addToken(TokenTypes.PREPROCESSOR); }
 
 	{LineTerminator}				{ addNullToken(); return firstToken; }
 
-	{Identifier}					{ addToken(Token.IDENTIFIER); }
+	{Identifier}					{ addToken(TokenTypes.IDENTIFIER); }
 
-	{WhiteSpace}+					{ addToken(Token.WHITESPACE); }
+	{WhiteSpace}+					{ addToken(TokenTypes.WHITESPACE); }
 
 	/* Preprocessor directives */
 	/* Special-case <includes> for uniform appearance with "string" includes "*/
@@ -556,16 +556,16 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 
                                                      addToken(end + 1, zzMarkedPos - 1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
                                                  }
-	"#"{WhiteSpace}*{PreprocessorWord}	{ addToken(Token.PREPROCESSOR); }
+	"#"{WhiteSpace}*{PreprocessorWord}	{ addToken(TokenTypes.PREPROCESSOR); }
 
 	/* String/Character Literals. */
-	{CharLiteral}					{ addToken(Token.LITERAL_CHAR); }
-	{UnclosedCharLiteral}			{ addToken(Token.ERROR_CHAR); /*addNullToken(); return firstToken;*/ }
-	{ErrorUnclosedCharLiteral}		{ addToken(Token.ERROR_CHAR); addNullToken(); return firstToken; }
-	{ErrorCharLiteral}				{ addToken(Token.ERROR_CHAR); }
-	{StringLiteral}				{ addToken(Token.LITERAL_STRING_DOUBLE_QUOTE); }
-	{UnclosedStringLiteral}			{ addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
-	{ErrorStringLiteral}			{ addToken(Token.ERROR_STRING_DOUBLE); }
+	{CharLiteral}					{ addToken(TokenTypes.LITERAL_CHAR); }
+	{UnclosedCharLiteral}			{ addToken(TokenTypes.ERROR_CHAR); /*addNullToken(); return firstToken;*/ }
+	{ErrorUnclosedCharLiteral}		{ addToken(TokenTypes.ERROR_CHAR); addNullToken(); return firstToken; }
+	{ErrorCharLiteral}				{ addToken(TokenTypes.ERROR_CHAR); }
+	{StringLiteral}				{ addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); }
+	{UnclosedStringLiteral}			{ addToken(TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
+	{ErrorStringLiteral}			{ addToken(TokenTypes.ERROR_STRING_DOUBLE); }
 
 	/* Comment Literals. */
 	{MLCBegin}					{ start = zzMarkedPos-2; yybegin(MLC); }
@@ -577,7 +577,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"[" |
 	"]" |
 	"{" |
-	"}"							{ addToken(Token.SEPARATOR); }
+	"}"							{ addToken(TokenTypes.SEPARATOR); }
 
 	/* Operators. */
 	{Trigraph} |
@@ -618,48 +618,48 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"++" |
 	"--" |
 	"." |
-	","							{ addToken(Token.OPERATOR); }
+	","							{ addToken(TokenTypes.OPERATOR); }
 
 	/* Numbers */
-	{IntegerLiteral}				{ addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
-	{HexLiteral}					{ addToken(Token.LITERAL_NUMBER_HEXADECIMAL); }
-	{FloatLiteral}					{ addToken(Token.LITERAL_NUMBER_FLOAT); }
-	{ErrorNumberFormat}				{ addToken(Token.ERROR_NUMBER_FORMAT); }
+	{IntegerLiteral}				{ addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT); }
+	{HexLiteral}					{ addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL); }
+	{FloatLiteral}					{ addToken(TokenTypes.LITERAL_NUMBER_FLOAT); }
+	{ErrorNumberFormat}				{ addToken(TokenTypes.ERROR_NUMBER_FORMAT); }
 
 	/* Some lines will end in '\' to wrap an expression. */
-	"\\"							{ addToken(Token.IDENTIFIER); }
+	"\\"							{ addToken(TokenTypes.IDENTIFIER); }
 
-	{ErrorIdentifier}				{ addToken(Token.ERROR_IDENTIFIER); }
+	{ErrorIdentifier}				{ addToken(TokenTypes.ERROR_IDENTIFIER); }
 
 	/* Other punctuation, we'll highlight it as "identifiers." */
-	";"							{ addToken(Token.IDENTIFIER); }
+	";"							{ addToken(TokenTypes.IDENTIFIER); }
 
 	/* Ended with a line not in a string or comment. */
 	<<EOF>>						{ addNullToken(); return firstToken; }
 
 	/* Catch any other (unhandled) characters and flag them as bad. */
-	.							{ addToken(Token.ERROR_IDENTIFIER); }
+	.							{ addToken(TokenTypes.ERROR_IDENTIFIER); }
 
 }
 
 <MLC> {
 
 	[^hwf\n\*]+					{}
-	{URL}						{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos; }
+	{URL}						{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos; }
 	[hwf]						{}
 
-	\n							{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken; }
-	{MLCEnd}						{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE); }
+	\n							{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken; }
+	{MLCEnd}						{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE); }
 	\*							{}
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken; }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken; }
 
 }
 
 
 <EOL_COMMENT> {
 	[^hwf\n]+				{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos; }
 	[hwf]					{}
-	\n						{ addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken; }
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken; }
+	\n						{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken; }
 }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/CTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/CTokenMaker.java
@@ -1654,14 +1654,14 @@ public class CTokenMaker extends AbstractJFlexCTokenMaker {
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = Token.NULL;
+		int state = TokenTypes.NULL;
 		switch (initialTokenType) {
-			case Token.COMMENT_MULTILINE:
+			case TokenTypes.COMMENT_MULTILINE:
 				state = MLC;
 				start = text.offset;
 				break;
 			default:
-				state = Token.NULL;
+				state = TokenTypes.NULL;
 		}
 
 		s = text;
@@ -1941,7 +1941,7 @@ public class CTokenMaker extends AbstractJFlexCTokenMaker {
 
       switch (zzAction < 0 ? zzAction : ZZ_ACTION[zzAction]) {
         case 27:
-          { addToken(Token.PREPROCESSOR);
+          { addToken(TokenTypes.PREPROCESSOR);
           }
         case 32: break;
         case 7:
@@ -1949,11 +1949,11 @@ public class CTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 33: break;
         case 24:
-          { addToken(Token.LITERAL_CHAR);
+          { addToken(TokenTypes.LITERAL_CHAR);
           }
         case 34: break;
         case 21:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE);
           }
         case 35: break;
         case 31:
@@ -1982,39 +1982,39 @@ public class CTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 37: break;
         case 9:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 38: break;
         case 26:
-          { addToken(Token.LITERAL_NUMBER_HEXADECIMAL);
+          { addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL);
           }
         case 39: break;
         case 18:
-          { addToken(Token.ERROR_CHAR); /*addNullToken(); return firstToken;*/
+          { addToken(TokenTypes.ERROR_CHAR); /*addNullToken(); return firstToken;*/
           }
         case 40: break;
         case 25:
-          { addToken(Token.ERROR_STRING_DOUBLE);
+          { addToken(TokenTypes.ERROR_STRING_DOUBLE);
           }
         case 41: break;
         case 14:
-          { addToken(Token.LITERAL_NUMBER_FLOAT);
+          { addToken(TokenTypes.LITERAL_NUMBER_FLOAT);
           }
         case 42: break;
         case 15:
-          { addToken(Token.RESERVED_WORD);
+          { addToken(TokenTypes.RESERVED_WORD);
           }
         case 43: break;
         case 5:
-          { addToken(Token.SEPARATOR);
+          { addToken(TokenTypes.SEPARATOR);
           }
         case 44: break;
         case 2:
-          { addToken(Token.IDENTIFIER);
+          { addToken(TokenTypes.IDENTIFIER);
           }
         case 45: break;
         case 12:
-          { addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
           }
         case 46: break;
         case 16:
@@ -2022,55 +2022,55 @@ public class CTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 47: break;
         case 22:
-          { addToken(Token.FUNCTION);
+          { addToken(TokenTypes.FUNCTION);
           }
         case 48: break;
         case 6:
-          { addToken(Token.ERROR_CHAR); addNullToken(); return firstToken;
+          { addToken(TokenTypes.ERROR_CHAR); addNullToken(); return firstToken;
           }
         case 49: break;
         case 8:
-          { addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
+          { addToken(TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
           }
         case 50: break;
         case 23:
-          { addToken(Token.DATA_TYPE);
+          { addToken(TokenTypes.DATA_TYPE);
           }
         case 51: break;
         case 1:
-          { addToken(Token.ERROR_IDENTIFIER);
+          { addToken(TokenTypes.ERROR_IDENTIFIER);
           }
         case 52: break;
         case 19:
-          { addToken(Token.ERROR_CHAR);
+          { addToken(TokenTypes.ERROR_CHAR);
           }
         case 53: break;
         case 20:
-          { addToken(Token.LITERAL_STRING_DOUBLE_QUOTE);
+          { addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
           }
         case 54: break;
         case 29:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos;
           }
         case 55: break;
         case 28:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos;
           }
         case 56: break;
         case 30:
-          { addToken(Token.RESERVED_WORD_2);
+          { addToken(TokenTypes.RESERVED_WORD_2);
           }
         case 57: break;
         case 13:
-          { addToken(Token.ERROR_NUMBER_FORMAT);
+          { addToken(TokenTypes.ERROR_NUMBER_FORMAT);
           }
         case 58: break;
         case 3:
-          { addToken(Token.LITERAL_NUMBER_DECIMAL_INT);
+          { addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT);
           }
         case 59: break;
         case 4:
-          { addToken(Token.OPERATOR);
+          { addToken(TokenTypes.OPERATOR);
           }
         case 60: break;
         case 10:
@@ -2078,7 +2078,7 @@ public class CTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 61: break;
         case 11:
-          { addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken;
           }
         case 62: break;
         default:
@@ -2086,7 +2086,7 @@ public class CTokenMaker extends AbstractJFlexCTokenMaker {
             zzAtEOF = true;
             switch (zzLexicalState) {
             case EOL_COMMENT: {
-              addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
             }
             case 512: break;
             case YYINITIAL: {
@@ -2094,7 +2094,7 @@ public class CTokenMaker extends AbstractJFlexCTokenMaker {
             }
             case 513: break;
             case MLC: {
-              addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken;
             }
             case 514: break;
             default:

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/ClojureTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/ClojureTokenMaker.flex
@@ -154,22 +154,22 @@ import org.fife.ui.rsyntaxtextarea.*;
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = Token.NULL;
+		int state = TokenTypes.NULL;
 		switch (initialTokenType) {
-			/*case Token.COMMENT_MULTILINE:
+			/*case TokenTypes.COMMENT_MULTILINE:
 				state = MLC;
 				start = text.offset;
 				break;
-			case Token.COMMENT_DOCUMENTATION:
+			case TokenTypes.COMMENT_DOCUMENTATION:
 				state = DOCCOMMENT;
 				start = text.offset;
 				break;*/
-			case Token.LITERAL_STRING_DOUBLE_QUOTE:
+			case TokenTypes.LITERAL_STRING_DOUBLE_QUOTE:
 				state = STRING;
 				start = text.offset;
 				break;
 			default:
-				state = Token.NULL;
+				state = TokenTypes.NULL;
 		}
 
 		s = text;
@@ -322,7 +322,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 "when" |
 "when-first" |
 "when-let" |
-"when-not"        { addToken(Token.RESERVED_WORD); }
+"when-not"        { addToken(TokenTypes.RESERVED_WORD); }
 
 "*warn-on-reflection*" |
 "*1" |
@@ -352,7 +352,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 "*read-eval*" |
 "*source-path*" |
 "*unchecked-math*" |
-"*use-context-classloader*"		{ addToken(Token.VARIABLE); }
+"*use-context-classloader*"		{ addToken(TokenTypes.VARIABLE); }
 
 "*current-namespace*" |
 "*in*" |
@@ -501,41 +501,41 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 "vector" |
 "with-meta" |
 "zero?" |
-"zipmap"      				{ addToken(Token.FUNCTION); }
+"zipmap"      				{ addToken(TokenTypes.FUNCTION); }
 
 {LineTerminator}				{ addNullToken(); return firstToken; }
 
-{WhiteSpace}+					{ addToken(Token.WHITESPACE); }
+{WhiteSpace}+					{ addToken(TokenTypes.WHITESPACE); }
 
-{CharLiteral}					{ addToken(Token.LITERAL_CHAR); }
+{CharLiteral}					{ addToken(TokenTypes.LITERAL_CHAR); }
 {StringLiteralStart}			{ start = zzMarkedPos-1; yybegin(STRING); }
 
-{Nil}                           { addToken(Token.DATA_TYPE); }
+{Nil}                           { addToken(TokenTypes.DATA_TYPE); }
 
-{BooleanLiteral}				{ addToken(Token.LITERAL_BOOLEAN); }
+{BooleanLiteral}				{ addToken(TokenTypes.LITERAL_BOOLEAN); }
 
 
-{Quote}							{ addToken(Token.SEPARATOR); }
-{Unquote}						{ addToken(Token.SEPARATOR); }
-{VarQuote}						{ addToken(Token.SEPARATOR); }
-{Dispatch}						{ addToken(Token.DATA_TYPE); }
+{Quote}							{ addToken(TokenTypes.SEPARATOR); }
+{Unquote}						{ addToken(TokenTypes.SEPARATOR); }
+{VarQuote}						{ addToken(TokenTypes.SEPARATOR); }
+{Dispatch}						{ addToken(TokenTypes.DATA_TYPE); }
 
 {LineCommentBegin}			{ start = zzMarkedPos-1; yybegin(EOL_COMMENT); }
 
-{Separator}					{ addToken(Token.SEPARATOR); }
+{Separator}					{ addToken(TokenTypes.SEPARATOR); }
 
-{Operator}					{ addToken(Token.OPERATOR); }
+{Operator}					{ addToken(TokenTypes.OPERATOR); }
 
-{IntegerLiteral}				{ addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
-{HexLiteral}					{ addToken(Token.LITERAL_NUMBER_HEXADECIMAL); }
-{FloatLiteral}					{ addToken(Token.LITERAL_NUMBER_FLOAT); }
-{ErrorNumberFormat}				{ addToken(Token.ERROR_NUMBER_FORMAT); }
-{Keyword}						{ addToken(Token.PREPROCESSOR); }
-{DefName}						{ addToken(Token.IDENTIFIER); }
+{IntegerLiteral}				{ addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT); }
+{HexLiteral}					{ addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL); }
+{FloatLiteral}					{ addToken(TokenTypes.LITERAL_NUMBER_FLOAT); }
+{ErrorNumberFormat}				{ addToken(TokenTypes.ERROR_NUMBER_FORMAT); }
+{Keyword}						{ addToken(TokenTypes.PREPROCESSOR); }
+{DefName}						{ addToken(TokenTypes.IDENTIFIER); }
 
 <<EOF>>						{ addNullToken(); return firstToken; }
 
-.							{ addToken(Token.ERROR_IDENTIFIER); }
+.							{ addToken(TokenTypes.ERROR_IDENTIFIER); }
 
 }
 
@@ -543,16 +543,16 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	[^\n\\\"]+			{}
 	\\.?				{ /* Skip escaped chars. */ }
 	\"\"				{}
-	\"					{ yybegin(YYINITIAL); addToken(start,zzStartRead, Token.LITERAL_STRING_DOUBLE_QUOTE); }
+	\"					{ yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); }
 	\n |
-	<<EOF>>				{ addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken; }
+	<<EOF>>				{ addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken; }
 }
 
 <EOL_COMMENT> {
 	[^hwf\n]+				{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos; }
 	[hwf]					{}
 	\n |
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken; }
 
 }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/ClojureTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/ClojureTokenMaker.java
@@ -1893,22 +1893,22 @@ public class ClojureTokenMaker extends AbstractJFlexTokenMaker {
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = Token.NULL;
+		int state = TokenTypes.NULL;
 		switch (initialTokenType) {
-			/*case Token.COMMENT_MULTILINE:
+			/*case TokenTypes.COMMENT_MULTILINE:
 				state = MLC;
 				start = text.offset;
 				break;
-			case Token.COMMENT_DOCUMENTATION:
+			case TokenTypes.COMMENT_DOCUMENTATION:
 				state = DOCCOMMENT;
 				start = text.offset;
 				break;*/
-			case Token.LITERAL_STRING_DOUBLE_QUOTE:
+			case TokenTypes.LITERAL_STRING_DOUBLE_QUOTE:
 				state = STRING;
 				start = text.offset;
 				break;
 			default:
-				state = Token.NULL;
+				state = TokenTypes.NULL;
 		}
 
 		s = text;
@@ -2189,7 +2189,7 @@ public class ClojureTokenMaker extends AbstractJFlexTokenMaker {
 
       switch (zzAction < 0 ? zzAction : ZZ_ACTION[zzAction]) {
         case 15:
-          { addToken(Token.PREPROCESSOR);
+          { addToken(TokenTypes.PREPROCESSOR);
           }
         case 26: break;
         case 6:
@@ -2197,47 +2197,47 @@ public class ClojureTokenMaker extends AbstractJFlexTokenMaker {
           }
         case 27: break;
         case 19:
-          { addToken(Token.LITERAL_CHAR);
+          { addToken(TokenTypes.LITERAL_CHAR);
           }
         case 28: break;
         case 9:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 29: break;
         case 17:
-          { addToken(Token.LITERAL_NUMBER_HEXADECIMAL);
+          { addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL);
           }
         case 30: break;
         case 18:
-          { addToken(Token.LITERAL_NUMBER_FLOAT);
+          { addToken(TokenTypes.LITERAL_NUMBER_FLOAT);
           }
         case 31: break;
         case 20:
-          { addToken(Token.RESERVED_WORD);
+          { addToken(TokenTypes.RESERVED_WORD);
           }
         case 32: break;
         case 22:
-          { addToken(Token.VARIABLE);
+          { addToken(TokenTypes.VARIABLE);
           }
         case 33: break;
         case 8:
-          { addToken(Token.SEPARATOR);
+          { addToken(TokenTypes.SEPARATOR);
           }
         case 34: break;
         case 1:
-          { addToken(Token.IDENTIFIER);
+          { addToken(TokenTypes.IDENTIFIER);
           }
         case 35: break;
         case 14:
-          { addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
           }
         case 36: break;
         case 21:
-          { addToken(Token.FUNCTION);
+          { addToken(TokenTypes.FUNCTION);
           }
         case 37: break;
         case 23:
-          { addToken(Token.DATA_TYPE);
+          { addToken(TokenTypes.DATA_TYPE);
           }
         case 38: break;
         case 11:
@@ -2245,23 +2245,23 @@ public class ClojureTokenMaker extends AbstractJFlexTokenMaker {
           }
         case 39: break;
         case 2:
-          { addToken(Token.ERROR_IDENTIFIER);
+          { addToken(TokenTypes.ERROR_IDENTIFIER);
           }
         case 40: break;
         case 24:
-          { addToken(Token.LITERAL_BOOLEAN);
+          { addToken(TokenTypes.LITERAL_BOOLEAN);
           }
         case 41: break;
         case 12:
-          { addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
           }
         case 42: break;
         case 25:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos;
           }
         case 43: break;
         case 16:
-          { addToken(Token.ERROR_NUMBER_FORMAT);
+          { addToken(TokenTypes.ERROR_NUMBER_FORMAT);
           }
         case 44: break;
         case 7:
@@ -2273,15 +2273,15 @@ public class ClojureTokenMaker extends AbstractJFlexTokenMaker {
           }
         case 46: break;
         case 5:
-          { addToken(Token.LITERAL_NUMBER_DECIMAL_INT);
+          { addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT);
           }
         case 47: break;
         case 4:
-          { addToken(Token.OPERATOR);
+          { addToken(TokenTypes.OPERATOR);
           }
         case 48: break;
         case 13:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead, Token.LITERAL_STRING_DOUBLE_QUOTE);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
           }
         case 49: break;
         case 10:
@@ -2293,11 +2293,11 @@ public class ClojureTokenMaker extends AbstractJFlexTokenMaker {
             zzAtEOF = true;
             switch (zzLexicalState) {
             case EOL_COMMENT: {
-              addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
             }
             case 631: break;
             case STRING: {
-              addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
             }
             case 632: break;
             case YYINITIAL: {

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/CsvTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/CsvTokenMaker.flex
@@ -107,7 +107,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 	 * Adds a token for either an even column or an odd column.
 	 */
 	private void addEvenOrOddColumnToken(int start, int end) {
-		addToken(start, end, evenOdd == 0 ? Token.IDENTIFIER : Token.DATA_TYPE);
+		addToken(start, end, evenOdd == 0 ? TokenTypes.IDENTIFIER : TokenTypes.DATA_TYPE);
 	}
 
 
@@ -161,7 +161,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 
 	@Override
 	public boolean getMarkOccurrencesOfTokenType(int type) {
-		return type == Token.IDENTIFIER || type == Token.DATA_TYPE;
+		return type == TokenTypes.IDENTIFIER || type == TokenTypes.DATA_TYPE;
 	}
 
 	/**
@@ -263,7 +263,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 <YYINITIAL> {
     \"                      { start = zzMarkedPos - 1; yybegin(STRING); }
     [,]                     {
-                                addToken(Token.OPERATOR);
+                                addToken(TokenTypes.OPERATOR);
                                 evenOdd = (evenOdd + 1) & 1;
                             }
     [^,\"\n]+               { addEvenOrOddColumnToken(); }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/CsvTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/CsvTokenMaker.java
@@ -275,7 +275,7 @@ public class CsvTokenMaker extends AbstractJFlexTokenMaker {
 	 * Adds a token for either an even column or an odd column.
 	 */
 	private void addEvenOrOddColumnToken(int start, int end) {
-		addToken(start, end, evenOdd == 0 ? Token.IDENTIFIER : Token.DATA_TYPE);
+		addToken(start, end, evenOdd == 0 ? TokenTypes.IDENTIFIER : TokenTypes.DATA_TYPE);
 	}
 
 
@@ -329,7 +329,7 @@ public class CsvTokenMaker extends AbstractJFlexTokenMaker {
 
 	@Override
 	public boolean getMarkOccurrencesOfTokenType(int type) {
-		return type == Token.IDENTIFIER || type == Token.DATA_TYPE;
+		return type == TokenTypes.IDENTIFIER || type == TokenTypes.DATA_TYPE;
 	}
 
 
@@ -658,7 +658,7 @@ public class CsvTokenMaker extends AbstractJFlexTokenMaker {
           }
         case 10: break;
         case 3:
-          { addToken(Token.OPERATOR);
+          { addToken(TokenTypes.OPERATOR);
                                 evenOdd = (evenOdd + 1) & 1;
           }
         case 11: break;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/DTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/DTokenMaker.flex
@@ -192,16 +192,16 @@ import org.fife.ui.rsyntaxtextarea.*;
 		// Start off in the proper state.
 		int state;
 		switch (initialTokenType) {
-			case Token.LITERAL_BACKQUOTE:
+			case TokenTypes.LITERAL_BACKQUOTE:
 				state = WYSIWYG_STRING_2;
 				break;
-			case Token.LITERAL_STRING_DOUBLE_QUOTE:
+			case TokenTypes.LITERAL_STRING_DOUBLE_QUOTE:
 				state = WYSIWYG_STRING_1;
 				break;
-			case Token.COMMENT_MULTILINE:
+			case TokenTypes.COMMENT_MULTILINE:
 				state = MLC;
 				break;
-			case Token.COMMENT_DOCUMENTATION:
+			case TokenTypes.COMMENT_DOCUMENTATION:
 				state = DOCCOMMENT;
 				break;
 			case INTERNAL_IN_NESTABLE_MLC:
@@ -482,8 +482,8 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
     "__gshared" |
     "__traits" |
     "__vector" |
-    "__parameters"				{ addToken(Token.RESERVED_WORD); }
-    "return"					{ addToken(Token.RESERVED_WORD_2); }
+    "__parameters"				{ addToken(TokenTypes.RESERVED_WORD); }
+    "return"					{ addToken(TokenTypes.RESERVED_WORD_2); }
 
 	/* Data types. */
 	"string" |
@@ -513,33 +513,33 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
     "uint" |
     "ulong" |
     "ushort" |
-    "wchar" 					{ addToken(Token.DATA_TYPE); }
+    "wchar" 					{ addToken(TokenTypes.DATA_TYPE); }
 
 	/* Booleans. */
-	{BooleanLiteral}			{ addToken(Token.LITERAL_BOOLEAN); }
+	{BooleanLiteral}			{ addToken(TokenTypes.LITERAL_BOOLEAN); }
 
 	/* Standard library (TODO) */
 	
 	{LineTerminator}				{ addNullToken(); return firstToken; }
 
-	{Identifier}					{ addToken(Token.IDENTIFIER); }
+	{Identifier}					{ addToken(TokenTypes.IDENTIFIER); }
 
-	{WhiteSpace}+					{ addToken(Token.WHITESPACE); }
+	{WhiteSpace}+					{ addToken(TokenTypes.WHITESPACE); }
 
 	/* String/Character literals. */
-	{CharLiteral}					{ addToken(Token.LITERAL_CHAR); }
-	{UnclosedCharLiteral}			{ addToken(Token.ERROR_CHAR); addNullToken(); return firstToken; }
-	{ErrorCharLiteral}				{ addToken(Token.ERROR_CHAR); }
-	{StringLiteral}				{ addToken(Token.LITERAL_STRING_DOUBLE_QUOTE); }
-	{UnclosedStringLiteral}			{ addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
-	{ErrorStringLiteral}			{ addToken(Token.ERROR_STRING_DOUBLE); }
-	{HexStringLiteral}				{ addToken(Token.LITERAL_STRING_DOUBLE_QUOTE); }
-	{UnclosedHexStringLiteral}		{ addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
-	{WysiwygStringLiteralStart}		{ addToken(Token.LITERAL_STRING_DOUBLE_QUOTE); yybegin(WYSIWYG_STRING_1); }
+	{CharLiteral}					{ addToken(TokenTypes.LITERAL_CHAR); }
+	{UnclosedCharLiteral}			{ addToken(TokenTypes.ERROR_CHAR); addNullToken(); return firstToken; }
+	{ErrorCharLiteral}				{ addToken(TokenTypes.ERROR_CHAR); }
+	{StringLiteral}				{ addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); }
+	{UnclosedStringLiteral}			{ addToken(TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
+	{ErrorStringLiteral}			{ addToken(TokenTypes.ERROR_STRING_DOUBLE); }
+	{HexStringLiteral}				{ addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); }
+	{UnclosedHexStringLiteral}		{ addToken(TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
+	{WysiwygStringLiteralStart}		{ addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); yybegin(WYSIWYG_STRING_1); }
     {WysiwygStringLiteralStart2}    { start = zzMarkedPos-1; yybegin(WYSIWYG_STRING_2); }
 
 	/* Comment literals. */
-	"/**/"						{ addToken(Token.COMMENT_MULTILINE); }
+	"/**/"						{ addToken(TokenTypes.COMMENT_MULTILINE); }
 	{MLCBegin}					{ start = zzMarkedPos-2; yybegin(MLC); }
 	{DocCommentBegin}			{ start = zzMarkedPos-3; yybegin(DOCCOMMENT); }
 	{NestableMLCBegin}			{ start = zzMarkedPos-2; nestedMlcDepth = 1; yybegin(NESTABLE_MLC); }
@@ -547,62 +547,62 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	{LineDocCommentBegin}		{ start = zzMarkedPos-3; yybegin(EOL_DOCCOMMENT); }
 
 	/* Annotations. */
-	{Annotation}					{ addToken(Token.ANNOTATION); }
+	{Annotation}					{ addToken(TokenTypes.ANNOTATION); }
 
 	/* Separators. */
-	{Separator}					{ addToken(Token.SEPARATOR); }
-	{Separator2}					{ addToken(Token.IDENTIFIER); }
+	{Separator}					{ addToken(TokenTypes.SEPARATOR); }
+	{Separator2}					{ addToken(TokenTypes.IDENTIFIER); }
 
 	/* Operators. */
-	{Operator}					{ addToken(Token.OPERATOR); }
+	{Operator}					{ addToken(TokenTypes.OPERATOR); }
 
 	/* Numbers */
-	{IntegerLiteral}				{ addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
-	{BinaryLiteral}					{ addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
-	{HexLiteral}					{ addToken(Token.LITERAL_NUMBER_HEXADECIMAL); }
-	{FloatLiteral}					{ addToken(Token.LITERAL_NUMBER_FLOAT); }
-	{ErrorNumberFormat}				{ addToken(Token.ERROR_NUMBER_FORMAT); }
+	{IntegerLiteral}				{ addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT); }
+	{BinaryLiteral}					{ addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT); }
+	{HexLiteral}					{ addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL); }
+	{FloatLiteral}					{ addToken(TokenTypes.LITERAL_NUMBER_FLOAT); }
+	{ErrorNumberFormat}				{ addToken(TokenTypes.ERROR_NUMBER_FORMAT); }
 
-	{ErrorIdentifier}				{ addToken(Token.ERROR_IDENTIFIER); }
+	{ErrorIdentifier}				{ addToken(TokenTypes.ERROR_IDENTIFIER); }
 
 	/* Ended with a line not in a string or comment. */
 	<<EOF>>						{ addNullToken(); return firstToken; }
 
 	/* Catch any other (unhandled) characters and flag them as identifiers. */
-	.							{ addToken(Token.ERROR_IDENTIFIER); }
+	.							{ addToken(TokenTypes.ERROR_IDENTIFIER); }
 
 }
 
 <MLC> {
 
 	[^hwf\n\*]+				{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos; }
 	[hwf]					{}
 
-	{MLCEnd}					{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE); }
+	{MLCEnd}					{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE); }
 	\*						{}
 	\n |
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken; }
 
 }
 
 <DOCCOMMENT> {
 
 	[^hwf\n\*]+					{}
-	{URL}						{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_DOCUMENTATION); start = zzMarkedPos; }
+	{URL}						{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_DOCUMENTATION); start = zzMarkedPos; }
 	[hwf]						{}
 
-	{MLCEnd}					{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_DOCUMENTATION); }
+	{MLCEnd}					{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_DOCUMENTATION); }
 	\*							{}
 	\n |
-	<<EOF>>						{ yybegin(YYINITIAL); addToken(start,zzEndRead, Token.COMMENT_DOCUMENTATION); return firstToken; }
+	<<EOF>>						{ yybegin(YYINITIAL); addToken(start,zzEndRead, TokenTypes.COMMENT_DOCUMENTATION); return firstToken; }
 
 }
 
 <NESTABLE_MLC> {
 
 	[^hwf\n\+\/]+			{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos; }
 	[hwf]					{}
 
 	{NestableMLCBegin}		{ nestedMlcDepth++; }
@@ -610,38 +610,38 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	
 	"+/"					{
 								if (--nestedMlcDepth==0) {
-									addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE); yybegin(YYINITIAL);
+									addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE); yybegin(YYINITIAL);
 								}
 							}
 	\+						{}
 	\n |
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addNestedMlcEndToken(); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addNestedMlcEndToken(); return firstToken; }
 }
 
 <EOL_COMMENT> {
 	[^hwf\n]+				{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos; }
 	[hwf]					{}
 	\n |
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken; }
 
 }
 
 <EOL_DOCCOMMENT> {
 	[^hwf\n]+				{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_DOCUMENTATION); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_DOCUMENTATION); start = zzMarkedPos; }
 	[hwf]					{}
 	\n |
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addNullToken(); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addNullToken(); return firstToken; }
 
 }
 
 <WYSIWYG_STRING_1> {
-	[^\"]+					{ addToken(Token.LITERAL_STRING_DOUBLE_QUOTE); }
-	\"						{ addToken(Token.LITERAL_STRING_DOUBLE_QUOTE); yybegin(YYINITIAL); }
+	[^\"]+					{ addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); }
+	\"						{ addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); yybegin(YYINITIAL); }
 	<<EOF>>					{
 								if (firstToken==null) {
-									addToken(Token.LITERAL_STRING_DOUBLE_QUOTE); 
+									addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
 								}
 								return firstToken;
 							}
@@ -649,6 +649,6 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 
 <WYSIWYG_STRING_2> {
 	[^\`]+					{}
-	\`						{ yybegin(YYINITIAL); addToken(start,zzStartRead, Token.LITERAL_BACKQUOTE); }
-	<<EOF>>			        { addToken(start,zzStartRead-1, Token.LITERAL_BACKQUOTE); return firstToken; }
+	\`						{ yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.LITERAL_BACKQUOTE); }
+	<<EOF>>			        { addToken(start,zzStartRead-1, TokenTypes.LITERAL_BACKQUOTE); return firstToken; }
 }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/DTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/DTokenMaker.java
@@ -1396,16 +1396,16 @@ public class DTokenMaker extends AbstractJFlexCTokenMaker {
 		// Start off in the proper state.
 		int state;
 		switch (initialTokenType) {
-			case Token.LITERAL_BACKQUOTE:
+			case TokenTypes.LITERAL_BACKQUOTE:
 				state = WYSIWYG_STRING_2;
 				break;
-			case Token.LITERAL_STRING_DOUBLE_QUOTE:
+			case TokenTypes.LITERAL_STRING_DOUBLE_QUOTE:
 				state = WYSIWYG_STRING_1;
 				break;
-			case Token.COMMENT_MULTILINE:
+			case TokenTypes.COMMENT_MULTILINE:
 				state = MLC;
 				break;
-			case Token.COMMENT_DOCUMENTATION:
+			case TokenTypes.COMMENT_DOCUMENTATION:
 				state = DOCCOMMENT;
 				break;
 			case INTERNAL_IN_NESTABLE_MLC:
@@ -1706,43 +1706,43 @@ public class DTokenMaker extends AbstractJFlexCTokenMaker {
 
       switch (zzAction < 0 ? zzAction : ZZ_ACTION[zzAction]) {
         case 14:
-          { yybegin(YYINITIAL); addToken(start,zzEndRead, Token.COMMENT_DOCUMENTATION); return firstToken;
+          { yybegin(YYINITIAL); addToken(start,zzEndRead, TokenTypes.COMMENT_DOCUMENTATION); return firstToken;
           }
         case 45: break;
         case 2:
-          { addToken(Token.IDENTIFIER);
+          { addToken(TokenTypes.IDENTIFIER);
           }
         case 46: break;
         case 40:
-          { addToken(Token.LITERAL_BOOLEAN);
+          { addToken(TokenTypes.LITERAL_BOOLEAN);
           }
         case 47: break;
         case 24:
-          { addToken(Token.ERROR_CHAR);
+          { addToken(TokenTypes.ERROR_CHAR);
           }
         case 48: break;
         case 21:
-          { addToken(Token.ERROR_NUMBER_FORMAT);
+          { addToken(TokenTypes.ERROR_NUMBER_FORMAT);
           }
         case 49: break;
         case 4:
-          { addToken(Token.ERROR_CHAR); addNullToken(); return firstToken;
+          { addToken(TokenTypes.ERROR_CHAR); addNullToken(); return firstToken;
           }
         case 50: break;
         case 18:
-          { addToken(Token.LITERAL_STRING_DOUBLE_QUOTE);
+          { addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
           }
         case 51: break;
         case 11:
-          { addToken(Token.ANNOTATION);
+          { addToken(TokenTypes.ANNOTATION);
           }
         case 52: break;
         case 6:
-          { addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
+          { addToken(TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
           }
         case 53: break;
         case 1:
-          { addToken(Token.ERROR_IDENTIFIER);
+          { addToken(TokenTypes.ERROR_IDENTIFIER);
           }
         case 54: break;
         case 32:
@@ -1754,15 +1754,15 @@ public class DTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 56: break;
         case 42:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_DOCUMENTATION); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_DOCUMENTATION); start = zzMarkedPos;
           }
         case 57: break;
         case 34:
-          { addToken(Token.LITERAL_CHAR);
+          { addToken(TokenTypes.LITERAL_CHAR);
           }
         case 58: break;
         case 23:
-          { addToken(Token.LITERAL_NUMBER_HEXADECIMAL);
+          { addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL);
           }
         case 59: break;
         case 27:
@@ -1770,31 +1770,31 @@ public class DTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 60: break;
         case 17:
-          { addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addNullToken(); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addNullToken(); return firstToken;
           }
         case 61: break;
         case 7:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 62: break;
         case 31:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_DOCUMENTATION);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_DOCUMENTATION);
           }
         case 63: break;
         case 38:
-          { addToken(Token.DATA_TYPE);
+          { addToken(TokenTypes.DATA_TYPE);
           }
         case 64: break;
         case 30:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE);
           }
         case 65: break;
         case 3:
-          { addToken(Token.LITERAL_NUMBER_DECIMAL_INT);
+          { addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT);
           }
         case 66: break;
         case 19:
-          { addToken(Token.LITERAL_STRING_DOUBLE_QUOTE); yybegin(YYINITIAL);
+          { addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); yybegin(YYINITIAL);
           }
         case 67: break;
         case 8:
@@ -1802,7 +1802,7 @@ public class DTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 68: break;
         case 20:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead, Token.LITERAL_BACKQUOTE);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.LITERAL_BACKQUOTE);
           }
         case 69: break;
         case 37:
@@ -1810,15 +1810,15 @@ public class DTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 70: break;
         case 15:
-          { addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addNestedMlcEndToken(); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addNestedMlcEndToken(); return firstToken;
           }
         case 71: break;
         case 29:
-          { addToken(Token.RESERVED_WORD);
+          { addToken(TokenTypes.RESERVED_WORD);
           }
         case 72: break;
         case 41:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos;
           }
         case 73: break;
         case 28:
@@ -1826,21 +1826,21 @@ public class DTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 74: break;
         case 44:
-          { addToken(Token.RESERVED_WORD_2);
+          { addToken(TokenTypes.RESERVED_WORD_2);
           }
         case 75: break;
         case 16:
-          { addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
           }
         case 76: break;
         case 10:
-          { addToken(Token.SEPARATOR);
+          { addToken(TokenTypes.SEPARATOR);
           }
         case 77: break;
         case 33:
           {
 								if (--nestedMlcDepth==0) {
-									addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE); yybegin(YYINITIAL);
+									addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE); yybegin(YYINITIAL);
 								}
           }
         case 78: break;
@@ -1849,27 +1849,27 @@ public class DTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 79: break;
         case 13:
-          { addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken;
           }
         case 80: break;
         case 9:
-          { addToken(Token.OPERATOR);
+          { addToken(TokenTypes.OPERATOR);
           }
         case 81: break;
         case 22:
-          { addToken(Token.LITERAL_NUMBER_FLOAT);
+          { addToken(TokenTypes.LITERAL_NUMBER_FLOAT);
           }
         case 82: break;
         case 25:
-          { addToken(Token.LITERAL_STRING_DOUBLE_QUOTE); yybegin(WYSIWYG_STRING_1);
+          { addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); yybegin(WYSIWYG_STRING_1);
           }
         case 83: break;
         case 43:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos;
           }
         case 84: break;
         case 39:
-          { addToken(Token.COMMENT_MULTILINE);
+          { addToken(TokenTypes.COMMENT_MULTILINE);
           }
         case 85: break;
         case 26:
@@ -1881,7 +1881,7 @@ public class DTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 87: break;
         case 35:
-          { addToken(Token.ERROR_STRING_DOUBLE);
+          { addToken(TokenTypes.ERROR_STRING_DOUBLE);
           }
         case 88: break;
         default:
@@ -1890,21 +1890,21 @@ public class DTokenMaker extends AbstractJFlexCTokenMaker {
             switch (zzLexicalState) {
             case WYSIWYG_STRING_1: {
               if (firstToken==null) {
-									addToken(Token.LITERAL_STRING_DOUBLE_QUOTE);
+									addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
 								}
 								return firstToken;
             }
             case 460: break;
             case EOL_COMMENT: {
-              addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
             }
             case 461: break;
             case NESTABLE_MLC: {
-              addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addNestedMlcEndToken(); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addNestedMlcEndToken(); return firstToken;
             }
             case 462: break;
             case DOCCOMMENT: {
-              yybegin(YYINITIAL); addToken(start,zzEndRead, Token.COMMENT_DOCUMENTATION); return firstToken;
+              yybegin(YYINITIAL); addToken(start,zzEndRead, TokenTypes.COMMENT_DOCUMENTATION); return firstToken;
             }
             case 463: break;
             case YYINITIAL: {
@@ -1912,15 +1912,15 @@ public class DTokenMaker extends AbstractJFlexCTokenMaker {
             }
             case 464: break;
             case MLC: {
-              addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken;
             }
             case 465: break;
             case WYSIWYG_STRING_2: {
-              addToken(start,zzStartRead-1, Token.LITERAL_BACKQUOTE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.LITERAL_BACKQUOTE); return firstToken;
             }
             case 466: break;
             case EOL_DOCCOMMENT: {
-              addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addNullToken(); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addNullToken(); return firstToken;
             }
             case 467: break;
             default:

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/DartTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/DartTokenMaker.flex
@@ -238,10 +238,10 @@ import org.fife.ui.rsyntaxtextarea.*;
 		// Start off in the proper state.
 		int state;
 		switch (initialTokenType) {
-			case Token.LITERAL_STRING_DOUBLE_QUOTE:
+			case TokenTypes.LITERAL_STRING_DOUBLE_QUOTE:
 				state = DART_MULTILINE_STRING_DOUBLE;
 				break;
-			case Token.LITERAL_CHAR:
+			case TokenTypes.LITERAL_CHAR:
 				state = DART_MULTILINE_STRING_SINGLE;
 				break;
 			case INTERNAL_IN_JS_MLC:
@@ -450,21 +450,21 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"break" |
 	"continue" |
 	"throw" |
-	"assert" 					{ addToken(Token.RESERVED_WORD); }
-	"return"					{ addToken(Token.RESERVED_WORD_2); }
+	"assert" 					{ addToken(TokenTypes.RESERVED_WORD); }
+	"return"					{ addToken(TokenTypes.RESERVED_WORD_2); }
 	
 	// Literals.
 	"false" |
-	"true"						{ addToken(Token.LITERAL_BOOLEAN); }
-	"NaN"						{ addToken(Token.RESERVED_WORD); }
-	"Infinity"					{ addToken(Token.RESERVED_WORD); }
+	"true"						{ addToken(TokenTypes.LITERAL_BOOLEAN); }
+	"NaN"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"Infinity"					{ addToken(TokenTypes.RESERVED_WORD); }
 
 	// Data types
 	"bool" |
 	"int" |
 	"double" |
 	"num" |
-	"void"						{ addToken(Token.DATA_TYPE); }
+	"void"						{ addToken(TokenTypes.DATA_TYPE); }
 	
 	// stdlib types
 	"AssertionError" |
@@ -523,11 +523,11 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"OutOfMemoryException" |
 	"StackOverflowException" |
 	"UnsupportedOperationException" |
-	"WrongArgumentCountException"	{ addToken(Token.FUNCTION); }
+	"WrongArgumentCountException"	{ addToken(TokenTypes.FUNCTION); }
 	
 	{LineTerminator}				{ addNullToken(); return firstToken; }
-	{JS_Identifier}					{ addToken(Token.IDENTIFIER); }
-	{Whitespace}					{ addToken(Token.WHITESPACE); }
+	{JS_Identifier}					{ addToken(TokenTypes.IDENTIFIER); }
+	{Whitespace}					{ addToken(TokenTypes.WHITESPACE); }
 
 	/* Multi-line string literals. */
 	\"\"\"						{ start = zzMarkedPos-3; yybegin(DART_MULTILINE_STRING_DOUBLE); }
@@ -537,9 +537,9 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	[\']							{ start = zzMarkedPos-1; validJSString = true; yybegin(JS_CHAR); }
 	[\"]							{ start = zzMarkedPos-1; validJSString = true; yybegin(JS_STRING); }
 
-	{DART_Annotation}				{ addToken(Token.ANNOTATION); }
+	{DART_Annotation}				{ addToken(TokenTypes.ANNOTATION); }
 	/* Comment literals. */
-	"/**/"							{ addToken(Token.COMMENT_MULTILINE); }
+	"/**/"							{ addToken(TokenTypes.COMMENT_MULTILINE); }
 	{JS_MLCBegin}					{ start = zzMarkedPos-2; yybegin(JS_MLC); }
 	{JS_LineCommentBegin}			{ start = zzMarkedPos-2; yybegin(JS_EOL_COMMENT); }
 
@@ -547,48 +547,48 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"#library" |
 	"#import" |
 	"#source" |
-	"#resource"						{ addToken(Token.RESERVED_WORD); }
+	"#resource"						{ addToken(TokenTypes.RESERVED_WORD); }
 	
 	/* Separators. */
-	{JS_Separator}					{ addToken(Token.SEPARATOR); }
-	{JS_Separator2}					{ addToken(Token.IDENTIFIER); }
+	{JS_Separator}					{ addToken(TokenTypes.SEPARATOR); }
+	{JS_Separator2}					{ addToken(TokenTypes.IDENTIFIER); }
 
 	/* Operators. */
-	{JS_Operator}					{ addToken(Token.OPERATOR); }
+	{JS_Operator}					{ addToken(TokenTypes.OPERATOR); }
 
 	/* Numbers */
-	{JS_IntegerLiteral}				{ addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
-	{JS_HexLiteral}				{ addToken(Token.LITERAL_NUMBER_HEXADECIMAL); }
-	{JS_FloatLiteral}				{ addToken(Token.LITERAL_NUMBER_FLOAT); }
-	{JS_ErrorNumberFormat}			{ addToken(Token.ERROR_NUMBER_FORMAT); }
+	{JS_IntegerLiteral}				{ addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT); }
+	{JS_HexLiteral}				{ addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL); }
+	{JS_FloatLiteral}				{ addToken(TokenTypes.LITERAL_NUMBER_FLOAT); }
+	{JS_ErrorNumberFormat}			{ addToken(TokenTypes.ERROR_NUMBER_FORMAT); }
 
-	{JS_ErrorIdentifier}			{ addToken(Token.ERROR_IDENTIFIER); }
+	{JS_ErrorIdentifier}			{ addToken(TokenTypes.ERROR_IDENTIFIER); }
 
 	/* Ended with a line not in a string or comment. */
 	<<EOF>>						{ addNullToken(); return firstToken; }
 
 	/* Catch any other (unhandled) characters and flag them as bad. */
-	.							{ addToken(Token.ERROR_IDENTIFIER); }
+	.							{ addToken(TokenTypes.ERROR_IDENTIFIER); }
 
 }
 
 <DART_MULTILINE_STRING_DOUBLE> {
 	[^\"\\\n]*				{}
 	\\.?						{ /* Skip escaped chars, handles case: '\"""'. */ }
-	\"\"\"					{ addToken(start,zzStartRead+2, Token.LITERAL_STRING_DOUBLE_QUOTE); yybegin(YYINITIAL); }
+	\"\"\"					{ addToken(start,zzStartRead+2, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); yybegin(YYINITIAL); }
 	\"						{}
 	\n |
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken; }
 }
 
 
 <DART_MULTILINE_STRING_SINGLE> {
 	[^\'\\\n]*				{}
 	\\.?						{ /* Skip escaped chars, handles case: "\'''". */ }
-	\'\'\'					{ addToken(start,zzStartRead+2, Token.LITERAL_CHAR); yybegin(YYINITIAL); }
+	\'\'\'					{ addToken(start,zzStartRead+2, TokenTypes.LITERAL_CHAR); yybegin(YYINITIAL); }
 	\'						{}
 	\n |
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.LITERAL_CHAR); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.LITERAL_CHAR); return firstToken; }
 }
 
 <JS_STRING> {
@@ -600,18 +600,18 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	\\.						{ /* Skip all escaped chars. */ }
 	\\						{ /* Line ending in '\' => continue to next line. */
 								if (validJSString) {
-									addToken(start,zzStartRead, Token.LITERAL_STRING_DOUBLE_QUOTE);
+									addToken(start,zzStartRead, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
 									addEndToken(INTERNAL_IN_JS_STRING_VALID);
 								}
 								else {
-									addToken(start,zzStartRead, Token.ERROR_STRING_DOUBLE);
+									addToken(start,zzStartRead, TokenTypes.ERROR_STRING_DOUBLE);
 									addEndToken(INTERNAL_IN_JS_STRING_INVALID);
 								}
 								return firstToken;
 							}
-	\"						{ int type = validJSString ? Token.LITERAL_STRING_DOUBLE_QUOTE : Token.ERROR_STRING_DOUBLE; addToken(start,zzStartRead, type); yybegin(YYINITIAL); }
+	\"						{ int type = validJSString ? TokenTypes.LITERAL_STRING_DOUBLE_QUOTE : TokenTypes.ERROR_STRING_DOUBLE; addToken(start,zzStartRead, type); yybegin(YYINITIAL); }
 	\n |
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
 }
 
 <JS_CHAR> {
@@ -623,35 +623,35 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	\\.						{ /* Skip all escaped chars. */ }
 	\\						{ /* Line ending in '\' => continue to next line. */
 								if (validJSString) {
-									addToken(start,zzStartRead, Token.LITERAL_CHAR);
+									addToken(start,zzStartRead, TokenTypes.LITERAL_CHAR);
 									addEndToken(INTERNAL_IN_JS_CHAR_VALID);
 								}
 								else {
-									addToken(start,zzStartRead, Token.ERROR_CHAR);
+									addToken(start,zzStartRead, TokenTypes.ERROR_CHAR);
 									addEndToken(INTERNAL_IN_JS_CHAR_INVALID);
 								}
 								return firstToken;
 							}
-	\'						{ int type = validJSString ? Token.LITERAL_CHAR : Token.ERROR_CHAR; addToken(start,zzStartRead, type); yybegin(YYINITIAL); }
+	\'						{ int type = validJSString ? TokenTypes.LITERAL_CHAR : TokenTypes.ERROR_CHAR; addToken(start,zzStartRead, type); yybegin(YYINITIAL); }
 	\n |
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.ERROR_CHAR); addNullToken(); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.ERROR_CHAR); addNullToken(); return firstToken; }
 }
 
 <JS_MLC> {
 	// JavaScript MLC's.  This state is essentially Java's MLC state.
 	[^hwf\n\*]+			{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos; }
 	[hwf]					{}
-	{JS_MLCEnd}				{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE); }
+	{JS_MLCEnd}				{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE); }
 	\*						{}
 	\n |
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_JS_MLC); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_JS_MLC); return firstToken; }
 }
 
 <JS_EOL_COMMENT> {
 	[^hwf\n]+				{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos; }
 	[hwf]					{}
 	\n |
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken; }
 }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/DartTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/DartTokenMaker.java
@@ -1598,10 +1598,10 @@ public class DartTokenMaker extends AbstractJFlexCTokenMaker {
 		// Start off in the proper state.
 		int state;
 		switch (initialTokenType) {
-			case Token.LITERAL_STRING_DOUBLE_QUOTE:
+			case TokenTypes.LITERAL_STRING_DOUBLE_QUOTE:
 				state = DART_MULTILINE_STRING_DOUBLE;
 				break;
-			case Token.LITERAL_CHAR:
+			case TokenTypes.LITERAL_CHAR:
 				state = DART_MULTILINE_STRING_SINGLE;
 				break;
 			case INTERNAL_IN_JS_MLC:
@@ -1933,19 +1933,19 @@ public class DartTokenMaker extends AbstractJFlexCTokenMaker {
 
       switch (zzAction < 0 ? zzAction : ZZ_ACTION[zzAction]) {
         case 11:
-          { addToken(start,zzStartRead-1, Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
           }
         case 45: break;
         case 5:
-          { addToken(Token.IDENTIFIER);
+          { addToken(TokenTypes.IDENTIFIER);
           }
         case 46: break;
         case 41:
-          { addToken(Token.LITERAL_BOOLEAN);
+          { addToken(TokenTypes.LITERAL_BOOLEAN);
           }
         case 47: break;
         case 39:
-          { addToken(start,zzStartRead+2, Token.LITERAL_CHAR); yybegin(YYINITIAL);
+          { addToken(start,zzStartRead+2, TokenTypes.LITERAL_CHAR); yybegin(YYINITIAL);
           }
         case 48: break;
         case 30:
@@ -1957,27 +1957,27 @@ public class DartTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 50: break;
         case 38:
-          { addToken(start,zzStartRead+2, Token.LITERAL_STRING_DOUBLE_QUOTE); yybegin(YYINITIAL);
+          { addToken(start,zzStartRead+2, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); yybegin(YYINITIAL);
           }
         case 51: break;
         case 23:
-          { addToken(Token.ERROR_NUMBER_FORMAT);
+          { addToken(TokenTypes.ERROR_NUMBER_FORMAT);
           }
         case 52: break;
         case 17:
-          { addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_JS_MLC); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_JS_MLC); return firstToken;
           }
         case 53: break;
         case 36:
-          { addToken(Token.FUNCTION);
+          { addToken(TokenTypes.FUNCTION);
           }
         case 54: break;
         case 28:
-          { addToken(Token.ANNOTATION);
+          { addToken(TokenTypes.ANNOTATION);
           }
         case 55: break;
         case 2:
-          { addToken(Token.ERROR_IDENTIFIER);
+          { addToken(TokenTypes.ERROR_IDENTIFIER);
           }
         case 56: break;
         case 27:
@@ -1985,7 +1985,7 @@ public class DartTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 57: break;
         case 13:
-          { int type = validJSString ? Token.LITERAL_STRING_DOUBLE_QUOTE : Token.ERROR_STRING_DOUBLE; addToken(start,zzStartRead, type); yybegin(YYINITIAL);
+          { int type = validJSString ? TokenTypes.LITERAL_STRING_DOUBLE_QUOTE : TokenTypes.ERROR_STRING_DOUBLE; addToken(start,zzStartRead, type); yybegin(YYINITIAL);
           }
         case 58: break;
         case 37:
@@ -1993,11 +1993,11 @@ public class DartTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 59: break;
         case 16:
-          { int type = validJSString ? Token.LITERAL_CHAR : Token.ERROR_CHAR; addToken(start,zzStartRead, type); yybegin(YYINITIAL);
+          { int type = validJSString ? TokenTypes.LITERAL_CHAR : TokenTypes.ERROR_CHAR; addToken(start,zzStartRead, type); yybegin(YYINITIAL);
           }
         case 60: break;
         case 14:
-          { addToken(start,zzStartRead-1, Token.ERROR_CHAR); addNullToken(); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.ERROR_CHAR); addNullToken(); return firstToken;
           }
         case 61: break;
         case 26:
@@ -2013,49 +2013,49 @@ public class DartTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 64: break;
         case 25:
-          { addToken(Token.LITERAL_NUMBER_HEXADECIMAL);
+          { addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL);
           }
         case 65: break;
         case 12:
           { /* Line ending in '\' => continue to next line. */
 								if (validJSString) {
-									addToken(start,zzStartRead, Token.LITERAL_STRING_DOUBLE_QUOTE);
+									addToken(start,zzStartRead, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
 									addEndToken(INTERNAL_IN_JS_STRING_VALID);
 								}
 								else {
-									addToken(start,zzStartRead, Token.ERROR_STRING_DOUBLE);
+									addToken(start,zzStartRead, TokenTypes.ERROR_STRING_DOUBLE);
 									addEndToken(INTERNAL_IN_JS_STRING_INVALID);
 								}
 								return firstToken;
           }
         case 66: break;
         case 3:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 67: break;
         case 35:
-          { addToken(Token.DATA_TYPE);
+          { addToken(TokenTypes.DATA_TYPE);
           }
         case 68: break;
         case 33:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE);
           }
         case 69: break;
         case 15:
           { /* Line ending in '\' => continue to next line. */
 								if (validJSString) {
-									addToken(start,zzStartRead, Token.LITERAL_CHAR);
+									addToken(start,zzStartRead, TokenTypes.LITERAL_CHAR);
 									addEndToken(INTERNAL_IN_JS_CHAR_VALID);
 								}
 								else {
-									addToken(start,zzStartRead, Token.ERROR_CHAR);
+									addToken(start,zzStartRead, TokenTypes.ERROR_CHAR);
 									addEndToken(INTERNAL_IN_JS_CHAR_INVALID);
 								}
 								return firstToken;
           }
         case 70: break;
         case 6:
-          { addToken(Token.LITERAL_NUMBER_DECIMAL_INT);
+          { addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT);
           }
         case 71: break;
         case 10:
@@ -2075,23 +2075,23 @@ public class DartTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 75: break;
         case 29:
-          { addToken(Token.RESERVED_WORD);
+          { addToken(TokenTypes.RESERVED_WORD);
           }
         case 76: break;
         case 42:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos;
           }
         case 77: break;
         case 44:
-          { addToken(Token.RESERVED_WORD_2);
+          { addToken(TokenTypes.RESERVED_WORD_2);
           }
         case 78: break;
         case 18:
-          { addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
           }
         case 79: break;
         case 8:
-          { addToken(Token.SEPARATOR);
+          { addToken(TokenTypes.SEPARATOR);
           }
         case 80: break;
         case 4:
@@ -2099,23 +2099,23 @@ public class DartTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 81: break;
         case 7:
-          { addToken(Token.OPERATOR);
+          { addToken(TokenTypes.OPERATOR);
           }
         case 82: break;
         case 21:
-          { addToken(start,zzStartRead-1, Token.LITERAL_CHAR); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.LITERAL_CHAR); return firstToken;
           }
         case 83: break;
         case 24:
-          { addToken(Token.LITERAL_NUMBER_FLOAT);
+          { addToken(TokenTypes.LITERAL_NUMBER_FLOAT);
           }
         case 84: break;
         case 43:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos;
           }
         case 85: break;
         case 40:
-          { addToken(Token.COMMENT_MULTILINE);
+          { addToken(TokenTypes.COMMENT_MULTILINE);
           }
         case 86: break;
         case 1:
@@ -2123,7 +2123,7 @@ public class DartTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 87: break;
         case 19:
-          { addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
           }
         case 88: break;
         default:
@@ -2131,19 +2131,19 @@ public class DartTokenMaker extends AbstractJFlexCTokenMaker {
             zzAtEOF = true;
             switch (zzLexicalState) {
             case JS_STRING: {
-              addToken(start,zzStartRead-1, Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
             }
             case 617: break;
             case JS_CHAR: {
-              addToken(start,zzStartRead-1, Token.ERROR_CHAR); addNullToken(); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.ERROR_CHAR); addNullToken(); return firstToken;
             }
             case 618: break;
             case DART_MULTILINE_STRING_DOUBLE: {
-              addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
             }
             case 619: break;
             case JS_EOL_COMMENT: {
-              addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
             }
             case 620: break;
             case YYINITIAL: {
@@ -2151,11 +2151,11 @@ public class DartTokenMaker extends AbstractJFlexCTokenMaker {
             }
             case 621: break;
             case JS_MLC: {
-              addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_JS_MLC); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_JS_MLC); return firstToken;
             }
             case 622: break;
             case DART_MULTILINE_STRING_SINGLE: {
-              addToken(start,zzStartRead-1, Token.LITERAL_CHAR); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.LITERAL_CHAR); return firstToken;
             }
             case 623: break;
             default:

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/DelphiTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/DelphiTokenMaker.flex
@@ -181,7 +181,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 		// Start off in the proper state.
 		int state;
 		switch (initialTokenType) {
-			case Token.COMMENT_MULTILINE:
+			case TokenTypes.COMMENT_MULTILINE:
 				state = MLC;
 				start = text.offset;
 				break;
@@ -198,7 +198,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 				start = text.offset;
 				break;
 			default:
-				state = Token.NULL;
+				state = TokenTypes.NULL;
 		}
 
 		s = text;
@@ -390,7 +390,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"var" |
 	"while" |
 	"with" |
-	"xor" 					{ addToken(Token.RESERVED_WORD); }
+	"xor" 					{ addToken(TokenTypes.RESERVED_WORD); }
 
 	/* Directives. */
 	"absolute" |
@@ -439,7 +439,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"varargs" |
 	"virtual" |
 	"write" |
-	"writeonly"				{ addToken(Token.FUNCTION); }
+	"writeonly"				{ addToken(TokenTypes.FUNCTION); }
 
 	/* Data types. */
 	"shortint" |
@@ -460,20 +460,20 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"extended" |
 	"comp" |
 	"currency" |
-	"pointer"					{ addToken(Token.DATA_TYPE); }
+	"pointer"					{ addToken(TokenTypes.DATA_TYPE); }
 
-	{BooleanLiteral}			{ addToken(Token.LITERAL_BOOLEAN); }
+	{BooleanLiteral}			{ addToken(TokenTypes.LITERAL_BOOLEAN); }
 
 	{LineTerminator}				{ addNullToken(); return firstToken; }
 
-	{Identifier}					{ addToken(Token.IDENTIFIER); }
+	{Identifier}					{ addToken(TokenTypes.IDENTIFIER); }
 
-	{WhiteSpace}+					{ addToken(Token.WHITESPACE); }
+	{WhiteSpace}+					{ addToken(TokenTypes.WHITESPACE); }
 
 	/* String/Character literals. */
-	{StringLiteral}				{ addToken(Token.LITERAL_STRING_DOUBLE_QUOTE); }
-	{UnclosedStringLiteral}			{ addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
-	{EscapeSequence}				{ addToken(Token.PREPROCESSOR); }
+	{StringLiteral}				{ addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); }
+	{UnclosedStringLiteral}			{ addToken(TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
+	{EscapeSequence}				{ addToken(TokenTypes.PREPROCESSOR); }
 
 	/* Comment literals. */
 	{CompilerDirective1Begin}	{start = zzMarkedPos-2; yybegin(COMPILER_DIRECTIVE); }
@@ -482,22 +482,22 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	{MLC2Begin}						{ start = zzMarkedPos-2; yybegin(MLC2); }
 	{LineCommentBegin}				{ start = zzMarkedPos-2; yybegin(EOL_COMMENT); }
 
-	{Separator}					{ addToken(Token.SEPARATOR); }
-	{Separator2}					{ addToken(Token.IDENTIFIER); }
-	{Operator}					{ addToken(Token.OPERATOR); }
+	{Separator}					{ addToken(TokenTypes.SEPARATOR); }
+	{Separator2}					{ addToken(TokenTypes.IDENTIFIER); }
+	{Operator}					{ addToken(TokenTypes.OPERATOR); }
 
-	{IntegerLiteral}				{ addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
-	{HexLiteral}					{ addToken(Token.LITERAL_NUMBER_HEXADECIMAL); }
-	{FloatLiteral}					{ addToken(Token.LITERAL_NUMBER_FLOAT); }
-	{ErrorNumberFormat}				{ addToken(Token.ERROR_NUMBER_FORMAT); }
+	{IntegerLiteral}				{ addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT); }
+	{HexLiteral}					{ addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL); }
+	{FloatLiteral}					{ addToken(TokenTypes.LITERAL_NUMBER_FLOAT); }
+	{ErrorNumberFormat}				{ addToken(TokenTypes.ERROR_NUMBER_FORMAT); }
 
-	{ErrorIdentifier}				{ addToken(Token.ERROR_IDENTIFIER); }
+	{ErrorIdentifier}				{ addToken(TokenTypes.ERROR_IDENTIFIER); }
 
 	/* Ended with a line not in a string or comment. */
 	<<EOF>>						{ addNullToken(); return firstToken; }
 
 	/* Catch any other (unhandled) characters. */
-	.							{ addToken(Token.IDENTIFIER); }
+	.							{ addToken(TokenTypes.IDENTIFIER); }
 
 }
 
@@ -505,12 +505,12 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 <MLC> {
 
 	[^hwf\n\}]+				{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos; }
 	[hwf]					{}
 
-	\n						{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken; }
-	{MLCEnd}					{ yybegin(YYINITIAL); addToken(start,zzStartRead, Token.COMMENT_MULTILINE); }
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken; }
+	\n						{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken; }
+	{MLCEnd}					{ yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.COMMENT_MULTILINE); }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken; }
 
 }
 
@@ -518,39 +518,39 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 <MLC2> {
 
 	[^hwf\n\*]+				{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos; }
 	[hwf]					{}
 
-	\n						{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addEndToken(INTERNAL_MLC2); return firstToken; }
-	{MLC2End}					{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE); }
+	\n						{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addEndToken(INTERNAL_MLC2); return firstToken; }
+	{MLC2End}					{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE); }
 	\*						{}
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addEndToken(INTERNAL_MLC2); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addEndToken(INTERNAL_MLC2); return firstToken; }
 
 }
 
 
 <COMPILER_DIRECTIVE> {
 	[^\n\}]+				{}
-	\n						{ addToken(start,zzStartRead-1, Token.PREPROCESSOR); addEndToken(INTERNAL_COMPILER_DIRECTIVE); return firstToken; }
-	{MLCEnd}					{ yybegin(YYINITIAL); addToken(start,zzStartRead, Token.PREPROCESSOR); }
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.PREPROCESSOR); addEndToken(INTERNAL_COMPILER_DIRECTIVE); return firstToken; }
+	\n						{ addToken(start,zzStartRead-1, TokenTypes.PREPROCESSOR); addEndToken(INTERNAL_COMPILER_DIRECTIVE); return firstToken; }
+	{MLCEnd}					{ yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.PREPROCESSOR); }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.PREPROCESSOR); addEndToken(INTERNAL_COMPILER_DIRECTIVE); return firstToken; }
 }
 
 
 <COMPILER_DIRECTIVE2> {
 	[^\n\*]+				{}
-	\n						{ addToken(start,zzStartRead-1, Token.PREPROCESSOR); addEndToken(INTERNAL_COMPILER_DIRECTIVE2); return firstToken; }
-	{MLC2End}					{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.PREPROCESSOR); }
+	\n						{ addToken(start,zzStartRead-1, TokenTypes.PREPROCESSOR); addEndToken(INTERNAL_COMPILER_DIRECTIVE2); return firstToken; }
+	{MLC2End}					{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.PREPROCESSOR); }
 	\*						{}
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.PREPROCESSOR); addEndToken(INTERNAL_COMPILER_DIRECTIVE2); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.PREPROCESSOR); addEndToken(INTERNAL_COMPILER_DIRECTIVE2); return firstToken; }
 }
 
 
 
 <EOL_COMMENT> {
 	[^hwf\n]+				{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos; }
 	[hwf]					{}
-	\n						{ addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken; }
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken; }
+	\n						{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken; }
 }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/DelphiTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/DelphiTokenMaker.java
@@ -1151,7 +1151,7 @@ public class DelphiTokenMaker extends AbstractJFlexTokenMaker {
 		// Start off in the proper state.
 		int state;
 		switch (initialTokenType) {
-			case Token.COMMENT_MULTILINE:
+			case TokenTypes.COMMENT_MULTILINE:
 				state = MLC;
 				start = text.offset;
 				break;
@@ -1168,7 +1168,7 @@ public class DelphiTokenMaker extends AbstractJFlexTokenMaker {
 				start = text.offset;
 				break;
 			default:
-				state = Token.NULL;
+				state = TokenTypes.NULL;
 		}
 
 		s = text;
@@ -1449,11 +1449,11 @@ public final void yybegin(int newState) {
 
       switch (zzAction < 0 ? zzAction : ZZ_ACTION[zzAction]) {
         case 15:
-          { addToken(start,zzStartRead-1, Token.PREPROCESSOR); addEndToken(INTERNAL_COMPILER_DIRECTIVE); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.PREPROCESSOR); addEndToken(INTERNAL_COMPILER_DIRECTIVE); return firstToken;
           }
         case 35: break;
         case 4:
-          { addToken(Token.PREPROCESSOR);
+          { addToken(TokenTypes.PREPROCESSOR);
           }
         case 36: break;
         case 5:
@@ -1461,43 +1461,43 @@ public final void yybegin(int newState) {
           }
         case 37: break;
         case 27:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE);
           }
         case 38: break;
         case 6:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 39: break;
         case 21:
-          { addToken(Token.LITERAL_NUMBER_HEXADECIMAL);
+          { addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL);
           }
         case 40: break;
         case 20:
-          { addToken(Token.LITERAL_NUMBER_FLOAT);
+          { addToken(TokenTypes.LITERAL_NUMBER_FLOAT);
           }
         case 41: break;
         case 26:
-          { addToken(Token.RESERVED_WORD);
+          { addToken(TokenTypes.RESERVED_WORD);
           }
         case 42: break;
         case 16:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead, Token.PREPROCESSOR);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.PREPROCESSOR);
           }
         case 43: break;
         case 9:
-          { addToken(Token.SEPARATOR);
+          { addToken(TokenTypes.SEPARATOR);
           }
         case 44: break;
         case 17:
-          { addToken(start,zzStartRead-1, Token.PREPROCESSOR); addEndToken(INTERNAL_COMPILER_DIRECTIVE2); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.PREPROCESSOR); addEndToken(INTERNAL_COMPILER_DIRECTIVE2); return firstToken;
           }
         case 45: break;
         case 2:
-          { addToken(Token.IDENTIFIER);
+          { addToken(TokenTypes.IDENTIFIER);
           }
         case 46: break;
         case 18:
-          { addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
           }
         case 47: break;
         case 25:
@@ -1505,35 +1505,35 @@ public final void yybegin(int newState) {
           }
         case 48: break;
         case 30:
-          { addToken(Token.FUNCTION);
+          { addToken(TokenTypes.FUNCTION);
           }
         case 49: break;
         case 7:
-          { addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
+          { addToken(TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
           }
         case 50: break;
         case 14:
-          { addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addEndToken(INTERNAL_MLC2); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addEndToken(INTERNAL_MLC2); return firstToken;
           }
         case 51: break;
         case 32:
-          { addToken(Token.DATA_TYPE);
+          { addToken(TokenTypes.DATA_TYPE);
           }
         case 52: break;
         case 1:
-          { addToken(Token.ERROR_IDENTIFIER);
+          { addToken(TokenTypes.ERROR_IDENTIFIER);
           }
         case 53: break;
         case 31:
-          { addToken(Token.LITERAL_BOOLEAN);
+          { addToken(TokenTypes.LITERAL_BOOLEAN);
           }
         case 54: break;
         case 22:
-          { addToken(Token.LITERAL_STRING_DOUBLE_QUOTE);
+          { addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
           }
         case 55: break;
         case 34:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos;
           }
         case 56: break;
         case 29:
@@ -1545,27 +1545,27 @@ public final void yybegin(int newState) {
           }
         case 58: break;
         case 33:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos;
           }
         case 59: break;
         case 19:
-          { addToken(Token.ERROR_NUMBER_FORMAT);
+          { addToken(TokenTypes.ERROR_NUMBER_FORMAT);
           }
         case 60: break;
         case 28:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.PREPROCESSOR);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.PREPROCESSOR);
           }
         case 61: break;
         case 13:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead, Token.COMMENT_MULTILINE);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.COMMENT_MULTILINE);
           }
         case 62: break;
         case 3:
-          { addToken(Token.LITERAL_NUMBER_DECIMAL_INT);
+          { addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT);
           }
         case 63: break;
         case 10:
-          { addToken(Token.OPERATOR);
+          { addToken(TokenTypes.OPERATOR);
           }
         case 64: break;
         case 8:
@@ -1581,7 +1581,7 @@ public final void yybegin(int newState) {
           }
         case 67: break;
         case 12:
-          { addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken;
           }
         case 68: break;
         default:
@@ -1589,11 +1589,11 @@ public final void yybegin(int newState) {
             zzAtEOF = true;
             switch (zzLexicalState) {
             case COMPILER_DIRECTIVE: {
-              addToken(start,zzStartRead-1, Token.PREPROCESSOR); addEndToken(INTERNAL_COMPILER_DIRECTIVE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.PREPROCESSOR); addEndToken(INTERNAL_COMPILER_DIRECTIVE); return firstToken;
             }
             case 438: break;
             case EOL_COMMENT: {
-              addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
             }
             case 439: break;
             case YYINITIAL: {
@@ -1601,15 +1601,15 @@ public final void yybegin(int newState) {
             }
             case 440: break;
             case COMPILER_DIRECTIVE2: {
-              addToken(start,zzStartRead-1, Token.PREPROCESSOR); addEndToken(INTERNAL_COMPILER_DIRECTIVE2); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.PREPROCESSOR); addEndToken(INTERNAL_COMPILER_DIRECTIVE2); return firstToken;
             }
             case 441: break;
             case MLC: {
-              addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken;
             }
             case 442: break;
             case MLC2: {
-              addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addEndToken(INTERNAL_MLC2); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addEndToken(INTERNAL_MLC2); return firstToken;
             }
             case 443: break;
             default:

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/DockerTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/DockerTokenMaker.flex
@@ -125,7 +125,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 	 */
 	@Override
 	public boolean getMarkOccurrencesOfTokenType(int type) {
-		return type==Token.IDENTIFIER || type==Token.RESERVED_WORD;
+		return type==TokenTypes.IDENTIFIER || type==TokenTypes.RESERVED_WORD;
 	}
 
 
@@ -234,46 +234,46 @@ WhiteSpace				= ([ \t\f])
 	"entrypoint" |
 	"label" |
 	"arg" |
-	"stopsignal" 					{ addToken(Token.RESERVED_WORD); }
+	"stopsignal" 					{ addToken(TokenTypes.RESERVED_WORD); }
 
-	{Identifier}					{ addToken(Token.IDENTIFIER); }
-	{WhiteSpace}+					{ addToken(Token.WHITESPACE); }
+	{Identifier}					{ addToken(TokenTypes.IDENTIFIER); }
+	{WhiteSpace}+					{ addToken(TokenTypes.WHITESPACE); }
 
 	"[" |
-	"]"								{ addToken(Token.SEPARATOR); }
+	"]"								{ addToken(TokenTypes.SEPARATOR); }
 	
 	"|" |
 	">" |
-	">>"							{ addToken(Token.OPERATOR); }
+	">>"							{ addToken(TokenTypes.OPERATOR); }
 	
 	/* String/Character literals. */
 	\"							{ start = zzMarkedPos-1; yybegin(STRING); }
 	\'							{ start = zzMarkedPos-1; yybegin(CHAR_LITERAL); }
 
 	/* Comment literals. */
-	"#".*			{ addToken(Token.COMMENT_EOL); addNullToken(); return firstToken; }
+	"#".*			{ addToken(TokenTypes.COMMENT_EOL); addNullToken(); return firstToken; }
 
 	/* Ended with a line not in a string or comment. */
 	"\n" |
 	<<EOF>>						{ addNullToken(); return firstToken; }
 
 	/* Catch any other (unhandled) characters. */
-	.							{ addToken(Token.IDENTIFIER); }
+	.							{ addToken(TokenTypes.IDENTIFIER); }
 
 }
 
 <STRING> {
 	[^\n\\\"]+			{}
 	\\.?				{ /* Skip escaped chars. */ }
-	\"					{ yybegin(YYINITIAL); addToken(start,zzStartRead, Token.LITERAL_STRING_DOUBLE_QUOTE); }
+	\"					{ yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); }
 	\n |
-	<<EOF>>				{ addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken; }
+	<<EOF>>				{ addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken; }
 }
 
 <CHAR_LITERAL> {
 	[^\n\\\']+			{}
 	\\.?					{ /* Skip escaped single quotes only, but this should still work. */ }
-	\'					{ yybegin(YYINITIAL); addToken(start,zzStartRead, Token.LITERAL_CHAR); }
+	\'					{ yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.LITERAL_CHAR); }
 	\n |
-	<<EOF>>				{ addToken(start,zzStartRead-1, Token.LITERAL_CHAR); return firstToken; }
+	<<EOF>>				{ addToken(start,zzStartRead-1, TokenTypes.LITERAL_CHAR); return firstToken; }
 }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/DockerTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/DockerTokenMaker.java
@@ -364,7 +364,7 @@ public class DockerTokenMaker extends AbstractJFlexTokenMaker {
 	 */
 	@Override
 	public boolean getMarkOccurrencesOfTokenType(int type) {
-		return type==Token.IDENTIFIER || type==Token.RESERVED_WORD;
+		return type==TokenTypes.IDENTIFIER || type==TokenTypes.RESERVED_WORD;
 	}
 
 
@@ -667,27 +667,27 @@ public class DockerTokenMaker extends AbstractJFlexTokenMaker {
 
       switch (zzAction < 0 ? zzAction : ZZ_ACTION[zzAction]) {
         case 16:
-          { addToken(Token.RESERVED_WORD);
+          { addToken(TokenTypes.RESERVED_WORD);
           }
         case 17: break;
         case 1:
-          { addToken(Token.IDENTIFIER);
+          { addToken(TokenTypes.IDENTIFIER);
           }
         case 18: break;
         case 7:
-          { addToken(Token.COMMENT_EOL); addNullToken(); return firstToken;
+          { addToken(TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
           }
         case 19: break;
         case 2:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 20: break;
         case 11:
-          { addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
           }
         case 21: break;
         case 14:
-          { addToken(start,zzStartRead-1, Token.LITERAL_CHAR); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.LITERAL_CHAR); return firstToken;
           }
         case 22: break;
         case 12:
@@ -695,7 +695,7 @@ public class DockerTokenMaker extends AbstractJFlexTokenMaker {
           }
         case 23: break;
         case 4:
-          { addToken(Token.OPERATOR);
+          { addToken(TokenTypes.OPERATOR);
           }
         case 24: break;
         case 15:
@@ -707,11 +707,11 @@ public class DockerTokenMaker extends AbstractJFlexTokenMaker {
           }
         case 26: break;
         case 13:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead, Token.LITERAL_CHAR);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.LITERAL_CHAR);
           }
         case 27: break;
         case 10:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead, Token.LITERAL_STRING_DOUBLE_QUOTE);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
           }
         case 28: break;
         case 8:
@@ -723,7 +723,7 @@ public class DockerTokenMaker extends AbstractJFlexTokenMaker {
           }
         case 30: break;
         case 3:
-          { addToken(Token.SEPARATOR);
+          { addToken(TokenTypes.SEPARATOR);
           }
         case 31: break;
         case 6:
@@ -735,11 +735,11 @@ public class DockerTokenMaker extends AbstractJFlexTokenMaker {
             zzAtEOF = true;
             switch (zzLexicalState) {
             case STRING: {
-              addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
             }
             case 85: break;
             case CHAR_LITERAL: {
-              addToken(start,zzStartRead-1, Token.LITERAL_CHAR); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.LITERAL_CHAR); return firstToken;
             }
             case 86: break;
             case YYINITIAL: {

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/DtdTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/DtdTokenMaker.flex
@@ -301,47 +301,47 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 %%
 
 <YYINITIAL> {
-	([^ \t\f<]+)				{ /* Not really valid */ addToken(Token.IDENTIFIER); }
+	([^ \t\f<]+)				{ /* Not really valid */ addToken(TokenTypes.IDENTIFIER); }
 	"<!--"						{ start = zzStartRead; prevState = zzLexicalState; yybegin(COMMENT); }
-	"<!"						{ addToken(Token.MARKUP_TAG_DELIMITER); yybegin(INTAG_START); }
-	"<"							{ addToken(Token.IDENTIFIER); }
-	{Whitespace}+				{ addToken(Token.WHITESPACE); }
+	"<!"						{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(INTAG_START); }
+	"<"							{ addToken(TokenTypes.IDENTIFIER); }
+	{Whitespace}+				{ addToken(TokenTypes.WHITESPACE); }
 	{LineTerminator} |
 	<<EOF>>						{ addNullToken(); return firstToken; }
 }
 
 <COMMENT> {
 	[^hwf\n\-]+					{}
-	{URL}						{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.MARKUP_COMMENT); addHyperlinkToken(temp,zzMarkedPos-1, Token.MARKUP_COMMENT); start = zzMarkedPos; }
+	{URL}						{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.MARKUP_COMMENT); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.MARKUP_COMMENT); start = zzMarkedPos; }
 	[hwf]						{}
-	"-->"						{ int temp = zzMarkedPos; addToken(start,zzStartRead+2, Token.MARKUP_COMMENT); start = temp; yybegin(prevState); }
+	"-->"						{ int temp = zzMarkedPos; addToken(start,zzStartRead+2, TokenTypes.MARKUP_COMMENT); start = temp; yybegin(prevState); }
 	"-"							{}
 	{LineTerminator} |
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.MARKUP_COMMENT); addEndToken(INTERNAL_IN_COMMENT - prevState); return firstToken; }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_COMMENT); addEndToken(INTERNAL_IN_COMMENT - prevState); return firstToken; }
 }
 
 <INTAG_START> {
-	("ELEMENT")					{ addToken(Token.MARKUP_TAG_NAME); yybegin(INTAG_ELEMENT); }
-	("ATTLIST")					{ addToken(Token.MARKUP_TAG_NAME); yybegin(INTAG_ATTLIST); }
-	([^ \t\f>]+)				{ addToken(Token.IDENTIFIER); }
-	{Whitespace}+				{ addToken(Token.WHITESPACE); }
-	(">")						{ addToken(Token.MARKUP_TAG_DELIMITER); yybegin(YYINITIAL); }
+	("ELEMENT")					{ addToken(TokenTypes.MARKUP_TAG_NAME); yybegin(INTAG_ELEMENT); }
+	("ATTLIST")					{ addToken(TokenTypes.MARKUP_TAG_NAME); yybegin(INTAG_ATTLIST); }
+	([^ \t\f>]+)				{ addToken(TokenTypes.IDENTIFIER); }
+	{Whitespace}+				{ addToken(TokenTypes.WHITESPACE); }
+	(">")						{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(YYINITIAL); }
 	<<EOF>>						{ addEndToken(INTERNAL_INTAG_START); return firstToken; }
 }
 
 <INTAG_ELEMENT> {
-	([^ \t\f>]+)				{ addToken(Token.MARKUP_TAG_ATTRIBUTE); }
-	{Whitespace}+				{ addToken(Token.WHITESPACE); }
-	(">")						{ addToken(Token.MARKUP_TAG_DELIMITER); yybegin(YYINITIAL); }
+	([^ \t\f>]+)				{ addToken(TokenTypes.MARKUP_TAG_ATTRIBUTE); }
+	{Whitespace}+				{ addToken(TokenTypes.WHITESPACE); }
+	(">")						{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(YYINITIAL); }
 	<<EOF>>						{ addEndToken(INTERNAL_INTAG_ELEMENT); return firstToken; }
 }
 
 <INTAG_ATTLIST> {
-	("CDATA"|"#IMPLIED"|"#REQUIRED")	{ addToken(Token.MARKUP_PROCESSING_INSTRUCTION); }
-	([^ \t\f>\"\']+)			{ addToken(Token.MARKUP_TAG_ATTRIBUTE); }
-	({UnclosedString}[\"]?)		{ addToken(Token.MARKUP_TAG_ATTRIBUTE_VALUE); }
-	({UnclosedChar}[\']?)		{ addToken(Token.MARKUP_TAG_ATTRIBUTE_VALUE); }
-	{Whitespace}+				{ addToken(Token.WHITESPACE); }
-	(">")						{ addToken(Token.MARKUP_TAG_DELIMITER); yybegin(YYINITIAL); }
+	("CDATA"|"#IMPLIED"|"#REQUIRED")	{ addToken(TokenTypes.MARKUP_PROCESSING_INSTRUCTION); }
+	([^ \t\f>\"\']+)			{ addToken(TokenTypes.MARKUP_TAG_ATTRIBUTE); }
+	({UnclosedString}[\"]?)		{ addToken(TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); }
+	({UnclosedChar}[\']?)		{ addToken(TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); }
+	{Whitespace}+				{ addToken(TokenTypes.WHITESPACE); }
+	(">")						{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(YYINITIAL); }
 	<<EOF>>						{ addEndToken(INTERNAL_INTAG_ATTLIST); return firstToken; }
 }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/DtdTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/DtdTokenMaker.java
@@ -17,6 +17,7 @@ import javax.swing.text.Segment;
 import org.fife.ui.rsyntaxtextarea.AbstractJFlexTokenMaker;
 import org.fife.ui.rsyntaxtextarea.Token;
 import org.fife.ui.rsyntaxtextarea.TokenImpl;
+import org.fife.ui.rsyntaxtextarea.TokenTypes;
 
 
 /**
@@ -737,31 +738,31 @@ public class DtdTokenMaker extends AbstractJFlexTokenMaker {
 
       switch (zzAction < 0 ? zzAction : ZZ_ACTION[zzAction]) {
         case 3:
-          { addToken(Token.IDENTIFIER);
+          { addToken(TokenTypes.IDENTIFIER);
           }
         case 16: break;
         case 2:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 17: break;
         case 1:
-          { /* Not really valid */ addToken(Token.IDENTIFIER);
+          { /* Not really valid */ addToken(TokenTypes.IDENTIFIER);
           }
         case 18: break;
         case 12:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.MARKUP_COMMENT); addHyperlinkToken(temp,zzMarkedPos-1, Token.MARKUP_COMMENT); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.MARKUP_COMMENT); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.MARKUP_COMMENT); start = zzMarkedPos;
           }
         case 19: break;
         case 9:
-          { addToken(Token.MARKUP_TAG_DELIMITER); yybegin(INTAG_START);
+          { addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(INTAG_START);
           }
         case 20: break;
         case 6:
-          { addToken(Token.MARKUP_TAG_DELIMITER); yybegin(YYINITIAL);
+          { addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(YYINITIAL);
           }
         case 21: break;
         case 10:
-          { int temp = zzMarkedPos; addToken(start,zzStartRead+2, Token.MARKUP_COMMENT); start = temp; yybegin(prevState);
+          { int temp = zzMarkedPos; addToken(start,zzStartRead+2, TokenTypes.MARKUP_COMMENT); start = temp; yybegin(prevState);
           }
         case 22: break;
         case 11:
@@ -769,19 +770,19 @@ public class DtdTokenMaker extends AbstractJFlexTokenMaker {
           }
         case 23: break;
         case 7:
-          { addToken(Token.MARKUP_TAG_ATTRIBUTE);
+          { addToken(TokenTypes.MARKUP_TAG_ATTRIBUTE);
           }
         case 24: break;
         case 15:
-          { addToken(Token.MARKUP_TAG_NAME); yybegin(INTAG_ATTLIST);
+          { addToken(TokenTypes.MARKUP_TAG_NAME); yybegin(INTAG_ATTLIST);
           }
         case 25: break;
         case 14:
-          { addToken(Token.MARKUP_TAG_NAME); yybegin(INTAG_ELEMENT);
+          { addToken(TokenTypes.MARKUP_TAG_NAME); yybegin(INTAG_ELEMENT);
           }
         case 26: break;
         case 13:
-          { addToken(Token.MARKUP_PROCESSING_INSTRUCTION);
+          { addToken(TokenTypes.MARKUP_PROCESSING_INSTRUCTION);
           }
         case 27: break;
         case 4:
@@ -789,11 +790,11 @@ public class DtdTokenMaker extends AbstractJFlexTokenMaker {
           }
         case 28: break;
         case 5:
-          { addToken(start,zzStartRead-1, Token.MARKUP_COMMENT); addEndToken(INTERNAL_IN_COMMENT - prevState); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.MARKUP_COMMENT); addEndToken(INTERNAL_IN_COMMENT - prevState); return firstToken;
           }
         case 29: break;
         case 8:
-          { addToken(Token.MARKUP_TAG_ATTRIBUTE_VALUE);
+          { addToken(TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE);
           }
         case 30: break;
         default:
@@ -817,7 +818,7 @@ public class DtdTokenMaker extends AbstractJFlexTokenMaker {
             }
             case 74: break;
             case COMMENT: {
-              addToken(start,zzStartRead-1, Token.MARKUP_COMMENT); addEndToken(INTERNAL_IN_COMMENT - prevState); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_COMMENT); addEndToken(INTERNAL_IN_COMMENT - prevState); return firstToken;
             }
             case 75: break;
             default:

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/FortranTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/FortranTokenMaker.flex
@@ -136,18 +136,18 @@ import org.fife.ui.rsyntaxtextarea.*;
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = Token.NULL;
+		int state = TokenTypes.NULL;
 		switch (initialTokenType) {
-			case Token.LITERAL_STRING_DOUBLE_QUOTE:
+			case TokenTypes.LITERAL_STRING_DOUBLE_QUOTE:
 				state = STRING;
 				start = text.offset;
 				break;
-			case Token.LITERAL_CHAR:
+			case TokenTypes.LITERAL_CHAR:
 				state = CHAR;
 				start = text.offset;
 				break;
 			default:
-				state = Token.NULL;
+				state = TokenTypes.NULL;
 		}
 
 		s = text;
@@ -230,181 +230,181 @@ Boolean				= (\.(true|false)\.)
 %%
 
 /* Keywords */
-<YYINITIAL> "INCLUDE"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "PROGRAM"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "MODULE"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "SUBROUTINE"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "FUNCTION"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "CONTAINS"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "USE"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "CALL"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "RETURN"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "IMPLICIT"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "EXPLICIT"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "NONE"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "DATA"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "PARAMETER"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "ALLOCATE"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "ALLOCATABLE"			{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "ALLOCATED"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "DEALLOCATE"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "INTEGER"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "REAL"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "DOUBLE"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "PRECISION"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "COMPLEX"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "LOGICAL"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "CHARACTER"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "DIMENSION"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "KIND"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "CASE"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "SELECT"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "DEFAULT"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "CONTINUE"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "CYCLE"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "DO"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "WHILE"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "ELSE"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "IF"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "ELSEIF"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "THEN"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "ELSEWHERE"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "END"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "ENDIF"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "ENDDO"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "FORALL"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "WHERE"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "EXIT"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "GOTO"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "PAUSE"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "STOP"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "BACKSPACE"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "CLOSE"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "ENDFILE"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "INQUIRE"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "OPEN"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "PRINT"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "READ"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "REWIND"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "WRITE"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "FORMAT"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "AIMAG"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "AINT"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "AMAX0"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "AMIN0"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "ANINT"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "CEILING"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "CMPLX"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "CONJG"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "DBLE"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "DCMPLX"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "DFLOAT"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "DIM"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "DPROD"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "FLOAT"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "FLOOR"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "IFIX"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "IMAG"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "INT"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "LOGICAL"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "MODULO"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "NINT"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "REAL"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "SIGN"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "SNGL"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "TRANSFER"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "ZEXT"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "ABS"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "ACOS"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "AIMAG"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "AINT"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "ALOG"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "ALOG10"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "AMAX0"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "AMAX1"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "AMIN0"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "AMIN1"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "AMOD"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "ANINT"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "ASIN"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "ATAN"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "ATAN2"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "CABS"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "CCOS"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "CHAR"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "CLOG"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "CMPLX"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "CONJG"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "COS"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "COSH"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "CSIN"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "CSQRT"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "DABS"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "DACOS"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "DASIN"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "DATAN"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "DATAN2"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "DBLE"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "DCOS"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "DCOSH"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "DDIM"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "DEXP"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "DIM"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "DINT"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "DLOG"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "DLOG10"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "DMAX1"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "DMIN1"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "DMOD"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "DNINT"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "DPROD"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "DREAL"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "DSIGN"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "DSIN"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "DSINH"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "DSQRT"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "DTAN"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "DTANH"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "EXP"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "FLOAT"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "IABS"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "ICHAR"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "IDIM"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "IDINT"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "IDNINT"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "IFIX"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "INDEX"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "INT"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "ISIGN"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "LEN"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "LGE"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "LGT"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "LLE"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "LLT"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "LOG"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "LOG10"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "MAX"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "MAX0"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "MAX1"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "MIN"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "MIN0"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "MIN1"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "MOD"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "NINT"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "REAL"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "SIGN"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "SIN"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "SINH"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "SNGL"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "SQRT"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "TAN"					{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "TANH"					{ addToken(Token.RESERVED_WORD); }
+<YYINITIAL> "INCLUDE"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "PROGRAM"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "MODULE"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "SUBROUTINE"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "FUNCTION"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "CONTAINS"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "USE"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "CALL"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "RETURN"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "IMPLICIT"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "EXPLICIT"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "NONE"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "DATA"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "PARAMETER"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "ALLOCATE"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "ALLOCATABLE"			{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "ALLOCATED"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "DEALLOCATE"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "INTEGER"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "REAL"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "DOUBLE"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "PRECISION"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "COMPLEX"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "LOGICAL"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "CHARACTER"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "DIMENSION"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "KIND"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "CASE"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "SELECT"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "DEFAULT"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "CONTINUE"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "CYCLE"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "DO"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "WHILE"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "ELSE"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "IF"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "ELSEIF"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "THEN"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "ELSEWHERE"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "END"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "ENDIF"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "ENDDO"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "FORALL"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "WHERE"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "EXIT"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "GOTO"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "PAUSE"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "STOP"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "BACKSPACE"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "CLOSE"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "ENDFILE"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "INQUIRE"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "OPEN"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "PRINT"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "READ"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "REWIND"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "WRITE"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "FORMAT"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "AIMAG"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "AINT"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "AMAX0"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "AMIN0"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "ANINT"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "CEILING"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "CMPLX"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "CONJG"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "DBLE"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "DCMPLX"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "DFLOAT"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "DIM"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "DPROD"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "FLOAT"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "FLOOR"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "IFIX"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "IMAG"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "INT"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "LOGICAL"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "MODULO"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "NINT"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "REAL"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "SIGN"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "SNGL"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "TRANSFER"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "ZEXT"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "ABS"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "ACOS"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "AIMAG"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "AINT"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "ALOG"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "ALOG10"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "AMAX0"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "AMAX1"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "AMIN0"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "AMIN1"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "AMOD"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "ANINT"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "ASIN"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "ATAN"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "ATAN2"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "CABS"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "CCOS"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "CHAR"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "CLOG"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "CMPLX"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "CONJG"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "COS"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "COSH"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "CSIN"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "CSQRT"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "DABS"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "DACOS"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "DASIN"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "DATAN"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "DATAN2"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "DBLE"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "DCOS"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "DCOSH"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "DDIM"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "DEXP"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "DIM"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "DINT"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "DLOG"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "DLOG10"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "DMAX1"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "DMIN1"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "DMOD"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "DNINT"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "DPROD"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "DREAL"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "DSIGN"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "DSIN"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "DSINH"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "DSQRT"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "DTAN"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "DTANH"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "EXP"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "FLOAT"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "IABS"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "ICHAR"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "IDIM"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "IDINT"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "IDNINT"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "IFIX"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "INDEX"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "INT"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "ISIGN"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "LEN"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "LGE"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "LGT"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "LLE"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "LLT"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "LOG"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "LOG10"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "MAX"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "MAX0"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "MAX1"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "MIN"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "MIN0"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "MIN1"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "MOD"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "NINT"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "REAL"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "SIGN"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "SIN"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "SINH"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "SNGL"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "SQRT"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "TAN"					{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "TANH"					{ addToken(TokenTypes.RESERVED_WORD); }
 
 <YYINITIAL> {
 
 	{LineTerminator}				{ addNullToken(); return firstToken; }
 
-	{WhiteSpace}+					{ addToken(Token.WHITESPACE); }
+	{WhiteSpace}+					{ addToken(TokenTypes.WHITESPACE); }
 
 	/* String/Character Literals. */
 	{CharDelimiter}				{ start = zzMarkedPos-1; yybegin(CHAR); }
@@ -419,12 +419,12 @@ Boolean				= (\.(true|false)\.)
 							// So we must check whether we're really at the beginning
 							// of the line ourselves...
 							if (zzStartRead==s.offset) {
-								addToken(zzStartRead,zzEndRead, Token.COMMENT_EOL);
+								addToken(zzStartRead,zzEndRead, TokenTypes.COMMENT_EOL);
 								addNullToken();
 								return firstToken;
 							}
 							else {
-								addToken(Token.IDENTIFIER);
+								addToken(TokenTypes.IDENTIFIER);
 							}
 						}
 	{Column1Comment2Begin}	{
@@ -433,42 +433,42 @@ Boolean				= (\.(true|false)\.)
 							// So we must check whether we're really at the beginning
 							// of the line ourselves...
 							if (zzStartRead==s.offset) {
-								addToken(zzStartRead,zzEndRead, Token.COMMENT_DOCUMENTATION);
+								addToken(zzStartRead,zzEndRead, TokenTypes.COMMENT_DOCUMENTATION);
 								addNullToken();
 								return firstToken;
 							}
 							else {
-								addToken(Token.IDENTIFIER);
+								addToken(TokenTypes.IDENTIFIER);
 							}
 						}
-	{AnywhereCommentBegin}	{ addToken(zzStartRead,zzEndRead, Token.COMMENT_EOL); addNullToken(); return firstToken; }
+	{AnywhereCommentBegin}	{ addToken(zzStartRead,zzEndRead, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken; }
 
 	/* Operators. */
-	{Operator}					{ addToken(Token.OPERATOR); }
+	{Operator}					{ addToken(TokenTypes.OPERATOR); }
 
 	/* Boolean literals. */
-	{Boolean}						{ addToken(Token.LITERAL_BOOLEAN); }
+	{Boolean}						{ addToken(TokenTypes.LITERAL_BOOLEAN); }
 
-	{Identifier}					{ addToken(Token.IDENTIFIER); }
+	{Identifier}					{ addToken(TokenTypes.IDENTIFIER); }
 
 	/* Ended with a line not in a string or char literal. */
 	<<EOF>>						{ addNullToken(); return firstToken; }
 
 	/* Catch any other (unhandled) characters. */
-	.							{ addToken(Token.IDENTIFIER); }
+	.							{ addToken(TokenTypes.IDENTIFIER); }
 
 }
 
 <CHAR> {
 	[^\'\n]*						{}
-	\'							{ yybegin(YYINITIAL); addToken(start,zzStartRead, Token.LITERAL_CHAR); }
-	\n							{ addToken(start,zzStartRead-1, Token.LITERAL_CHAR); return firstToken; }
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.LITERAL_CHAR); return firstToken; }
+	\'							{ yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.LITERAL_CHAR); }
+	\n							{ addToken(start,zzStartRead-1, TokenTypes.LITERAL_CHAR); return firstToken; }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.LITERAL_CHAR); return firstToken; }
 }
 
 <STRING> {
 	[^\"\n]*						{}
-	\"							{ yybegin(YYINITIAL); addToken(start,zzStartRead, Token.LITERAL_STRING_DOUBLE_QUOTE); }
-	\n							{ addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken; }
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken; }
+	\"							{ yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); }
+	\n							{ addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken; }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken; }
 }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/FortranTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/FortranTokenMaker.java
@@ -599,18 +599,18 @@ public class FortranTokenMaker extends AbstractJFlexTokenMaker {
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = Token.NULL;
+		int state = TokenTypes.NULL;
 		switch (initialTokenType) {
-			case Token.LITERAL_STRING_DOUBLE_QUOTE:
+			case TokenTypes.LITERAL_STRING_DOUBLE_QUOTE:
 				state = STRING;
 				start = text.offset;
 				break;
-			case Token.LITERAL_CHAR:
+			case TokenTypes.LITERAL_CHAR:
 				state = CHAR;
 				start = text.offset;
 				break;
 			default:
-				state = Token.NULL;
+				state = TokenTypes.NULL;
 		}
 
 		s = text;
@@ -891,27 +891,27 @@ public final void yybegin(int newState) {
 
       switch (zzAction < 0 ? zzAction : ZZ_ACTION[zzAction]) {
         case 15:
-          { addToken(Token.RESERVED_WORD);
+          { addToken(TokenTypes.RESERVED_WORD);
           }
         case 17: break;
         case 2:
-          { addToken(Token.IDENTIFIER);
+          { addToken(TokenTypes.IDENTIFIER);
           }
         case 18: break;
         case 4:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 19: break;
         case 11:
-          { addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
           }
         case 20: break;
         case 13:
-          { addToken(start,zzStartRead-1, Token.LITERAL_CHAR); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.LITERAL_CHAR); return firstToken;
           }
         case 21: break;
         case 10:
-          { addToken(Token.OPERATOR);
+          { addToken(TokenTypes.OPERATOR);
           }
         case 22: break;
         case 5:
@@ -920,17 +920,17 @@ public final void yybegin(int newState) {
 							// So we must check whether we're really at the beginning
 							// of the line ourselves...
 							if (zzStartRead==s.offset) {
-								addToken(zzStartRead,zzEndRead, Token.COMMENT_EOL);
+								addToken(zzStartRead,zzEndRead, TokenTypes.COMMENT_EOL);
 								addNullToken();
 								return firstToken;
 							}
 							else {
-								addToken(Token.IDENTIFIER);
+								addToken(TokenTypes.IDENTIFIER);
 							}
           }
         case 23: break;
         case 16:
-          { addToken(Token.LITERAL_BOOLEAN);
+          { addToken(TokenTypes.LITERAL_BOOLEAN);
           }
         case 24: break;
         case 8:
@@ -938,7 +938,7 @@ public final void yybegin(int newState) {
           }
         case 25: break;
         case 7:
-          { addToken(zzStartRead,zzEndRead, Token.COMMENT_EOL); addNullToken(); return firstToken;
+          { addToken(zzStartRead,zzEndRead, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
           }
         case 26: break;
         case 6:
@@ -947,12 +947,12 @@ public final void yybegin(int newState) {
 							// So we must check whether we're really at the beginning
 							// of the line ourselves...
 							if (zzStartRead==s.offset) {
-								addToken(zzStartRead,zzEndRead, Token.COMMENT_DOCUMENTATION);
+								addToken(zzStartRead,zzEndRead, TokenTypes.COMMENT_DOCUMENTATION);
 								addNullToken();
 								return firstToken;
 							}
 							else {
-								addToken(Token.IDENTIFIER);
+								addToken(TokenTypes.IDENTIFIER);
 							}
           }
         case 27: break;
@@ -961,11 +961,11 @@ public final void yybegin(int newState) {
           }
         case 28: break;
         case 14:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead, Token.LITERAL_CHAR);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.LITERAL_CHAR);
           }
         case 29: break;
         case 12:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead, Token.LITERAL_STRING_DOUBLE_QUOTE);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
           }
         case 30: break;
         case 3:
@@ -981,7 +981,7 @@ public final void yybegin(int newState) {
             zzAtEOF = true;
             switch (zzLexicalState) {
             case STRING: {
-              addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
             }
             case 258: break;
             case YYINITIAL: {
@@ -989,7 +989,7 @@ public final void yybegin(int newState) {
             }
             case 259: break;
             case CHAR: {
-              addToken(start,zzStartRead-1, Token.LITERAL_CHAR); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.LITERAL_CHAR); return firstToken;
             }
             case 260: break;
             default:

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/GoTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/GoTokenMaker.flex
@@ -145,12 +145,12 @@ import org.fife.ui.rsyntaxtextarea.*;
 		// Start off in the proper state.
 		int state = YYINITIAL;
 		switch (initialTokenType) {
-			case Token.COMMENT_MULTILINE:
+			case TokenTypes.COMMENT_MULTILINE:
 				state = MLC;
 				start = text.offset;
 				break;
 			default:
-				state = Token.NULL;
+				state = TokenTypes.NULL;
 		}
 
 		s = text;
@@ -296,9 +296,9 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"struct" |
 	"switch" |
 	"type" |
-	"var" 					{ addToken(Token.RESERVED_WORD); }
+	"var" 					{ addToken(TokenTypes.RESERVED_WORD); }
 
-	"return"				{ addToken(Token.RESERVED_WORD_2); }
+	"return"				{ addToken(TokenTypes.RESERVED_WORD_2); }
 
 	/* Data types. */
 	"bool" |
@@ -319,7 +319,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"float32" |
 	"float64" |
 	"complex64" |
-	"complex128"			{ addToken(Token.DATA_TYPE); }
+	"complex128"			{ addToken(TokenTypes.DATA_TYPE); }
 
 	/* Standard functions */
 	"append" |
@@ -336,7 +336,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"print" |
 	"println" |
 	"real" |
-	"recover"				{ addToken(Token.FUNCTION); }
+	"recover"				{ addToken(TokenTypes.FUNCTION); }
 
     /* Strings package */
     "Compare" |
@@ -382,25 +382,25 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
     "TrimRight" |
     "TrimRightFunc" |
     "TrimSpace" |
-    "TrimSuffix"				{ addToken(Token.FUNCTION); }
+    "TrimSuffix"				{ addToken(TokenTypes.FUNCTION); }
 
     /* Boolean literals */
-    ("true"|"false"|"nil")      { addToken(Token.LITERAL_BOOLEAN); }
+    ("true"|"false"|"nil")      { addToken(TokenTypes.LITERAL_BOOLEAN); }
 
 	{LineTerminator}				{ addNullToken(); return firstToken; }
 
-	{Identifier}					{ addToken(Token.IDENTIFIER); }
+	{Identifier}					{ addToken(TokenTypes.IDENTIFIER); }
 
-	{WhiteSpace}+					{ addToken(Token.WHITESPACE); }
+	{WhiteSpace}+					{ addToken(TokenTypes.WHITESPACE); }
 
 	/* String/Character Literals. */
-	{CharLiteral}					{ addToken(Token.LITERAL_CHAR); }
-	{UnclosedCharLiteral}			{ addToken(Token.ERROR_CHAR); /*addNullToken(); return firstToken;*/ }
-	{ErrorUnclosedCharLiteral}		{ addToken(Token.ERROR_CHAR); addNullToken(); return firstToken; }
-	{ErrorCharLiteral}				{ addToken(Token.ERROR_CHAR); }
-	{StringLiteral}				{ addToken(Token.LITERAL_STRING_DOUBLE_QUOTE); }
-	{UnclosedStringLiteral}			{ addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
-	{ErrorStringLiteral}			{ addToken(Token.ERROR_STRING_DOUBLE); }
+	{CharLiteral}					{ addToken(TokenTypes.LITERAL_CHAR); }
+	{UnclosedCharLiteral}			{ addToken(TokenTypes.ERROR_CHAR); /*addNullToken(); return firstToken;*/ }
+	{ErrorUnclosedCharLiteral}		{ addToken(TokenTypes.ERROR_CHAR); addNullToken(); return firstToken; }
+	{ErrorCharLiteral}				{ addToken(TokenTypes.ERROR_CHAR); }
+	{StringLiteral}				{ addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); }
+	{UnclosedStringLiteral}			{ addToken(TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
+	{ErrorStringLiteral}			{ addToken(TokenTypes.ERROR_STRING_DOUBLE); }
 
 	/* Comment Literals. */
 	{MLCBegin}					{ start = zzMarkedPos-2; yybegin(MLC); }
@@ -412,7 +412,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"[" |
 	"]" |
 	"{" |
-	"}"							{ addToken(Token.SEPARATOR); }
+	"}"							{ addToken(TokenTypes.SEPARATOR); }
 
 	/* Operators. */
 	{Trigraph} |
@@ -458,49 +458,49 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"++" |
 	"--" |
 	"." |
-	","							{ addToken(Token.OPERATOR); }
+	","							{ addToken(TokenTypes.OPERATOR); }
 
 	/* Numbers */
-	{IntegerLit}	    			{ addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
-	{HexLit}	    				{ addToken(Token.LITERAL_NUMBER_HEXADECIMAL); }
-	{FloatLit}  					{ addToken(Token.LITERAL_NUMBER_FLOAT); }
-	{ImaginaryLit} 					{ addToken(Token.LITERAL_NUMBER_FLOAT); }
-	{ErrorNumberFormat}				{ addToken(Token.ERROR_NUMBER_FORMAT); }
+	{IntegerLit}	    			{ addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT); }
+	{HexLit}	    				{ addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL); }
+	{FloatLit}  					{ addToken(TokenTypes.LITERAL_NUMBER_FLOAT); }
+	{ImaginaryLit} 					{ addToken(TokenTypes.LITERAL_NUMBER_FLOAT); }
+	{ErrorNumberFormat}				{ addToken(TokenTypes.ERROR_NUMBER_FORMAT); }
 
 	/* Some lines will end in '\' to wrap an expression. */
-	"\\"							{ addToken(Token.IDENTIFIER); }
+	"\\"							{ addToken(TokenTypes.IDENTIFIER); }
 
-	{ErrorIdentifier}				{ addToken(Token.ERROR_IDENTIFIER); }
+	{ErrorIdentifier}				{ addToken(TokenTypes.ERROR_IDENTIFIER); }
 
 	/* Other punctuation, we'll highlight it as "identifiers." */
-	";"							{ addToken(Token.IDENTIFIER); }
+	";"							{ addToken(TokenTypes.IDENTIFIER); }
 
 	/* Ended with a line not in a string or comment. */
 	<<EOF>>						{ addNullToken(); return firstToken; }
 
 	/* Catch any other (unhandled) characters and flag them as bad. */
-	.							{ addToken(Token.ERROR_IDENTIFIER); }
+	.							{ addToken(TokenTypes.ERROR_IDENTIFIER); }
 
 }
 
 <MLC> {
 
 	[^hwf\n\*]+					{}
-	{URL}						{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos; }
+	{URL}						{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos; }
 	[hwf]						{}
 
-	\n							{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken; }
-	{MLCEnd}						{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE); }
+	\n							{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken; }
+	{MLCEnd}						{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE); }
 	\*							{}
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken; }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken; }
 
 }
 
 
 <EOL_COMMENT> {
 	[^hwf\n]+				{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos; }
 	[hwf]					{}
-	\n						{ addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken; }
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken; }
+	\n						{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken; }
 }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/GoTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/GoTokenMaker.java
@@ -1064,12 +1064,12 @@ public class GoTokenMaker extends AbstractJFlexCTokenMaker {
 		// Start off in the proper state.
 		int state = YYINITIAL;
 		switch (initialTokenType) {
-			case Token.COMMENT_MULTILINE:
+			case TokenTypes.COMMENT_MULTILINE:
 				state = MLC;
 				start = text.offset;
 				break;
 			default:
-				state = Token.NULL;
+				state = TokenTypes.NULL;
 		}
 
 		s = text;
@@ -1353,11 +1353,11 @@ public class GoTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 31: break;
         case 22:
-          { addToken(Token.LITERAL_CHAR);
+          { addToken(TokenTypes.LITERAL_CHAR);
           }
         case 32: break;
         case 21:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE);
           }
         case 33: break;
         case 16:
@@ -1365,39 +1365,39 @@ public class GoTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 34: break;
         case 9:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 35: break;
         case 24:
-          { addToken(Token.LITERAL_NUMBER_HEXADECIMAL);
+          { addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL);
           }
         case 36: break;
         case 17:
-          { addToken(Token.ERROR_CHAR); /*addNullToken(); return firstToken;*/
+          { addToken(TokenTypes.ERROR_CHAR); /*addNullToken(); return firstToken;*/
           }
         case 37: break;
         case 23:
-          { addToken(Token.ERROR_STRING_DOUBLE);
+          { addToken(TokenTypes.ERROR_STRING_DOUBLE);
           }
         case 38: break;
         case 14:
-          { addToken(Token.LITERAL_NUMBER_FLOAT);
+          { addToken(TokenTypes.LITERAL_NUMBER_FLOAT);
           }
         case 39: break;
         case 20:
-          { addToken(Token.RESERVED_WORD);
+          { addToken(TokenTypes.RESERVED_WORD);
           }
         case 40: break;
         case 5:
-          { addToken(Token.SEPARATOR);
+          { addToken(TokenTypes.SEPARATOR);
           }
         case 41: break;
         case 2:
-          { addToken(Token.IDENTIFIER);
+          { addToken(TokenTypes.IDENTIFIER);
           }
         case 42: break;
         case 12:
-          { addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
           }
         case 43: break;
         case 15:
@@ -1405,59 +1405,59 @@ public class GoTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 44: break;
         case 26:
-          { addToken(Token.FUNCTION);
+          { addToken(TokenTypes.FUNCTION);
           }
         case 45: break;
         case 6:
-          { addToken(Token.ERROR_CHAR); addNullToken(); return firstToken;
+          { addToken(TokenTypes.ERROR_CHAR); addNullToken(); return firstToken;
           }
         case 46: break;
         case 8:
-          { addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
+          { addToken(TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
           }
         case 47: break;
         case 25:
-          { addToken(Token.DATA_TYPE);
+          { addToken(TokenTypes.DATA_TYPE);
           }
         case 48: break;
         case 1:
-          { addToken(Token.ERROR_IDENTIFIER);
+          { addToken(TokenTypes.ERROR_IDENTIFIER);
           }
         case 49: break;
         case 18:
-          { addToken(Token.ERROR_CHAR);
+          { addToken(TokenTypes.ERROR_CHAR);
           }
         case 50: break;
         case 27:
-          { addToken(Token.LITERAL_BOOLEAN);
+          { addToken(TokenTypes.LITERAL_BOOLEAN);
           }
         case 51: break;
         case 19:
-          { addToken(Token.LITERAL_STRING_DOUBLE_QUOTE);
+          { addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
           }
         case 52: break;
         case 29:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos;
           }
         case 53: break;
         case 28:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos;
           }
         case 54: break;
         case 30:
-          { addToken(Token.RESERVED_WORD_2);
+          { addToken(TokenTypes.RESERVED_WORD_2);
           }
         case 55: break;
         case 13:
-          { addToken(Token.ERROR_NUMBER_FORMAT);
+          { addToken(TokenTypes.ERROR_NUMBER_FORMAT);
           }
         case 56: break;
         case 3:
-          { addToken(Token.LITERAL_NUMBER_DECIMAL_INT);
+          { addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT);
           }
         case 57: break;
         case 4:
-          { addToken(Token.OPERATOR);
+          { addToken(TokenTypes.OPERATOR);
           }
         case 58: break;
         case 10:
@@ -1465,7 +1465,7 @@ public class GoTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 59: break;
         case 11:
-          { addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken;
           }
         case 60: break;
         default:
@@ -1473,7 +1473,7 @@ public class GoTokenMaker extends AbstractJFlexCTokenMaker {
             zzAtEOF = true;
             switch (zzLexicalState) {
             case EOL_COMMENT: {
-              addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
             }
             case 349: break;
             case YYINITIAL: {
@@ -1481,7 +1481,7 @@ public class GoTokenMaker extends AbstractJFlexCTokenMaker {
             }
             case 350: break;
             case MLC: {
-              addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken;
             }
             case 351: break;
             default:

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/GroovyTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/GroovyTokenMaker.flex
@@ -146,26 +146,26 @@ import org.fife.ui.rsyntaxtextarea.*;
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = Token.NULL;
+		int state = TokenTypes.NULL;
 		switch (initialTokenType) {
-			case Token.LITERAL_STRING_DOUBLE_QUOTE:
+			case TokenTypes.LITERAL_STRING_DOUBLE_QUOTE:
 				state = MULTILINE_STRING_DOUBLE;
 				start = text.offset;
 				break;
-			case Token.LITERAL_CHAR:
+			case TokenTypes.LITERAL_CHAR:
 				state = MULTILINE_STRING_SINGLE;
 				start = text.offset;
 				break;
-			case Token.COMMENT_MULTILINE:
+			case TokenTypes.COMMENT_MULTILINE:
 				state = MLC;
 				start = text.offset;
 				break;
-			case Token.COMMENT_DOCUMENTATION:
+			case TokenTypes.COMMENT_DOCUMENTATION:
 				state = DOCCOMMENT;
 				start = text.offset;
 				break;
 			default:
-				state = Token.NULL;
+				state = TokenTypes.NULL;
 		}
 
 		s = text;
@@ -201,7 +201,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 					ch=='['
 				)) ||
 				/* Operators "==", "===", "!=", "!==", etc. */
-				(t.getType()==Token.OPERATOR &&
+				(t.getType()==TokenTypes.OPERATOR &&
 					((ch=t.charAt(t.length()-1))=='=' || ch=='~'));
 	}
 
@@ -387,8 +387,8 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"try" |
 	"void" |
 	"volatile" |
-	"while"				{ addToken(Token.RESERVED_WORD); }
-	"return"			{ addToken(Token.RESERVED_WORD_2); }
+	"while"				{ addToken(TokenTypes.RESERVED_WORD); }
+	"return"			{ addToken(TokenTypes.RESERVED_WORD_2); }
 
 	/* Groovy keywords */
 	"as" |
@@ -398,7 +398,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"property" |
 	"test" |
 	"using" |
-	"in"				{ addToken(Token.RESERVED_WORD); }
+	"in"				{ addToken(TokenTypes.RESERVED_WORD); }
 
 	/* Data types. */
 	"boolean" |
@@ -408,10 +408,10 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"float" |
 	"int" |
 	"long" |
-	"short"					{ addToken(Token.DATA_TYPE); }
+	"short"					{ addToken(TokenTypes.DATA_TYPE); }
 
 	/* Booleans. */
-	{BooleanLiteral}			{ addToken(Token.LITERAL_BOOLEAN); }
+	{BooleanLiteral}			{ addToken(TokenTypes.LITERAL_BOOLEAN); }
 
 	/* java.lang classes */
 	"Appendable" |
@@ -731,7 +731,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
     "UnknownFormatConversionException" |
     "UnknownFormatFlagsException" |
 
-    "ServiceConfigurationError" 		{ addToken(Token.FUNCTION); }
+    "ServiceConfigurationError" 		{ addToken(TokenTypes.FUNCTION); }
 
 	/* Commonly used methods added to Object class */
 	"addShutdownHook" |
@@ -773,13 +773,13 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"sprintf" |
 	"toString" |
 	"use" |
-	"with" 			{ addToken(Token.FUNCTION); }
+	"with" 			{ addToken(TokenTypes.FUNCTION); }
 
 	{LineTerminator}				{ addNullToken(); return firstToken; }
 
-	{Identifier}					{ addToken(Token.IDENTIFIER); }
+	{Identifier}					{ addToken(TokenTypes.IDENTIFIER); }
 
-	{WhiteSpace}+					{ addToken(Token.WHITESPACE); }
+	{WhiteSpace}+					{ addToken(TokenTypes.WHITESPACE); }
 
 	/* Multiline string literals. */
 	\"\"\"						{ start = zzMarkedPos-3; yybegin(MULTILINE_STRING_DOUBLE); }
@@ -787,13 +787,13 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 
 
 	/* String/Character literals. */
-	{CharLiteral}					{ addToken(Token.LITERAL_CHAR); }
-	{UnclosedCharLiteral}			{ addToken(Token.ERROR_CHAR); addNullToken(); return firstToken; }
-	{ErrorCharLiteral}				{ addToken(Token.ERROR_CHAR); }
+	{CharLiteral}					{ addToken(TokenTypes.LITERAL_CHAR); }
+	{UnclosedCharLiteral}			{ addToken(TokenTypes.ERROR_CHAR); addNullToken(); return firstToken; }
+	{ErrorCharLiteral}				{ addToken(TokenTypes.ERROR_CHAR); }
 	\"								{ start = zzMarkedPos-1; yybegin(STRING_DOUBLE); }
 
 	/* Comment literals. */
-	"/**/"						{ addToken(Token.COMMENT_MULTILINE); }
+	"/**/"						{ addToken(TokenTypes.COMMENT_MULTILINE); }
 	{MLCBegin}					{ start = zzMarkedPos-2; yybegin(MLC); }
 	{DocCommentBegin}			{ start = zzMarkedPos-3; yybegin(DOCCOMMENT); }
 	{LineCommentBegin}			{ start = zzMarkedPos-2; yybegin(EOL_COMMENT); }
@@ -802,7 +802,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	{Regex}	{
 				boolean highlightedAsRegex = false;
 				if (zzBuffer[zzStartRead]=='~' || firstToken==null) {
-					addToken(Token.REGEX);
+					addToken(TokenTypes.REGEX);
 					highlightedAsRegex = true;
 				}
 				else {
@@ -810,7 +810,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 					// the previous token, highlight it as such.
 					Token t = firstToken.getLastNonCommentNonWhitespaceToken();
 					if (regexCanFollow(t)) {
-						addToken(Token.REGEX);
+						addToken(TokenTypes.REGEX);
 						highlightedAsRegex = true;
 					}
 				}
@@ -818,35 +818,35 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 				// individual tokens.
 				if (!highlightedAsRegex) {
 					int temp = zzStartRead + 1;
-					addToken(zzStartRead, zzStartRead, Token.OPERATOR);
+					addToken(zzStartRead, zzStartRead, TokenTypes.OPERATOR);
 					zzStartRead = zzCurrentPos = zzMarkedPos = temp;
 				}
 			}
 
 	/* Annotations. */
-	{Annotation}					{ addToken(Token.ANNOTATION); }
+	{Annotation}					{ addToken(TokenTypes.ANNOTATION); }
 
 	/* Separators. */
-	{Separator}					{ addToken(Token.SEPARATOR); }
-	{Separator2}					{ addToken(Token.IDENTIFIER); }
+	{Separator}					{ addToken(TokenTypes.SEPARATOR); }
+	{Separator2}					{ addToken(TokenTypes.IDENTIFIER); }
 
 	/* Operators. */
-	{Operator}					{ addToken(Token.OPERATOR); }
+	{Operator}					{ addToken(TokenTypes.OPERATOR); }
 
 	/* Numbers */
-	{IntegerLiteral}				{ addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
-	{BinaryLiteral}					{ addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
-	{HexLiteral}					{ addToken(Token.LITERAL_NUMBER_HEXADECIMAL); }
-	{FloatLiteral}					{ addToken(Token.LITERAL_NUMBER_FLOAT); }
-	{ErrorNumberFormat}				{ addToken(Token.ERROR_NUMBER_FORMAT); }
+	{IntegerLiteral}				{ addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT); }
+	{BinaryLiteral}					{ addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT); }
+	{HexLiteral}					{ addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL); }
+	{FloatLiteral}					{ addToken(TokenTypes.LITERAL_NUMBER_FLOAT); }
+	{ErrorNumberFormat}				{ addToken(TokenTypes.ERROR_NUMBER_FORMAT); }
 
-	{ErrorIdentifier}				{ addToken(Token.ERROR_IDENTIFIER); }
+	{ErrorIdentifier}				{ addToken(TokenTypes.ERROR_IDENTIFIER); }
 
 	/* Ended with a line not in a string or comment. */
 	<<EOF>>						{ addNullToken(); return firstToken; }
 
 	/* Catch any other (unhandled) characters and flag them as bad. */
-	.							{ addToken(Token.ERROR_IDENTIFIER); }
+	.							{ addToken(TokenTypes.ERROR_IDENTIFIER); }
 
 }
 
@@ -854,13 +854,13 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 <MLC> {
 
 	[^hwf\n\*]+				{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos; }
 	[hwf]					{}
 
-	\n						{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken; }
-	{MLCEnd}					{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE); }
+	\n						{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken; }
+	{MLCEnd}					{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE); }
 	\*						{}
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken; }
 
 }
 
@@ -868,60 +868,60 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 <DOCCOMMENT> {
 
 	[^hwf\@\{\n\<\*]+			{}
-	{URL}						{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_DOCUMENTATION); start = zzMarkedPos; }
+	{URL}						{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_DOCUMENTATION); start = zzMarkedPos; }
 	[hwf]						{}
 
-	"@"{BlockTag}				{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, Token.VARIABLE); start = zzMarkedPos; }
+	"@"{BlockTag}				{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, TokenTypes.VARIABLE); start = zzMarkedPos; }
 	"@"							{}
-	"{@"{InlineTag}[^\}]*"}"	{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, Token.VARIABLE); start = zzMarkedPos; }
+	"{@"{InlineTag}[^\}]*"}"	{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, TokenTypes.VARIABLE); start = zzMarkedPos; }
 	"{"							{}
-	\n							{ addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); return firstToken; }
-	"<"[/]?({Letter}[^\>]*)?">"	{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, Token.PREPROCESSOR); start = zzMarkedPos; }
+	\n							{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); return firstToken; }
+	"<"[/]?({Letter}[^\>]*)?">"	{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, TokenTypes.PREPROCESSOR); start = zzMarkedPos; }
 	\<							{}
-	{MLCEnd}					{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_DOCUMENTATION); }
+	{MLCEnd}					{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_DOCUMENTATION); }
 	\*							{}
-	<<EOF>>						{ yybegin(YYINITIAL); addToken(start,zzEndRead, Token.COMMENT_DOCUMENTATION); return firstToken; }
+	<<EOF>>						{ yybegin(YYINITIAL); addToken(start,zzEndRead, TokenTypes.COMMENT_DOCUMENTATION); return firstToken; }
 
 }
 
 
 <EOL_COMMENT> {
 	[^hwf\n]+				{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos; }
 	[hwf]					{}
 	\n |
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken; }
 }
 
 
 <MULTILINE_STRING_DOUBLE> {
 	[^\"\\\$\n]*				{}
 	\\.?						{ /* Skip escaped chars, handles case: '\"""'. */ }
-	\"\"\"					{ yybegin(YYINITIAL); addToken(start,zzStartRead+2, Token.LITERAL_STRING_DOUBLE_QUOTE); }
-	{Variable}				{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); addToken(temp,zzMarkedPos-1, Token.VARIABLE); start = zzMarkedPos; }
+	\"\"\"					{ yybegin(YYINITIAL); addToken(start,zzStartRead+2, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); }
+	{Variable}				{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); addToken(temp,zzMarkedPos-1, TokenTypes.VARIABLE); start = zzMarkedPos; }
 	{VariableStart}			{}
 	\"						{}
 	\n |
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken; }
 }
 
 
 <MULTILINE_STRING_SINGLE> {
 	[^\'\\\n]*				{}
 	\\.?						{ /* Skip escaped chars, handles case: "\'''". */ }
-	\'\'\'					{ yybegin(YYINITIAL); addToken(start,zzStartRead+2, Token.LITERAL_CHAR); }
+	\'\'\'					{ yybegin(YYINITIAL); addToken(start,zzStartRead+2, TokenTypes.LITERAL_CHAR); }
 	\'						{}
 	\n |
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.LITERAL_CHAR); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.LITERAL_CHAR); return firstToken; }
 }
 
 <STRING_DOUBLE> {
 	[^\n\\\$\"]+		{}
-	\n					{ addToken(start,zzStartRead-1, Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
+	\n					{ addToken(start,zzStartRead-1, TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
 	\\.?					{ /* Skip escaped chars. */ }
-	{Variable}			{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); addToken(temp,zzMarkedPos-1, Token.VARIABLE); start = zzMarkedPos; }
+	{Variable}			{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); addToken(temp,zzMarkedPos-1, TokenTypes.VARIABLE); start = zzMarkedPos; }
 	{VariableStart}		{}
-	\"					{ yybegin(YYINITIAL); addToken(start,zzStartRead, Token.LITERAL_STRING_DOUBLE_QUOTE); }
-	<<EOF>>				{ addToken(start,zzStartRead-1, Token.ERROR_STRING_DOUBLE); return firstToken; }
+	\"					{ yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); }
+	<<EOF>>				{ addToken(start,zzStartRead-1, TokenTypes.ERROR_STRING_DOUBLE); return firstToken; }
 }
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/GroovyTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/GroovyTokenMaker.java
@@ -4996,26 +4996,26 @@ public class GroovyTokenMaker extends AbstractJFlexCTokenMaker {
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = Token.NULL;
+		int state = TokenTypes.NULL;
 		switch (initialTokenType) {
-			case Token.LITERAL_STRING_DOUBLE_QUOTE:
+			case TokenTypes.LITERAL_STRING_DOUBLE_QUOTE:
 				state = MULTILINE_STRING_DOUBLE;
 				start = text.offset;
 				break;
-			case Token.LITERAL_CHAR:
+			case TokenTypes.LITERAL_CHAR:
 				state = MULTILINE_STRING_SINGLE;
 				start = text.offset;
 				break;
-			case Token.COMMENT_MULTILINE:
+			case TokenTypes.COMMENT_MULTILINE:
 				state = MLC;
 				start = text.offset;
 				break;
-			case Token.COMMENT_DOCUMENTATION:
+			case TokenTypes.COMMENT_DOCUMENTATION:
 				state = DOCCOMMENT;
 				start = text.offset;
 				break;
 			default:
-				state = Token.NULL;
+				state = TokenTypes.NULL;
 		}
 
 		s = text;
@@ -5051,7 +5051,7 @@ public class GroovyTokenMaker extends AbstractJFlexCTokenMaker {
 					ch=='['
 				)) ||
 				/* Operators "==", "===", "!=", "!==", etc. */
-				(t.getType()==Token.OPERATOR &&
+				(t.getType()==TokenTypes.OPERATOR &&
 					((ch=t.charAt(t.length()-1))=='=' || ch=='~'));
 	}
 
@@ -5321,15 +5321,15 @@ public class GroovyTokenMaker extends AbstractJFlexCTokenMaker {
 
       switch (zzAction < 0 ? zzAction : ZZ_ACTION[zzAction]) {
         case 21:
-          { addToken(start,zzStartRead-1, Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
           }
         case 49: break;
         case 3:
-          { addToken(Token.IDENTIFIER);
+          { addToken(TokenTypes.IDENTIFIER);
           }
         case 50: break;
         case 43:
-          { addToken(Token.LITERAL_BOOLEAN);
+          { addToken(TokenTypes.LITERAL_BOOLEAN);
           }
         case 51: break;
         case 6:
@@ -5341,27 +5341,27 @@ public class GroovyTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 53: break;
         case 13:
-          { addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); return firstToken;
           }
         case 54: break;
         case 35:
-          { addToken(Token.ERROR_CHAR);
+          { addToken(TokenTypes.ERROR_CHAR);
           }
         case 55: break;
         case 22:
-          { addToken(Token.ERROR_NUMBER_FORMAT);
+          { addToken(TokenTypes.ERROR_NUMBER_FORMAT);
           }
         case 56: break;
         case 5:
-          { addToken(Token.ERROR_CHAR); addNullToken(); return firstToken;
+          { addToken(TokenTypes.ERROR_CHAR); addNullToken(); return firstToken;
           }
         case 57: break;
         case 11:
-          { addToken(Token.ANNOTATION);
+          { addToken(TokenTypes.ANNOTATION);
           }
         case 58: break;
         case 29:
-          { addToken(Token.FUNCTION);
+          { addToken(TokenTypes.FUNCTION);
           }
         case 59: break;
         case 34:
@@ -5369,13 +5369,13 @@ public class GroovyTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 60: break;
         case 2:
-          { addToken(Token.ERROR_IDENTIFIER);
+          { addToken(TokenTypes.ERROR_IDENTIFIER);
           }
         case 61: break;
         case 37:
           { boolean highlightedAsRegex = false;
 				if (zzBuffer[zzStartRead]=='~' || firstToken==null) {
-					addToken(Token.REGEX);
+					addToken(TokenTypes.REGEX);
 					highlightedAsRegex = true;
 				}
 				else {
@@ -5383,7 +5383,7 @@ public class GroovyTokenMaker extends AbstractJFlexCTokenMaker {
 					// the previous token, highlight it as such.
 					Token t = firstToken.getLastNonCommentNonWhitespaceToken();
 					if (regexCanFollow(t)) {
-						addToken(Token.REGEX);
+						addToken(TokenTypes.REGEX);
 						highlightedAsRegex = true;
 					}
 				}
@@ -5391,25 +5391,25 @@ public class GroovyTokenMaker extends AbstractJFlexCTokenMaker {
 				// individual tokens.
 				if (!highlightedAsRegex) {
 					int temp = zzStartRead + 1;
-					addToken(zzStartRead, zzStartRead, Token.OPERATOR);
+					addToken(zzStartRead, zzStartRead, TokenTypes.OPERATOR);
 					zzStartRead = zzCurrentPos = zzMarkedPos = temp;
 				}
           }
         case 62: break;
         case 41:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead+2, Token.LITERAL_CHAR);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead+2, TokenTypes.LITERAL_CHAR);
           }
         case 63: break;
         case 46:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, Token.VARIABLE); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, TokenTypes.VARIABLE); start = zzMarkedPos;
           }
         case 64: break;
         case 32:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, Token.PREPROCESSOR); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, TokenTypes.PREPROCESSOR); start = zzMarkedPos;
           }
         case 65: break;
         case 45:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_DOCUMENTATION); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_DOCUMENTATION); start = zzMarkedPos;
           }
         case 66: break;
         case 15:
@@ -5417,7 +5417,7 @@ public class GroovyTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 67: break;
         case 25:
-          { addToken(Token.LITERAL_CHAR);
+          { addToken(TokenTypes.LITERAL_CHAR);
           }
         case 68: break;
         case 19:
@@ -5425,11 +5425,11 @@ public class GroovyTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 69: break;
         case 40:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead+2, Token.LITERAL_STRING_DOUBLE_QUOTE);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead+2, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
           }
         case 70: break;
         case 24:
-          { addToken(Token.LITERAL_NUMBER_HEXADECIMAL);
+          { addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL);
           }
         case 71: break;
         case 27:
@@ -5437,31 +5437,31 @@ public class GroovyTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 72: break;
         case 8:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 73: break;
         case 31:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_DOCUMENTATION);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_DOCUMENTATION);
           }
         case 74: break;
         case 39:
-          { addToken(Token.DATA_TYPE);
+          { addToken(TokenTypes.DATA_TYPE);
           }
         case 75: break;
         case 30:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE);
           }
         case 76: break;
         case 4:
-          { addToken(Token.LITERAL_NUMBER_DECIMAL_INT);
+          { addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT);
           }
         case 77: break;
         case 33:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); addToken(temp,zzMarkedPos-1, Token.VARIABLE); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); addToken(temp,zzMarkedPos-1, TokenTypes.VARIABLE); start = zzMarkedPos;
           }
         case 78: break;
         case 20:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead, Token.LITERAL_STRING_DOUBLE_QUOTE);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
           }
         case 79: break;
         case 17:
@@ -5473,23 +5473,23 @@ public class GroovyTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 81: break;
         case 28:
-          { addToken(Token.RESERVED_WORD);
+          { addToken(TokenTypes.RESERVED_WORD);
           }
         case 82: break;
         case 44:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos;
           }
         case 83: break;
         case 48:
-          { addToken(Token.RESERVED_WORD_2);
+          { addToken(TokenTypes.RESERVED_WORD_2);
           }
         case 84: break;
         case 14:
-          { addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
           }
         case 85: break;
         case 10:
-          { addToken(Token.SEPARATOR);
+          { addToken(TokenTypes.SEPARATOR);
           }
         case 86: break;
         case 7:
@@ -5497,27 +5497,27 @@ public class GroovyTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 87: break;
         case 12:
-          { addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken;
           }
         case 88: break;
         case 9:
-          { addToken(Token.OPERATOR);
+          { addToken(TokenTypes.OPERATOR);
           }
         case 89: break;
         case 18:
-          { addToken(start,zzStartRead-1, Token.LITERAL_CHAR); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.LITERAL_CHAR); return firstToken;
           }
         case 90: break;
         case 23:
-          { addToken(Token.LITERAL_NUMBER_FLOAT);
+          { addToken(TokenTypes.LITERAL_NUMBER_FLOAT);
           }
         case 91: break;
         case 47:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos;
           }
         case 92: break;
         case 42:
-          { addToken(Token.COMMENT_MULTILINE);
+          { addToken(TokenTypes.COMMENT_MULTILINE);
           }
         case 93: break;
         case 26:
@@ -5529,7 +5529,7 @@ public class GroovyTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 95: break;
         case 16:
-          { addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
           }
         case 96: break;
         default:
@@ -5537,15 +5537,15 @@ public class GroovyTokenMaker extends AbstractJFlexCTokenMaker {
             zzAtEOF = true;
             switch (zzLexicalState) {
             case EOL_COMMENT: {
-              addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
             }
             case 2059: break;
             case MULTILINE_STRING_DOUBLE: {
-              addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
             }
             case 2060: break;
             case DOCCOMMENT: {
-              yybegin(YYINITIAL); addToken(start,zzEndRead, Token.COMMENT_DOCUMENTATION); return firstToken;
+              yybegin(YYINITIAL); addToken(start,zzEndRead, TokenTypes.COMMENT_DOCUMENTATION); return firstToken;
             }
             case 2061: break;
             case YYINITIAL: {
@@ -5553,15 +5553,15 @@ public class GroovyTokenMaker extends AbstractJFlexCTokenMaker {
             }
             case 2062: break;
             case MLC: {
-              addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken;
             }
             case 2063: break;
             case STRING_DOUBLE: {
-              addToken(start,zzStartRead-1, Token.ERROR_STRING_DOUBLE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.ERROR_STRING_DOUBLE); return firstToken;
             }
             case 2064: break;
             case MULTILINE_STRING_SINGLE: {
-              addToken(start,zzStartRead-1, Token.LITERAL_CHAR); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.LITERAL_CHAR); return firstToken;
             }
             case 2065: break;
             default:

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/HTMLTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/HTMLTokenMaker.flex
@@ -1002,8 +1002,8 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"void" |
 	"while" |
 	"with" |
-    "yield"                     { addToken(Token.RESERVED_WORD); }
-	"return"					{ addToken(Token.RESERVED_WORD_2); }
+    "yield"                     { addToken(TokenTypes.RESERVED_WORD); }
+	"return"					{ addToken(TokenTypes.RESERVED_WORD_2); }
 
 	//JavaScript 1.6
 	"each" 						{if(JavaScriptTokenMaker.isJavaScriptCompatible("1.6")){ addToken(TokenTypes.RESERVED_WORD);} else {addToken(TokenTypes.IDENTIFIER);} }
@@ -1011,30 +1011,30 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"let" 						{if(JavaScriptTokenMaker.isJavaScriptCompatible("1.7")){ addToken(TokenTypes.RESERVED_WORD);} else {addToken(TokenTypes.IDENTIFIER);} }
 
 	// Reserved (but not yet used) ECMA keywords.
-	"abstract"					{ addToken(Token.RESERVED_WORD); }
-	"boolean"						{ addToken(Token.DATA_TYPE); }
-	"byte"						{ addToken(Token.DATA_TYPE); }
-	"char"						{ addToken(Token.DATA_TYPE); }
-	"default"						{ addToken(Token.RESERVED_WORD); }
-	"double"						{ addToken(Token.DATA_TYPE); }
-	"enum"						{ addToken(Token.RESERVED_WORD); }
-	"final"						{ addToken(Token.RESERVED_WORD); }
-	"float"						{ addToken(Token.DATA_TYPE); }
-	"goto"						{ addToken(Token.RESERVED_WORD); }
-	"implements"					{ addToken(Token.RESERVED_WORD); }
-	"int"						{ addToken(Token.DATA_TYPE); }
-	"interface"					{ addToken(Token.RESERVED_WORD); }
-	"long"						{ addToken(Token.DATA_TYPE); }
-	"native"						{ addToken(Token.RESERVED_WORD); }
-	"package"						{ addToken(Token.RESERVED_WORD); }
-	"private"						{ addToken(Token.RESERVED_WORD); }
-	"protected"					{ addToken(Token.RESERVED_WORD); }
-	"public"						{ addToken(Token.RESERVED_WORD); }
-	"short"						{ addToken(Token.DATA_TYPE); }
-	"synchronized"					{ addToken(Token.RESERVED_WORD); }
-	"throws"						{ addToken(Token.RESERVED_WORD); }
-	"transient"					{ addToken(Token.RESERVED_WORD); }
-	"volatile"					{ addToken(Token.RESERVED_WORD); }
+	"abstract"					{ addToken(TokenTypes.RESERVED_WORD); }
+	"boolean"						{ addToken(TokenTypes.DATA_TYPE); }
+	"byte"						{ addToken(TokenTypes.DATA_TYPE); }
+	"char"						{ addToken(TokenTypes.DATA_TYPE); }
+	"default"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"double"						{ addToken(TokenTypes.DATA_TYPE); }
+	"enum"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"final"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"float"						{ addToken(TokenTypes.DATA_TYPE); }
+	"goto"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"implements"					{ addToken(TokenTypes.RESERVED_WORD); }
+	"int"						{ addToken(TokenTypes.DATA_TYPE); }
+	"interface"					{ addToken(TokenTypes.RESERVED_WORD); }
+	"long"						{ addToken(TokenTypes.DATA_TYPE); }
+	"native"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"package"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"private"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"protected"					{ addToken(TokenTypes.RESERVED_WORD); }
+	"public"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"short"						{ addToken(TokenTypes.DATA_TYPE); }
+	"synchronized"					{ addToken(TokenTypes.RESERVED_WORD); }
+	"throws"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"transient"					{ addToken(TokenTypes.RESERVED_WORD); }
+	"volatile"					{ addToken(TokenTypes.RESERVED_WORD); }
 
 	// Literals.
 	"false" |

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/HTMLTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/HTMLTokenMaker.java
@@ -2601,7 +2601,7 @@ public class HTMLTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 121: break;
         case 109:
-          { addToken(Token.RESERVED_WORD_2);
+          { addToken(TokenTypes.RESERVED_WORD_2);
           }
         case 122: break;
         case 89:
@@ -3020,7 +3020,7 @@ public class HTMLTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 208: break;
         case 84:
-          { addToken(Token.RESERVED_WORD);
+          { addToken(TokenTypes.RESERVED_WORD);
           }
         case 209: break;
         case 97:
@@ -3066,7 +3066,7 @@ public class HTMLTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 214: break;
         case 98:
-          { addToken(Token.DATA_TYPE);
+          { addToken(TokenTypes.DATA_TYPE);
           }
         case 215: break;
         case 83:

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/HandlebarsTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/HandlebarsTokenMaker.flex
@@ -998,7 +998,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
     /* Handlebars states */
     "{{{{" |
     "{{{" |
-    "{{"                        { hbCurlyCount = zzMarkedPos - zzStartRead; addToken(Token.SEPARATOR); hbInState = zzLexicalState; yybegin(HB, LANG_INDEX_HANDLEBARS); }
+    "{{"                        { hbCurlyCount = zzMarkedPos - zzStartRead; addToken(TokenTypes.SEPARATOR); hbInState = zzLexicalState; yybegin(HB, LANG_INDEX_HANDLEBARS); }
     "{"                         { addToken(TokenTypes.MARKUP_TAG_ATTRIBUTE); }
 
 	"/"						{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); }
@@ -1016,7 +1016,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
     /* Handlebars states */
     "{{{{" |
     "{{{" |
-    "{{"                        { int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); hbCurlyCount = zzMarkedPos - temp; addToken(temp, zzMarkedPos-1, Token.SEPARATOR); hbInState = zzLexicalState; yybegin(HB, LANG_INDEX_HANDLEBARS); }
+    "{{"                        { int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); hbCurlyCount = zzMarkedPos - temp; addToken(temp, zzMarkedPos-1, TokenTypes.SEPARATOR); hbInState = zzLexicalState; yybegin(HB, LANG_INDEX_HANDLEBARS); }
     "{"                         {}
 
 	[^\"{]*						{}
@@ -1028,7 +1028,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
     /* Handlebars states */
     "{{{{" |
     "{{{" |
-    "{{"                        { int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); hbCurlyCount = zzMarkedPos - temp; addToken(temp, zzMarkedPos-1, Token.SEPARATOR); hbInState = zzLexicalState; yybegin(HB, LANG_INDEX_HANDLEBARS); }
+    "{{"                        { int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); hbCurlyCount = zzMarkedPos - temp; addToken(temp, zzMarkedPos-1, TokenTypes.SEPARATOR); hbInState = zzLexicalState; yybegin(HB, LANG_INDEX_HANDLEBARS); }
     "{"                         {}
 
 	[^\'{]*						{}
@@ -1129,8 +1129,8 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"void" |
 	"while" |
 	"with" |
-    "yield"                     { addToken(Token.RESERVED_WORD); }
-	"return"					{ addToken(Token.RESERVED_WORD_2); }
+    "yield"                     { addToken(TokenTypes.RESERVED_WORD); }
+	"return"					{ addToken(TokenTypes.RESERVED_WORD_2); }
 
 	//JavaScript 1.6
 	"each" 						{if(JavaScriptTokenMaker.isJavaScriptCompatible("1.6")){ addToken(TokenTypes.RESERVED_WORD);} else {addToken(TokenTypes.IDENTIFIER);} }
@@ -1138,30 +1138,30 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"let" 						{if(JavaScriptTokenMaker.isJavaScriptCompatible("1.7")){ addToken(TokenTypes.RESERVED_WORD);} else {addToken(TokenTypes.IDENTIFIER);} }
 
 	// Reserved (but not yet used) ECMA keywords.
-	"abstract"					{ addToken(Token.RESERVED_WORD); }
-	"boolean"						{ addToken(Token.DATA_TYPE); }
-	"byte"						{ addToken(Token.DATA_TYPE); }
-	"char"						{ addToken(Token.DATA_TYPE); }
-	"default"						{ addToken(Token.RESERVED_WORD); }
-	"double"						{ addToken(Token.DATA_TYPE); }
-	"enum"						{ addToken(Token.RESERVED_WORD); }
-	"final"						{ addToken(Token.RESERVED_WORD); }
-	"float"						{ addToken(Token.DATA_TYPE); }
-	"goto"						{ addToken(Token.RESERVED_WORD); }
-	"implements"					{ addToken(Token.RESERVED_WORD); }
-	"int"						{ addToken(Token.DATA_TYPE); }
-	"interface"					{ addToken(Token.RESERVED_WORD); }
-	"long"						{ addToken(Token.DATA_TYPE); }
-	"native"						{ addToken(Token.RESERVED_WORD); }
-	"package"						{ addToken(Token.RESERVED_WORD); }
-	"private"						{ addToken(Token.RESERVED_WORD); }
-	"protected"					{ addToken(Token.RESERVED_WORD); }
-	"public"						{ addToken(Token.RESERVED_WORD); }
-	"short"						{ addToken(Token.DATA_TYPE); }
-	"synchronized"					{ addToken(Token.RESERVED_WORD); }
-	"throws"						{ addToken(Token.RESERVED_WORD); }
-	"transient"					{ addToken(Token.RESERVED_WORD); }
-	"volatile"					{ addToken(Token.RESERVED_WORD); }
+	"abstract"					{ addToken(TokenTypes.RESERVED_WORD); }
+	"boolean"						{ addToken(TokenTypes.DATA_TYPE); }
+	"byte"						{ addToken(TokenTypes.DATA_TYPE); }
+	"char"						{ addToken(TokenTypes.DATA_TYPE); }
+	"default"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"double"						{ addToken(TokenTypes.DATA_TYPE); }
+	"enum"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"final"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"float"						{ addToken(TokenTypes.DATA_TYPE); }
+	"goto"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"implements"					{ addToken(TokenTypes.RESERVED_WORD); }
+	"int"						{ addToken(TokenTypes.DATA_TYPE); }
+	"interface"					{ addToken(TokenTypes.RESERVED_WORD); }
+	"long"						{ addToken(TokenTypes.DATA_TYPE); }
+	"native"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"package"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"private"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"protected"					{ addToken(TokenTypes.RESERVED_WORD); }
+	"public"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"short"						{ addToken(TokenTypes.DATA_TYPE); }
+	"synchronized"					{ addToken(TokenTypes.RESERVED_WORD); }
+	"throws"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"transient"					{ addToken(TokenTypes.RESERVED_WORD); }
+	"volatile"					{ addToken(TokenTypes.RESERVED_WORD); }
 
 	// Literals.
 	"false" |

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/HandlebarsTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/HandlebarsTokenMaker.java
@@ -2867,7 +2867,7 @@ public class HandlebarsTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 144: break;
         case 131:
-          { addToken(Token.RESERVED_WORD_2);
+          { addToken(TokenTypes.RESERVED_WORD_2);
           }
         case 145: break;
         case 103:
@@ -3215,7 +3215,7 @@ public class HandlebarsTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 218: break;
         case 91:
-          { hbCurlyCount = zzMarkedPos - zzStartRead; addToken(Token.SEPARATOR); hbInState = zzLexicalState; yybegin(HB, LANG_INDEX_HANDLEBARS);
+          { hbCurlyCount = zzMarkedPos - zzStartRead; addToken(TokenTypes.SEPARATOR); hbInState = zzLexicalState; yybegin(HB, LANG_INDEX_HANDLEBARS);
           }
         case 219: break;
         case 32:
@@ -3360,7 +3360,7 @@ public class HandlebarsTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 243: break;
         case 92:
-          { int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); hbCurlyCount = zzMarkedPos - temp; addToken(temp, zzMarkedPos-1, Token.SEPARATOR); hbInState = zzLexicalState; yybegin(HB, LANG_INDEX_HANDLEBARS);
+          { int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); hbCurlyCount = zzMarkedPos - temp; addToken(temp, zzMarkedPos-1, TokenTypes.SEPARATOR); hbInState = zzLexicalState; yybegin(HB, LANG_INDEX_HANDLEBARS);
           }
         case 244: break;
         case 18:
@@ -3397,7 +3397,7 @@ public class HandlebarsTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 250: break;
         case 98:
-          { addToken(Token.RESERVED_WORD);
+          { addToken(TokenTypes.RESERVED_WORD);
           }
         case 251: break;
         case 115:
@@ -3447,7 +3447,7 @@ public class HandlebarsTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 257: break;
         case 116:
-          { addToken(Token.DATA_TYPE);
+          { addToken(TokenTypes.DATA_TYPE);
           }
         case 258: break;
         case 97:

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/HostsTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/HostsTokenMaker.flex
@@ -133,7 +133,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 
 	@Override
 	public boolean getMarkOccurrencesOfTokenType(int type) {
-		return type == Token.RESERVED_WORD;
+		return type == TokenTypes.RESERVED_WORD;
 	}
 
 
@@ -232,10 +232,10 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 
 <YYINITIAL> {
 	{Identifier}			{
-								addToken(first ? Token.RESERVED_WORD : Token.IDENTIFIER);
+								addToken(first ? TokenTypes.RESERVED_WORD : TokenTypes.IDENTIFIER);
 								first = false;
 							}
-	{Whitespace}			{ addToken(Token.WHITESPACE); }
+	{Whitespace}			{ addToken(TokenTypes.WHITESPACE); }
 	{LineCommentBegin}		{ start = zzMarkedPos-1; yybegin(EOL_COMMENT); }
 	\n |
 	<<EOF>>					{ addNullToken(); return firstToken; }
@@ -243,8 +243,8 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 
 <EOL_COMMENT> {
 	[^hwf\n]+				{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos; }
 	[hwf]					{}
 	\n |
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken; }
 }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/HostsTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/HostsTokenMaker.java
@@ -314,7 +314,7 @@ public class HostsTokenMaker extends AbstractJFlexTokenMaker {
 
 	@Override
 	public boolean getMarkOccurrencesOfTokenType(int type) {
-		return type == Token.RESERVED_WORD;
+		return type == TokenTypes.RESERVED_WORD;
 	}
 
 
@@ -622,7 +622,7 @@ public class HostsTokenMaker extends AbstractJFlexTokenMaker {
           }
         case 8: break;
         case 7:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos;
           }
         case 9: break;
         case 4:
@@ -630,15 +630,15 @@ public class HostsTokenMaker extends AbstractJFlexTokenMaker {
           }
         case 10: break;
         case 3:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 11: break;
         case 6:
-          { addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
           }
         case 12: break;
         case 1:
-          { addToken(first ? Token.RESERVED_WORD : Token.IDENTIFIER);
+          { addToken(first ? TokenTypes.RESERVED_WORD : TokenTypes.IDENTIFIER);
 								first = false;
           }
         case 13: break;
@@ -651,7 +651,7 @@ public class HostsTokenMaker extends AbstractJFlexTokenMaker {
             zzAtEOF = true;
             switch (zzLexicalState) {
             case EOL_COMMENT: {
-              addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
             }
             case 25: break;
             case YYINITIAL: {

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/HtaccessTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/HtaccessTokenMaker.flex
@@ -290,19 +290,19 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 
 <YYINITIAL> {
 
-	{Whitespace}				{ addToken(Token.WHITESPACE); }
+	{Whitespace}				{ addToken(TokenTypes.WHITESPACE); }
 	{LineCommentBegin}			{ start = zzMarkedPos-1; yybegin(EOL_COMMENT); }	
 	
 	"<"{TagName}				{
 									int count = yylength();
-									addToken(zzStartRead,zzStartRead, Token.MARKUP_TAG_DELIMITER);
-									addToken(zzMarkedPos-(count-1), zzMarkedPos-1, Token.MARKUP_TAG_NAME);
+									addToken(zzStartRead,zzStartRead, TokenTypes.MARKUP_TAG_DELIMITER);
+									addToken(zzMarkedPos-(count-1), zzMarkedPos-1, TokenTypes.MARKUP_TAG_NAME);
 									yybegin(INTAG);
 								}
 	"</"{TagName}				{
 									int count = yylength();
-									addToken(zzStartRead,zzStartRead+1, Token.MARKUP_TAG_DELIMITER);
-									addToken(zzMarkedPos-(count-2), zzMarkedPos-1, Token.MARKUP_TAG_NAME);
+									addToken(zzStartRead,zzStartRead+1, TokenTypes.MARKUP_TAG_DELIMITER);
+									addToken(zzMarkedPos-(count-2), zzMarkedPos-1, TokenTypes.MARKUP_TAG_NAME);
 									yybegin(INTAG);
 								}
 	
@@ -456,23 +456,23 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"SSLVerifyClient" |
 	"SSLVerifyDepth" |
 	"UnsetEnv" |
-	"XBitHack"					{ addToken(Token.FUNCTION); }
+	"XBitHack"					{ addToken(TokenTypes.FUNCTION); }
 
-	{Identifier}				{ addToken(Token.IDENTIFIER); }
-	{StringLiteral}				{ addToken(Token.LITERAL_STRING_DOUBLE_QUOTE); }
-	{UnclosedStringLiteral}		{ addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
-	{ErrorStringLiteral}		{ addToken(Token.ERROR_STRING_DOUBLE); }
+	{Identifier}				{ addToken(TokenTypes.IDENTIFIER); }
+	{StringLiteral}				{ addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); }
+	{UnclosedStringLiteral}		{ addToken(TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
+	{ErrorStringLiteral}		{ addToken(TokenTypes.ERROR_STRING_DOUBLE); }
 	
-	.							{ addToken(Token.IDENTIFIER); }
+	.							{ addToken(TokenTypes.IDENTIFIER); }
 	\n |
 	<<EOF>>						{ addNullToken(); return firstToken; }
 }
 
 <INTAG> {
-	{InTagIdentifier}			{ addToken(Token.MARKUP_TAG_ATTRIBUTE); }
-	{Whitespace}+				{ addToken(Token.WHITESPACE); }
-	"="							{ addToken(Token.OPERATOR); }
-	">"							{ yybegin(YYINITIAL); addToken(Token.MARKUP_TAG_DELIMITER); }
+	{InTagIdentifier}			{ addToken(TokenTypes.MARKUP_TAG_ATTRIBUTE); }
+	{Whitespace}+				{ addToken(TokenTypes.WHITESPACE); }
+	"="							{ addToken(TokenTypes.OPERATOR); }
+	">"							{ yybegin(YYINITIAL); addToken(TokenTypes.MARKUP_TAG_DELIMITER); }
 	[\"]						{ start = zzMarkedPos-1; yybegin(INATTR_DOUBLE); }
 	[\']						{ start = zzMarkedPos-1; yybegin(INATTR_SINGLE); }
 	<<EOF>>						{ addToken(start,zzStartRead-1, INTERNAL_INTAG); return firstToken; }
@@ -480,21 +480,21 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 
 <INATTR_DOUBLE> {
 	[^\"]*						{}
-	[\"]						{ yybegin(INTAG); addToken(start,zzStartRead, Token.MARKUP_TAG_ATTRIBUTE_VALUE); }
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE); return firstToken; }
+	[\"]						{ yybegin(INTAG); addToken(start,zzStartRead, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE); return firstToken; }
 }
 
 <INATTR_SINGLE> {
 	[^\']*						{}
-	[\']						{ yybegin(INTAG); addToken(start,zzStartRead, Token.MARKUP_TAG_ATTRIBUTE_VALUE); }
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE); return firstToken; }
+	[\']						{ yybegin(INTAG); addToken(start,zzStartRead, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE); return firstToken; }
 }
 
 <EOL_COMMENT> {
 	[^hwf\n]+				{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos; }
 	[hwf]					{}
 	\n |
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken; }
 
 }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/HtaccessTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/HtaccessTokenMaker.java
@@ -1386,7 +1386,7 @@ public final void yybegin(int newState) {
 
       switch (zzAction < 0 ? zzAction : ZZ_ACTION[zzAction]) {
         case 12:
-          { yybegin(INTAG); addToken(start,zzStartRead, Token.MARKUP_TAG_ATTRIBUTE_VALUE);
+          { yybegin(INTAG); addToken(start,zzStartRead, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE);
           }
         case 20: break;
         case 4:
@@ -1395,39 +1395,39 @@ public final void yybegin(int newState) {
         case 21: break;
         case 15:
           { int count = yylength();
-									addToken(zzStartRead,zzStartRead+1, Token.MARKUP_TAG_DELIMITER);
-									addToken(zzMarkedPos-(count-2), zzMarkedPos-1, Token.MARKUP_TAG_NAME);
+									addToken(zzStartRead,zzStartRead+1, TokenTypes.MARKUP_TAG_DELIMITER);
+									addToken(zzMarkedPos-(count-2), zzMarkedPos-1, TokenTypes.MARKUP_TAG_NAME);
 									yybegin(INTAG);
           }
         case 22: break;
         case 3:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 23: break;
         case 17:
-          { addToken(Token.ERROR_STRING_DOUBLE);
+          { addToken(TokenTypes.ERROR_STRING_DOUBLE);
           }
         case 24: break;
         case 2:
-          { addToken(Token.IDENTIFIER);
+          { addToken(TokenTypes.IDENTIFIER);
           }
         case 25: break;
         case 6:
-          { addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
           }
         case 26: break;
         case 18:
-          { addToken(Token.FUNCTION);
+          { addToken(TokenTypes.FUNCTION);
           }
         case 27: break;
         case 14:
-          { addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
+          { addToken(TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
           }
         case 28: break;
         case 13:
           { int count = yylength();
-									addToken(zzStartRead,zzStartRead, Token.MARKUP_TAG_DELIMITER);
-									addToken(zzMarkedPos-(count-1), zzMarkedPos-1, Token.MARKUP_TAG_NAME);
+									addToken(zzStartRead,zzStartRead, TokenTypes.MARKUP_TAG_DELIMITER);
+									addToken(zzMarkedPos-(count-1), zzMarkedPos-1, TokenTypes.MARKUP_TAG_NAME);
 									yybegin(INTAG);
           }
         case 29: break;
@@ -1436,11 +1436,11 @@ public final void yybegin(int newState) {
           }
         case 30: break;
         case 8:
-          { yybegin(YYINITIAL); addToken(Token.MARKUP_TAG_DELIMITER);
+          { yybegin(YYINITIAL); addToken(TokenTypes.MARKUP_TAG_DELIMITER);
           }
         case 31: break;
         case 16:
-          { addToken(Token.LITERAL_STRING_DOUBLE_QUOTE);
+          { addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
           }
         case 32: break;
         case 10:
@@ -1448,7 +1448,7 @@ public final void yybegin(int newState) {
           }
         case 33: break;
         case 19:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos;
           }
         case 34: break;
         case 5:
@@ -1456,11 +1456,11 @@ public final void yybegin(int newState) {
           }
         case 35: break;
         case 11:
-          { addToken(Token.OPERATOR);
+          { addToken(TokenTypes.OPERATOR);
           }
         case 36: break;
         case 7:
-          { addToken(Token.MARKUP_TAG_ATTRIBUTE);
+          { addToken(TokenTypes.MARKUP_TAG_ATTRIBUTE);
           }
         case 37: break;
         case 1:
@@ -1472,7 +1472,7 @@ public final void yybegin(int newState) {
             zzAtEOF = true;
             switch (zzLexicalState) {
             case EOL_COMMENT: {
-              addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
             }
             case 796: break;
             case INTAG: {
@@ -1480,7 +1480,7 @@ public final void yybegin(int newState) {
             }
             case 797: break;
             case INATTR_DOUBLE: {
-              addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE); return firstToken;
             }
             case 798: break;
             case YYINITIAL: {
@@ -1488,7 +1488,7 @@ public final void yybegin(int newState) {
             }
             case 799: break;
             case INATTR_SINGLE: {
-              addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE); return firstToken;
             }
             case 800: break;
             default:

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/IniTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/IniTokenMaker.flex
@@ -140,11 +140,11 @@ Section				= ([\[][^\]]*[\]]?)
 %%
 
 <YYINITIAL> {
-	{Identifier}		{ addToken(Token.DATA_TYPE); }
-	{Equals}			{ addToken(Token.OPERATOR); yybegin(PRE_VALUE); }
-	{Whitespace}		{ addToken(Token.WHITESPACE); }
-	{Comment}			{ addToken(Token.COMMENT_EOL); }
-	{Section}			{ addToken(Token.PREPROCESSOR); }
+	{Identifier}		{ addToken(TokenTypes.DATA_TYPE); }
+	{Equals}			{ addToken(TokenTypes.OPERATOR); yybegin(PRE_VALUE); }
+	{Whitespace}		{ addToken(TokenTypes.WHITESPACE); }
+	{Comment}			{ addToken(TokenTypes.COMMENT_EOL); }
+	{Section}			{ addToken(TokenTypes.PREPROCESSOR); }
     \n                  { addNullToken(); return firstToken; }
 	<<EOF>>				{ addNullToken(); return firstToken; }
 }
@@ -173,7 +173,7 @@ Section				= ([\[][^\]]*[\]]?)
 }
 
 <VALUE> {
-    {Comment}			{ addIdentifier(TokenTypes.IDENTIFIER); addToken(Token.COMMENT_EOL); }
+    {Comment}			{ addIdentifier(TokenTypes.IDENTIFIER); addToken(TokenTypes.COMMENT_EOL); }
     {Whitespace}        { addIdentifier(TokenTypes.IDENTIFIER); addToken(TokenTypes.WHITESPACE); }
 	[^]                 { updateIdentifier(); }
 	<<EOF>>				{ addIdentifier(TokenTypes.IDENTIFIER); addNullToken(); return firstToken; }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/IniTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/IniTokenMaker.java
@@ -583,12 +583,12 @@ public class IniTokenMaker extends AbstractJFlexTokenMaker {
       else {
         switch (zzAction < 0 ? zzAction : ZZ_ACTION[zzAction]) {
           case 1:
-            { addToken(Token.DATA_TYPE);
+            { addToken(TokenTypes.DATA_TYPE);
             }
           // fall through
           case 17: break;
           case 2:
-            { addToken(Token.WHITESPACE);
+            { addToken(TokenTypes.WHITESPACE);
             }
           // fall through
           case 18: break;
@@ -598,17 +598,17 @@ public class IniTokenMaker extends AbstractJFlexTokenMaker {
           // fall through
           case 19: break;
           case 4:
-            { addToken(Token.COMMENT_EOL);
+            { addToken(TokenTypes.COMMENT_EOL);
             }
           // fall through
           case 20: break;
           case 5:
-            { addToken(Token.OPERATOR); yybegin(PRE_VALUE);
+            { addToken(TokenTypes.OPERATOR); yybegin(PRE_VALUE);
             }
           // fall through
           case 21: break;
           case 6:
-            { addToken(Token.PREPROCESSOR);
+            { addToken(TokenTypes.PREPROCESSOR);
             }
           // fall through
           case 22: break;
@@ -623,7 +623,7 @@ public class IniTokenMaker extends AbstractJFlexTokenMaker {
           // fall through
           case 24: break;
           case 9:
-            { addIdentifier(TokenTypes.IDENTIFIER); addToken(Token.COMMENT_EOL);
+            { addIdentifier(TokenTypes.IDENTIFIER); addToken(TokenTypes.COMMENT_EOL);
             }
           // fall through
           case 25: break;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/JSPTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/JSPTokenMaker.flex
@@ -365,8 +365,8 @@ import org.fife.ui.rsyntaxtextarea.*;
 
 	@Override
 	public boolean getMarkOccurrencesOfTokenType(int type) {
-		return type==Token.FUNCTION || type==Token.VARIABLE ||
-				type==Token.MARKUP_TAG_NAME;
+		return type==TokenTypes.FUNCTION || type==TokenTypes.VARIABLE ||
+				type==TokenTypes.MARKUP_TAG_NAME;
 	}
 
 
@@ -411,13 +411,13 @@ import org.fife.ui.rsyntaxtextarea.*;
 		// Start off in the proper state.
 		int state;
 		switch (initialTokenType) {
-			case Token.MARKUP_COMMENT:
+			case TokenTypes.MARKUP_COMMENT:
 				state = COMMENT;
 				break;
-			case Token.PREPROCESSOR:
+			case TokenTypes.PREPROCESSOR:
 				state = PI;
 				break;
-			case Token.VARIABLE:
+			case TokenTypes.VARIABLE:
 				state = DTD;
 				break;
 			case INTERNAL_INTAG:
@@ -540,7 +540,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 					}
 				}
 				else {
-					state = Token.NULL;
+					state = TokenTypes.NULL;
 				}
 				break;
 		}
@@ -796,38 +796,38 @@ CSS_Number					= ({CSS_Digits}|{CSS_Hex})
 <YYINITIAL> {
 	"<!--"						{ start = zzMarkedPos-4; yybegin(COMMENT); }
 	"<"[sS][cC][rR][iI][pP][tT]	{
-								  addToken(zzStartRead,zzStartRead, Token.MARKUP_TAG_DELIMITER);
-								  addToken(zzMarkedPos-6,zzMarkedPos-1, Token.MARKUP_TAG_NAME);
+								  addToken(zzStartRead,zzStartRead, TokenTypes.MARKUP_TAG_DELIMITER);
+								  addToken(zzMarkedPos-6,zzMarkedPos-1, TokenTypes.MARKUP_TAG_NAME);
 								  start = zzMarkedPos; yybegin(INTAG_SCRIPT);
 								}
 	"<"[sS][tT][yY][lL][eE]		{
-								  addToken(zzStartRead,zzStartRead, Token.MARKUP_TAG_DELIMITER);
-								  addToken(zzMarkedPos-5,zzMarkedPos-1, Token.MARKUP_TAG_NAME);
+								  addToken(zzStartRead,zzStartRead, TokenTypes.MARKUP_TAG_DELIMITER);
+								  addToken(zzMarkedPos-5,zzMarkedPos-1, TokenTypes.MARKUP_TAG_NAME);
 								  start = zzMarkedPos; cssPrevState = zzLexicalState; yybegin(INTAG_STYLE);
 								}
 	"<!"						{ start = zzMarkedPos-2; yybegin(DTD); }
 	"<?"						{ start = zzMarkedPos-2; yybegin(PI); }
 	"<%--"					{ start = zzMarkedPos-4; yybegin(HIDDEN_COMMENT); }
-	{JspStart}				{ addToken(Token.MARKUP_TAG_DELIMITER); jspInState = zzLexicalState; yybegin(JAVA_EXPRESSION); }
-	"<%@"                         { addToken(Token.MARKUP_TAG_DELIMITER); yybegin(JSP_DIRECTIVE); }
+	{JspStart}				{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); jspInState = zzLexicalState; yybegin(JAVA_EXPRESSION); }
+	"<%@"                         { addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(JSP_DIRECTIVE); }
 	"<"({Letter}|{Digit})+		{
 									int count = yylength();
-									addToken(zzStartRead,zzStartRead, Token.MARKUP_TAG_DELIMITER);
+									addToken(zzStartRead,zzStartRead, TokenTypes.MARKUP_TAG_DELIMITER);
 									zzMarkedPos -= (count-1); //yypushback(count-1);
 									yybegin(INTAG_CHECK_TAG_NAME);
 								}
 	"</"({Letter}|{Digit})+		{
 									int count = yylength();
-									addToken(zzStartRead,zzStartRead+1, Token.MARKUP_TAG_DELIMITER);
+									addToken(zzStartRead,zzStartRead+1, TokenTypes.MARKUP_TAG_DELIMITER);
 									zzMarkedPos -= (count-2); //yypushback(count-2);
 									yybegin(INTAG_CHECK_TAG_NAME);
 								}
-	"<"							{ addToken(Token.MARKUP_TAG_DELIMITER); yybegin(INTAG); }
-	"</"						{ addToken(Token.MARKUP_TAG_DELIMITER); yybegin(INTAG); }
+	"<"							{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(INTAG); }
+	"</"						{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(INTAG); }
 	{LineTerminator}			{ addNullToken(); return firstToken; }
-	{Identifier}				{ addToken(Token.IDENTIFIER); } // Catches everything.
-	{EntityReference}			{ addToken(Token.MARKUP_ENTITY_REFERENCE); }
-	{Whitespace}+				{ addToken(Token.WHITESPACE); }
+	{Identifier}				{ addToken(TokenTypes.IDENTIFIER); } // Catches everything.
+	{EntityReference}			{ addToken(TokenTypes.MARKUP_ENTITY_REFERENCE); }
+	{Whitespace}+				{ addToken(TokenTypes.WHITESPACE); }
 	<<EOF>>					{ addNullToken(); return firstToken; }
 }
 
@@ -843,35 +843,35 @@ CSS_Number					= ({CSS_Digits}|{CSS_Hex})
                                 start = zzMarkedPos;
                             }
 	[hwf]					{}
-	"-->"					{ yybegin(YYINITIAL); addToken(start,zzStartRead+2, Token.MARKUP_COMMENT); }
+	"-->"					{ yybegin(YYINITIAL); addToken(start,zzStartRead+2, TokenTypes.MARKUP_COMMENT); }
 	"-"						{}
 	{LineTerminator} |
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.MARKUP_COMMENT); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_COMMENT); return firstToken; }
 }
 
 <HIDDEN_COMMENT> {
 	[^hwf\n\-]+				{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.MARKUP_COMMENT); addHyperlinkToken(temp,zzMarkedPos-1, Token.MARKUP_COMMENT); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.MARKUP_COMMENT); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.MARKUP_COMMENT); start = zzMarkedPos; }
 	[hwf]					{}
-	"--%>"					{ yybegin(YYINITIAL); addToken(start,zzStartRead+3, Token.MARKUP_COMMENT); }
+	"--%>"					{ yybegin(YYINITIAL); addToken(start,zzStartRead+3, TokenTypes.MARKUP_COMMENT); }
 	"-"						{}
 	{LineTerminator} |
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.MARKUP_COMMENT); addEndToken(INTERNAL_IN_HIDDEN_COMMENT); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_COMMENT); addEndToken(INTERNAL_IN_HIDDEN_COMMENT); return firstToken; }
 }
 
 <PI> {
 	[^\n\?]+					{}
-	{LineTerminator}			{ addToken(start,zzStartRead-1, Token.MARKUP_PROCESSING_INSTRUCTION); return firstToken; }
-	"?>"						{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.MARKUP_PROCESSING_INSTRUCTION); }
+	{LineTerminator}			{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_PROCESSING_INSTRUCTION); return firstToken; }
+	"?>"						{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.MARKUP_PROCESSING_INSTRUCTION); }
 	"?"						{}
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.MARKUP_PROCESSING_INSTRUCTION); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_PROCESSING_INSTRUCTION); return firstToken; }
 }
 
 <DTD> {
 	[^\n>]+					{}
-	{LineTerminator}			{ addToken(start,zzStartRead-1, Token.MARKUP_DTD); return firstToken; }
-	">"						{ yybegin(YYINITIAL); addToken(start,zzStartRead, Token.MARKUP_DTD); }
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.MARKUP_DTD); return firstToken; }
+	{LineTerminator}			{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_DTD); return firstToken; }
+	">"						{ yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.MARKUP_DTD); }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_DTD); return firstToken; }
 }
 
 <INTAG_CHECK_TAG_NAME> {
@@ -1000,77 +1000,77 @@ CSS_Number					= ({CSS_Digits}|{CSS_Hex})
 	[uU] |
 	[uU][lL] |
 	[vV][aA][rR] |
-	[vV][iI][dD][eE][oO]    { addToken(Token.MARKUP_TAG_NAME); }
+	[vV][iI][dD][eE][oO]    { addToken(TokenTypes.MARKUP_TAG_NAME); }
 	{InTagIdentifier}		{ /* A non-recognized HTML tag name */ yypushback(yylength()); yybegin(INTAG); }
 	.						{ /* Shouldn't happen */ yypushback(1); yybegin(INTAG); }
 	<<EOF>>					{ addToken(zzMarkedPos,zzMarkedPos, INTERNAL_INTAG); return firstToken; }
 }
 
 <INTAG> {
-	{JspStart}				{ addToken(Token.MARKUP_TAG_DELIMITER); jspInState = zzLexicalState; yybegin(JAVA_EXPRESSION); }
-	"/"						{ addToken(Token.MARKUP_TAG_DELIMITER); }
-	{InTagIdentifier}			{ addToken(Token.MARKUP_TAG_ATTRIBUTE); }
-	{Whitespace}				{ addToken(Token.WHITESPACE); }
-	"="						{ addToken(Token.OPERATOR); }
-	"/>"						{ yybegin(YYINITIAL); addToken(Token.MARKUP_TAG_DELIMITER); }
-	">"						{ yybegin(YYINITIAL); addToken(Token.MARKUP_TAG_DELIMITER); }
+	{JspStart}				{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); jspInState = zzLexicalState; yybegin(JAVA_EXPRESSION); }
+	"/"						{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); }
+	{InTagIdentifier}			{ addToken(TokenTypes.MARKUP_TAG_ATTRIBUTE); }
+	{Whitespace}				{ addToken(TokenTypes.WHITESPACE); }
+	"="						{ addToken(TokenTypes.OPERATOR); }
+	"/>"						{ yybegin(YYINITIAL); addToken(TokenTypes.MARKUP_TAG_DELIMITER); }
+	">"						{ yybegin(YYINITIAL); addToken(TokenTypes.MARKUP_TAG_DELIMITER); }
 	[\"]						{ start = zzMarkedPos-1; yybegin(INATTR_DOUBLE); }
 	[\']						{ start = zzMarkedPos-1; yybegin(INATTR_SINGLE); }
 	<<EOF>>					{ addToken(zzMarkedPos,zzMarkedPos, INTERNAL_INTAG); return firstToken; }
 }
 
 <INATTR_DOUBLE> {
-	{JspStart}				{ int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addToken(temp, zzMarkedPos-1, Token.MARKUP_TAG_DELIMITER); jspInState = zzLexicalState; yybegin(JAVA_EXPRESSION); }
+	{JspStart}				{ int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addToken(temp, zzMarkedPos-1, TokenTypes.MARKUP_TAG_DELIMITER); jspInState = zzLexicalState; yybegin(JAVA_EXPRESSION); }
 	[^\"<]*					{}
 	"<"						{ /* Allowing JSP expressions, etc. */ }
-	[\"]					{ addToken(start,zzStartRead, Token.MARKUP_TAG_ATTRIBUTE_VALUE); yybegin(INTAG); }
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE); return firstToken; }
+	[\"]					{ addToken(start,zzStartRead, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); yybegin(INTAG); }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE); return firstToken; }
 }
 
 <INATTR_SINGLE> {
-	{JspStart}				{ int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addToken(temp, zzMarkedPos-1, Token.MARKUP_TAG_DELIMITER); jspInState = zzLexicalState; yybegin(JAVA_EXPRESSION); }
+	{JspStart}				{ int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addToken(temp, zzMarkedPos-1, TokenTypes.MARKUP_TAG_DELIMITER); jspInState = zzLexicalState; yybegin(JAVA_EXPRESSION); }
 	[^\'<]*					{}
 	"<"						{ /* Allowing JSP expressions, etc. */ }
-	[\']					{ addToken(start,zzStartRead, Token.MARKUP_TAG_ATTRIBUTE_VALUE); yybegin(INTAG); }
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE); return firstToken; }
+	[\']					{ addToken(start,zzStartRead, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); yybegin(INTAG); }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE); return firstToken; }
 }
 
 <INTAG_SCRIPT> {
-	{JspStart}				{ addToken(Token.MARKUP_TAG_DELIMITER); jspInState = zzLexicalState; yybegin(JAVA_EXPRESSION); }
-	{InTagIdentifier}			{ addToken(Token.MARKUP_TAG_ATTRIBUTE); }
-	"/>"					{	addToken(Token.MARKUP_TAG_DELIMITER); yybegin(YYINITIAL); }
-	"/"						{ addToken(Token.MARKUP_TAG_DELIMITER); } // Won't appear in valid HTML.
-	{Whitespace}+				{ addToken(Token.WHITESPACE); }
-	"="						{ addToken(Token.OPERATOR); }
-	">"						{ addToken(Token.MARKUP_TAG_DELIMITER); yybegin(JAVASCRIPT, LANG_INDEX_JS); }
+	{JspStart}				{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); jspInState = zzLexicalState; yybegin(JAVA_EXPRESSION); }
+	{InTagIdentifier}			{ addToken(TokenTypes.MARKUP_TAG_ATTRIBUTE); }
+	"/>"					{	addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(YYINITIAL); }
+	"/"						{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); } // Won't appear in valid HTML.
+	{Whitespace}+				{ addToken(TokenTypes.WHITESPACE); }
+	"="						{ addToken(TokenTypes.OPERATOR); }
+	">"						{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(JAVASCRIPT, LANG_INDEX_JS); }
 	[\"]						{ start = zzMarkedPos-1; yybegin(INATTR_DOUBLE_SCRIPT); }
 	[\']						{ start = zzMarkedPos-1; yybegin(INATTR_SINGLE_SCRIPT); }
 	<<EOF>>					{ addToken(zzMarkedPos,zzMarkedPos, INTERNAL_INTAG_SCRIPT); return firstToken; }
 }
 
 <INATTR_DOUBLE_SCRIPT> {
-	{JspStart}				{ int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addToken(temp, zzMarkedPos-1, Token.MARKUP_TAG_DELIMITER); jspInState = zzLexicalState; yybegin(JAVA_EXPRESSION); }
+	{JspStart}				{ int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addToken(temp, zzMarkedPos-1, TokenTypes.MARKUP_TAG_DELIMITER); jspInState = zzLexicalState; yybegin(JAVA_EXPRESSION); }
 	[^\"<]*					{}
 	"<"						{ /* Allowing JSP expressions, etc. */ }
-	[\"]					{ yybegin(INTAG_SCRIPT); addToken(start,zzStartRead, Token.MARKUP_TAG_ATTRIBUTE_VALUE); }
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE_QUOTE_SCRIPT); return firstToken; }
+	[\"]					{ yybegin(INTAG_SCRIPT); addToken(start,zzStartRead, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE_QUOTE_SCRIPT); return firstToken; }
 }
 
 <INATTR_SINGLE_SCRIPT> {
-	{JspStart}				{ int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addToken(temp, zzMarkedPos-1, Token.MARKUP_TAG_DELIMITER); jspInState = zzLexicalState; yybegin(JAVA_EXPRESSION); }
+	{JspStart}				{ int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addToken(temp, zzMarkedPos-1, TokenTypes.MARKUP_TAG_DELIMITER); jspInState = zzLexicalState; yybegin(JAVA_EXPRESSION); }
 	[^\'<]*					{}
 	"<"						{ /* Allowing JSP expressions, etc. */ }
-	[\']					{ yybegin(INTAG_SCRIPT); addToken(start,zzStartRead, Token.MARKUP_TAG_ATTRIBUTE_VALUE); }
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE_QUOTE_SCRIPT); return firstToken; }
+	[\']					{ yybegin(INTAG_SCRIPT); addToken(start,zzStartRead, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE_QUOTE_SCRIPT); return firstToken; }
 }
 
 <INTAG_STYLE> {
-	{InTagIdentifier}			{ addToken(Token.MARKUP_TAG_ATTRIBUTE); }
-	"/>"					{	addToken(Token.MARKUP_TAG_DELIMITER); yybegin(YYINITIAL); }
-	"/"						{ addToken(Token.MARKUP_TAG_DELIMITER); } // Won't appear in valid HTML.
-	{Whitespace}				{ addToken(Token.WHITESPACE); }
-	"="						{ addToken(Token.OPERATOR); }
-	">"						{ addToken(Token.MARKUP_TAG_DELIMITER); yybegin(CSS, LANG_INDEX_CSS); }
+	{InTagIdentifier}			{ addToken(TokenTypes.MARKUP_TAG_ATTRIBUTE); }
+	"/>"					{	addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(YYINITIAL); }
+	"/"						{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); } // Won't appear in valid HTML.
+	{Whitespace}				{ addToken(TokenTypes.WHITESPACE); }
+	"="						{ addToken(TokenTypes.OPERATOR); }
+	">"						{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(CSS, LANG_INDEX_CSS); }
 	[\"]						{ start = zzMarkedPos-1; yybegin(INATTR_DOUBLE_STYLE); }
 	[\']						{ start = zzMarkedPos-1; yybegin(INATTR_SINGLE_STYLE); }
 	<<EOF>>					{ addToken(zzMarkedPos,zzMarkedPos, INTERNAL_INTAG_STYLE); return firstToken; }
@@ -1078,23 +1078,23 @@ CSS_Number					= ({CSS_Digits}|{CSS_Hex})
 
 <INATTR_DOUBLE_STYLE> {
 	[^\"]*						{}
-	[\"]						{ yybegin(INTAG_STYLE); addToken(start,zzStartRead, Token.MARKUP_TAG_ATTRIBUTE_VALUE); }
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE_QUOTE_STYLE); return firstToken; }
+	[\"]						{ yybegin(INTAG_STYLE); addToken(start,zzStartRead, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE_QUOTE_STYLE); return firstToken; }
 }
 
 <INATTR_SINGLE_STYLE> {
 	[^\']*						{}
-	[\']						{ yybegin(INTAG_STYLE); addToken(start,zzStartRead, Token.MARKUP_TAG_ATTRIBUTE_VALUE); }
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE_QUOTE_STYLE); return firstToken; }
+	[\']						{ yybegin(INTAG_STYLE); addToken(start,zzStartRead, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE_QUOTE_STYLE); return firstToken; }
 }
 
 <JAVASCRIPT> {
 
 	{EndScriptTag}					{
 								  yybegin(YYINITIAL, LANG_INDEX_DEFAULT);
-								  addToken(zzStartRead,zzStartRead+1, Token.MARKUP_TAG_DELIMITER);
-								  addToken(zzMarkedPos-7,zzMarkedPos-2, Token.MARKUP_TAG_NAME);
-								  addToken(zzMarkedPos-1,zzMarkedPos-1, Token.MARKUP_TAG_DELIMITER);
+								  addToken(zzStartRead,zzStartRead+1, TokenTypes.MARKUP_TAG_DELIMITER);
+								  addToken(zzMarkedPos-7,zzMarkedPos-2, TokenTypes.MARKUP_TAG_NAME);
+								  addToken(zzMarkedPos-1,zzMarkedPos-1, TokenTypes.MARKUP_TAG_DELIMITER);
 								}
 
 	// ECMA 3+ keywords.
@@ -1112,13 +1112,13 @@ CSS_Number					= ({CSS_Digits}|{CSS_Hex})
 	"var" |
 	"void" |
 	"while" |
-	"with"						{ addToken(Token.RESERVED_WORD); }
-	"return"					{ addToken(Token.RESERVED_WORD_2); }
+	"with"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"return"					{ addToken(TokenTypes.RESERVED_WORD_2); }
 
 	//JavaScript 1.6
-	"each" 						{if(JavaScriptTokenMaker.isJavaScriptCompatible("1.6")){ addToken(Token.RESERVED_WORD);} else {addToken(Token.IDENTIFIER);} }
+	"each" 						{if(JavaScriptTokenMaker.isJavaScriptCompatible("1.6")){ addToken(TokenTypes.RESERVED_WORD);} else {addToken(TokenTypes.IDENTIFIER);} }
 	//JavaScript 1.7
-	"let" 						{if(JavaScriptTokenMaker.isJavaScriptCompatible("1.7")){ addToken(Token.RESERVED_WORD);} else {addToken(Token.IDENTIFIER);} }
+	"let" 						{if(JavaScriptTokenMaker.isJavaScriptCompatible("1.7")){ addToken(TokenTypes.RESERVED_WORD);} else {addToken(TokenTypes.IDENTIFIER);} }
 
 	// Reserved (but not yet used) ECMA keywords.
 	"abstract" |
@@ -1153,13 +1153,13 @@ CSS_Number					= ({CSS_Digits}|{CSS_Hex})
 	"transient" |
 	"try" |
 	"volatile" |
-	"null"						{ addToken(Token.RESERVED_WORD); }
-	{PrimitiveTypes}				{ addToken(Token.DATA_TYPE); }
+	"null"						{ addToken(TokenTypes.RESERVED_WORD); }
+	{PrimitiveTypes}				{ addToken(TokenTypes.DATA_TYPE); }
 
 	// Literals.
-	{BooleanLiteral}				{ addToken(Token.LITERAL_BOOLEAN); }
-	"NaN"						{ addToken(Token.RESERVED_WORD); }
-	"Infinity"					{ addToken(Token.RESERVED_WORD); }
+	{BooleanLiteral}				{ addToken(TokenTypes.LITERAL_BOOLEAN); }
+	"NaN"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"Infinity"					{ addToken(TokenTypes.RESERVED_WORD); }
 
 	// Functions.
 	"eval" |
@@ -1168,11 +1168,11 @@ CSS_Number					= ({CSS_Digits}|{CSS_Hex})
 	"escape" |
 	"unescape" |
 	"isNaN" |
-	"isFinite"					{ addToken(Token.FUNCTION); }
+	"isFinite"					{ addToken(TokenTypes.FUNCTION); }
 
 	{LineTerminator}				{ addEndToken(INTERNAL_IN_JS); return firstToken; }
-	{JS_Identifier}				{ addToken(Token.IDENTIFIER); }
-	{Whitespace}+					{ addToken(Token.WHITESPACE); }
+	{JS_Identifier}				{ addToken(TokenTypes.IDENTIFIER); }
+	{Whitespace}+					{ addToken(TokenTypes.WHITESPACE); }
 
 	/* String/Character literals. */
 	[\']							{ start = zzMarkedPos-1; validJSString = true; yybegin(JS_CHAR); }
@@ -1180,7 +1180,7 @@ CSS_Number					= ({CSS_Digits}|{CSS_Hex})
 	[\`]							{ start = zzMarkedPos-1; validJSString = true; yybegin(JS_TEMPLATE_LITERAL); }
 
 	/* Comment literals. */
-	"/**/"						{ addToken(Token.COMMENT_MULTILINE); }
+	"/**/"						{ addToken(TokenTypes.COMMENT_MULTILINE); }
 	{JS_MLCBegin}					{ start = zzMarkedPos-2; yybegin(JS_MLC); }
 	{JS_LineCommentBegin}			{ start = zzMarkedPos-2; yybegin(JS_EOL_COMMENT); }
 
@@ -1188,7 +1188,7 @@ CSS_Number					= ({CSS_Digits}|{CSS_Hex})
 	{JS_Regex}						{
 										boolean highlightedAsRegex = false;
 										if (firstToken==null) {
-											addToken(Token.REGEX);
+											addToken(TokenTypes.REGEX);
 											highlightedAsRegex = true;
 										}
 										else {
@@ -1196,7 +1196,7 @@ CSS_Number					= ({CSS_Digits}|{CSS_Hex})
 											// the previous token, highlight it as such.
 											Token t = firstToken.getLastNonCommentNonWhitespaceToken();
 											if (RSyntaxUtilities.regexCanFollowInJavaScript(t)) {
-												addToken(Token.REGEX);
+												addToken(TokenTypes.REGEX);
 												highlightedAsRegex = true;
 											}
 										}
@@ -1204,40 +1204,40 @@ CSS_Number					= ({CSS_Digits}|{CSS_Hex})
 										// individual tokens.
 										if (!highlightedAsRegex) {
 											int temp = zzStartRead + 1;
-											addToken(zzStartRead, zzStartRead, Token.OPERATOR);
+											addToken(zzStartRead, zzStartRead, TokenTypes.OPERATOR);
 											zzStartRead = zzCurrentPos = zzMarkedPos = temp;
 										}
 									}
 
 	/* Separators. */
-	{JS_Separator}					{ addToken(Token.SEPARATOR); }
-	{JS_Separator2}				{ addToken(Token.IDENTIFIER); }
+	{JS_Separator}					{ addToken(TokenTypes.SEPARATOR); }
+	{JS_Separator2}				{ addToken(TokenTypes.IDENTIFIER); }
 
-	{JspStart}				{ addToken(Token.MARKUP_TAG_DELIMITER); jspInState = zzLexicalState; yybegin(JAVA_EXPRESSION); }
+	{JspStart}				{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); jspInState = zzLexicalState; yybegin(JAVA_EXPRESSION); }
 
 	/* Operators. */
-	{JS_Operator}					{ addToken(Token.OPERATOR); }
+	{JS_Operator}					{ addToken(TokenTypes.OPERATOR); }
 
 	/* Numbers */
-	{JS_IntegerLiteral}				{ addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
-	{JS_HexLiteral}				{ addToken(Token.LITERAL_NUMBER_HEXADECIMAL); }
-	{JS_FloatLiteral}				{ addToken(Token.LITERAL_NUMBER_FLOAT); }
-	{JS_ErrorNumberFormat}			{ addToken(Token.ERROR_NUMBER_FORMAT); }
+	{JS_IntegerLiteral}				{ addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT); }
+	{JS_HexLiteral}				{ addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL); }
+	{JS_FloatLiteral}				{ addToken(TokenTypes.LITERAL_NUMBER_FLOAT); }
+	{JS_ErrorNumberFormat}			{ addToken(TokenTypes.ERROR_NUMBER_FORMAT); }
 
-	{JS_ErrorIdentifier}			{ addToken(Token.ERROR_IDENTIFIER); }
+	{JS_ErrorIdentifier}			{ addToken(TokenTypes.ERROR_IDENTIFIER); }
 
 	/* Ended with a line not in a string or comment. */
 	<<EOF>>						{ addEndToken(INTERNAL_IN_JS); return firstToken; }
 
 	/* Catch any other (unhandled) characters and flag them as bad. */
-	.							{ addToken(Token.ERROR_IDENTIFIER); }
+	.							{ addToken(TokenTypes.ERROR_IDENTIFIER); }
 
 }
 
 
 <JS_STRING> {
 	[^\n\\\"]+				{}
-	\n						{ addToken(start,zzStartRead-1, Token.ERROR_STRING_DOUBLE); addEndToken(INTERNAL_IN_JS); return firstToken; }
+	\n						{ addToken(start,zzStartRead-1, TokenTypes.ERROR_STRING_DOUBLE); addEndToken(INTERNAL_IN_JS); return firstToken; }
 	\\x{HexDigit}{2}		{}
 	\\x						{ /* Invalid latin-1 character \xXX */ validJSString = false; }
 	\\u{HexDigit}{4}		{}
@@ -1245,22 +1245,22 @@ CSS_Number					= ({CSS_Digits}|{CSS_Hex})
 	\\.						{ /* Skip all escaped chars. */ }
 	\\						{ /* Line ending in '\' => continue to next line. */
 								if (validJSString) {
-									addToken(start,zzStartRead, Token.LITERAL_STRING_DOUBLE_QUOTE);
+									addToken(start,zzStartRead, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
 									addEndToken(INTERNAL_IN_JS_STRING_VALID);
 								}
 								else {
-									addToken(start,zzStartRead, Token.ERROR_STRING_DOUBLE);
+									addToken(start,zzStartRead, TokenTypes.ERROR_STRING_DOUBLE);
 									addEndToken(INTERNAL_IN_JS_STRING_INVALID);
 								}
 								return firstToken;
 							}
-	\"						{ int type = validJSString ? Token.LITERAL_STRING_DOUBLE_QUOTE : Token.ERROR_STRING_DOUBLE; addToken(start,zzStartRead, type); yybegin(JAVASCRIPT); }
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.ERROR_STRING_DOUBLE); addEndToken(INTERNAL_IN_JS); return firstToken; }
+	\"						{ int type = validJSString ? TokenTypes.LITERAL_STRING_DOUBLE_QUOTE : TokenTypes.ERROR_STRING_DOUBLE; addToken(start,zzStartRead, type); yybegin(JAVASCRIPT); }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.ERROR_STRING_DOUBLE); addEndToken(INTERNAL_IN_JS); return firstToken; }
 }
 
 <JS_CHAR> {
 	[^\n\\\']+				{}
-	\n						{ addToken(start,zzStartRead-1, Token.ERROR_CHAR); addEndToken(INTERNAL_IN_JS); return firstToken; }
+	\n						{ addToken(start,zzStartRead-1, TokenTypes.ERROR_CHAR); addEndToken(INTERNAL_IN_JS); return firstToken; }
 	\\x{HexDigit}{2}		{}
 	\\x						{ /* Invalid latin-1 character \xXX */ validJSString = false; }
 	\\u{HexDigit}{4}		{}
@@ -1268,17 +1268,17 @@ CSS_Number					= ({CSS_Digits}|{CSS_Hex})
 	\\.						{ /* Skip all escaped chars. */ }
 	\\						{ /* Line ending in '\' => continue to next line. */
 								if (validJSString) {
-									addToken(start,zzStartRead, Token.LITERAL_CHAR);
+									addToken(start,zzStartRead, TokenTypes.LITERAL_CHAR);
 									addEndToken(INTERNAL_IN_JS_CHAR_VALID);
 								}
 								else {
-									addToken(start,zzStartRead, Token.ERROR_CHAR);
+									addToken(start,zzStartRead, TokenTypes.ERROR_CHAR);
 									addEndToken(INTERNAL_IN_JS_CHAR_INVALID);
 								}
 								return firstToken;
 							}
-	\'						{ int type = validJSString ? Token.LITERAL_CHAR : Token.ERROR_CHAR; addToken(start,zzStartRead, type); yybegin(JAVASCRIPT); }
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.ERROR_CHAR); addEndToken(INTERNAL_IN_JS); return firstToken; }
+	\'						{ int type = validJSString ? TokenTypes.LITERAL_CHAR : TokenTypes.ERROR_CHAR; addToken(start,zzStartRead, type); yybegin(JAVASCRIPT); }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.ERROR_CHAR); addEndToken(INTERNAL_IN_JS); return firstToken; }
 }
 
 
@@ -1291,7 +1291,7 @@ CSS_Number					= ({CSS_Digits}|{CSS_Hex})
 	\\.						{ /* Skip all escaped chars. */ }
 
 	{JS_TemplateLiteralExprStart}	{
-								addToken(start, zzStartRead - 1, Token.LITERAL_BACKQUOTE);
+								addToken(start, zzStartRead - 1, TokenTypes.LITERAL_BACKQUOTE);
 								start = zzMarkedPos-2;
 								if (varDepths==null) {
 									varDepths = new Stack<>();
@@ -1304,16 +1304,16 @@ CSS_Number					= ({CSS_Digits}|{CSS_Hex})
 							}
 	"$"						{ /* Skip valid '$' that is not part of template literal expression start */ }
 	
-	\`						{ int type = validJSString ? Token.LITERAL_BACKQUOTE : Token.ERROR_STRING_DOUBLE; addToken(start,zzStartRead, type); yybegin(JAVASCRIPT); }
+	\`						{ int type = validJSString ? TokenTypes.LITERAL_BACKQUOTE : TokenTypes.ERROR_STRING_DOUBLE; addToken(start,zzStartRead, type); yybegin(JAVASCRIPT); }
 
 	/* Line ending in '\' => continue to next line, though not necessary in template strings. */
 	\\						{
 								if (validJSString) {
-									addToken(start,zzStartRead, Token.LITERAL_BACKQUOTE);
+									addToken(start,zzStartRead, TokenTypes.LITERAL_BACKQUOTE);
 									addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_VALID);
 								}
 								else {
-									addToken(start,zzStartRead, Token.ERROR_STRING_DOUBLE);
+									addToken(start,zzStartRead, TokenTypes.ERROR_STRING_DOUBLE);
 									addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_INVALID);
 								}
 								return firstToken;
@@ -1321,11 +1321,11 @@ CSS_Number					= ({CSS_Digits}|{CSS_Hex})
 	\n |
 	<<EOF>>					{
 								if (validJSString) {
-									addToken(start, zzStartRead - 1, Token.LITERAL_BACKQUOTE);
+									addToken(start, zzStartRead - 1, TokenTypes.LITERAL_BACKQUOTE);
 									addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_VALID);
 								}
 								else {
-									addToken(start,zzStartRead - 1, Token.ERROR_STRING_DOUBLE);
+									addToken(start,zzStartRead - 1, TokenTypes.ERROR_STRING_DOUBLE);
 									addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_INVALID);
 								}
 								return firstToken;
@@ -1338,7 +1338,7 @@ CSS_Number					= ({CSS_Digits}|{CSS_Hex})
 							if (!varDepths.empty()) {
 								varDepths.pop();
 								if (varDepths.empty()) {
-									addToken(start,zzStartRead, Token.VARIABLE);
+									addToken(start,zzStartRead, TokenTypes.VARIABLE);
 									start = zzMarkedPos;
 									yybegin(JS_TEMPLATE_LITERAL);
 								}
@@ -1349,46 +1349,46 @@ CSS_Number					= ({CSS_Digits}|{CSS_Hex})
 	\n |
 	<<EOF>>				{
 							// TODO: This isn't right.  The expression and its depth should continue to the next line.
-							addToken(start,zzStartRead-1, Token.VARIABLE); addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_INVALID); return firstToken;
+							addToken(start,zzStartRead-1, TokenTypes.VARIABLE); addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_INVALID); return firstToken;
 						}
 }
 
 <JS_MLC> {
 	// JavaScript MLC's.  This state is essentially Java's MLC state.
 	[^hwf<\n\*]+				{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos; }
 	[hwf]					{}
 	{EndScriptTag}			{
 							  yybegin(YYINITIAL);
 							  int temp = zzStartRead;
-							  addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE);
-							  addToken(temp,temp+1, Token.MARKUP_TAG_DELIMITER);
-							  addToken(zzMarkedPos-7,zzMarkedPos-2, Token.MARKUP_TAG_NAME);
-							  addToken(zzMarkedPos-1,zzMarkedPos-1, Token.MARKUP_TAG_DELIMITER);
+							  addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE);
+							  addToken(temp,temp+1, TokenTypes.MARKUP_TAG_DELIMITER);
+							  addToken(zzMarkedPos-7,zzMarkedPos-2, TokenTypes.MARKUP_TAG_NAME);
+							  addToken(zzMarkedPos-1,zzMarkedPos-1, TokenTypes.MARKUP_TAG_DELIMITER);
 							}
 	"<"						{}
-	\n							{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_JS_MLC); return firstToken; }
-	{JS_MLCEnd}					{ yybegin(JAVASCRIPT); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE); }
+	\n							{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_JS_MLC); return firstToken; }
+	{JS_MLCEnd}					{ yybegin(JAVASCRIPT); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE); }
 	\*							{}
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_JS_MLC); return firstToken; }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_JS_MLC); return firstToken; }
 }
 
 
 <JS_EOL_COMMENT> {
 	[^hwf<\n]+				{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos; }
 	[hwf]					{}
 	{EndScriptTag}			{
 							  int temp = zzStartRead;
-							  addToken(start,zzStartRead-1, Token.COMMENT_EOL);
+							  addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL);
 							  yybegin(YYINITIAL, LANG_INDEX_DEFAULT);
-							  addToken(temp,temp+1, Token.MARKUP_TAG_DELIMITER);
-							  addToken(zzMarkedPos-7,zzMarkedPos-2, Token.MARKUP_TAG_NAME);
-							  addToken(zzMarkedPos-1,zzMarkedPos-1, Token.MARKUP_TAG_DELIMITER);
+							  addToken(temp,temp+1, TokenTypes.MARKUP_TAG_DELIMITER);
+							  addToken(zzMarkedPos-7,zzMarkedPos-2, TokenTypes.MARKUP_TAG_NAME);
+							  addToken(zzMarkedPos-1,zzMarkedPos-1, TokenTypes.MARKUP_TAG_DELIMITER);
 							}
 	"<"						{}
-	\n						{ addToken(start,zzStartRead-1, Token.COMMENT_EOL); addEndToken(INTERNAL_IN_JS); return firstToken; }
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_EOL); addEndToken(INTERNAL_IN_JS); return firstToken; }
+	\n						{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addEndToken(INTERNAL_IN_JS); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addEndToken(INTERNAL_IN_JS); return firstToken; }
 
 }
 
@@ -1396,24 +1396,24 @@ CSS_Number					= ({CSS_Digits}|{CSS_Hex})
 <CSS> {
 	{EndStyleTag}		{
 						  yybegin(YYINITIAL, LANG_INDEX_DEFAULT);
-						  addToken(zzStartRead,zzStartRead+1, Token.MARKUP_TAG_DELIMITER);
-						  addToken(zzMarkedPos-6,zzMarkedPos-2, Token.MARKUP_TAG_NAME);
-						  addToken(zzMarkedPos-1,zzMarkedPos-1, Token.MARKUP_TAG_DELIMITER);
+						  addToken(zzStartRead,zzStartRead+1, TokenTypes.MARKUP_TAG_DELIMITER);
+						  addToken(zzMarkedPos-6,zzMarkedPos-2, TokenTypes.MARKUP_TAG_NAME);
+						  addToken(zzMarkedPos-1,zzMarkedPos-1, TokenTypes.MARKUP_TAG_DELIMITER);
 						}
-	{CSS_SelectorPiece}	{ addToken(Token.DATA_TYPE); }
-	{CSS_PseudoClass}	{ addToken(Token.RESERVED_WORD); }
-	":"					{ /* Unknown pseudo class */ addToken(Token.DATA_TYPE); }
-	{CSS_AtKeyword}		{ addToken(Token.REGEX); }
-	{CSS_Id}			{ addToken(Token.VARIABLE); }
-	"{"					{ addToken(Token.SEPARATOR); yybegin(CSS_PROPERTY); }
-	[,]					{ addToken(Token.IDENTIFIER); }
+	{CSS_SelectorPiece}	{ addToken(TokenTypes.DATA_TYPE); }
+	{CSS_PseudoClass}	{ addToken(TokenTypes.RESERVED_WORD); }
+	":"					{ /* Unknown pseudo class */ addToken(TokenTypes.DATA_TYPE); }
+	{CSS_AtKeyword}		{ addToken(TokenTypes.REGEX); }
+	{CSS_Id}			{ addToken(TokenTypes.VARIABLE); }
+	"{"					{ addToken(TokenTypes.SEPARATOR); yybegin(CSS_PROPERTY); }
+	[,]					{ addToken(TokenTypes.IDENTIFIER); }
 	\"					{ start = zzMarkedPos-1; cssPrevState = zzLexicalState; yybegin(CSS_STRING); }
 	\'					{ start = zzMarkedPos-1; cssPrevState = zzLexicalState; yybegin(CSS_CHAR_LITERAL); }
-	[+>~\^$\|=]			{ addToken(Token.OPERATOR); }
-	{CSS_Separator}		{ addToken(Token.SEPARATOR); }
-	{Whitespace}		{ addToken(Token.WHITESPACE); }
+	[+>~\^$\|=]			{ addToken(TokenTypes.OPERATOR); }
+	{CSS_Separator}		{ addToken(TokenTypes.SEPARATOR); }
+	{Whitespace}		{ addToken(TokenTypes.WHITESPACE); }
 	{CSS_MlcStart}		{ start = zzMarkedPos-2; cssPrevState = zzLexicalState; yybegin(CSS_C_STYLE_COMMENT); }
-	.					{ /*System.out.println("CSS: " + yytext());*/ addToken(Token.IDENTIFIER); }
+	.					{ /*System.out.println("CSS: " + yytext());*/ addToken(TokenTypes.IDENTIFIER); }
 	"\n" |
 	<<EOF>>				{ addEndToken(INTERNAL_CSS); return firstToken; }
 }
@@ -1421,17 +1421,17 @@ CSS_Number					= ({CSS_Digits}|{CSS_Hex})
 <CSS_PROPERTY> {
 	{EndStyleTag}		{
 						  yybegin(YYINITIAL, LANG_INDEX_DEFAULT);
-						  addToken(zzStartRead,zzStartRead+1, Token.MARKUP_TAG_DELIMITER);
-						  addToken(zzMarkedPos-6,zzMarkedPos-2, Token.MARKUP_TAG_NAME);
-						  addToken(zzMarkedPos-1,zzMarkedPos-1, Token.MARKUP_TAG_DELIMITER);
+						  addToken(zzStartRead,zzStartRead+1, TokenTypes.MARKUP_TAG_DELIMITER);
+						  addToken(zzMarkedPos-6,zzMarkedPos-2, TokenTypes.MARKUP_TAG_NAME);
+						  addToken(zzMarkedPos-1,zzMarkedPos-1, TokenTypes.MARKUP_TAG_DELIMITER);
 						}
-	{CSS_Property}		{ addToken(Token.RESERVED_WORD); }
-	"{"					{ addToken(Token.SEPARATOR); /* helps with auto-closing curlies when editing CSS */ }
-	"}"					{ addToken(Token.SEPARATOR); yybegin(CSS); }
-	":"					{ addToken(Token.OPERATOR); yybegin(CSS_VALUE); }
-	{Whitespace}		{ addToken(Token.WHITESPACE); }
+	{CSS_Property}		{ addToken(TokenTypes.RESERVED_WORD); }
+	"{"					{ addToken(TokenTypes.SEPARATOR); /* helps with auto-closing curlies when editing CSS */ }
+	"}"					{ addToken(TokenTypes.SEPARATOR); yybegin(CSS); }
+	":"					{ addToken(TokenTypes.OPERATOR); yybegin(CSS_VALUE); }
+	{Whitespace}		{ addToken(TokenTypes.WHITESPACE); }
 	{CSS_MlcStart}		{ start = zzMarkedPos-2; cssPrevState = zzLexicalState; yybegin(CSS_C_STYLE_COMMENT); }
-	.					{ /*System.out.println("css_property: " + yytext());*/ addToken(Token.IDENTIFIER); }
+	.					{ /*System.out.println("css_property: " + yytext());*/ addToken(TokenTypes.IDENTIFIER); }
 	"\n" |
 	<<EOF>>				{ addEndToken(INTERNAL_CSS_PROPERTY); return firstToken; }
 }
@@ -1439,27 +1439,27 @@ CSS_Number					= ({CSS_Digits}|{CSS_Hex})
 <CSS_VALUE> {
 	{EndStyleTag}		{
 						  yybegin(YYINITIAL, LANG_INDEX_DEFAULT);
-						  addToken(zzStartRead,zzStartRead+1, Token.MARKUP_TAG_DELIMITER);
-						  addToken(zzMarkedPos-6,zzMarkedPos-2, Token.MARKUP_TAG_NAME);
-						  addToken(zzMarkedPos-1,zzMarkedPos-1, Token.MARKUP_TAG_DELIMITER);
+						  addToken(zzStartRead,zzStartRead+1, TokenTypes.MARKUP_TAG_DELIMITER);
+						  addToken(zzMarkedPos-6,zzMarkedPos-2, TokenTypes.MARKUP_TAG_NAME);
+						  addToken(zzMarkedPos-1,zzMarkedPos-1, TokenTypes.MARKUP_TAG_DELIMITER);
 						}
-	{CSS_Value}			{ addToken(Token.IDENTIFIER); }
-	"!important"		{ addToken(Token.PREPROCESSOR); }
+	{CSS_Value}			{ addToken(TokenTypes.IDENTIFIER); }
+	"!important"		{ addToken(TokenTypes.PREPROCESSOR); }
 	{CSS_Function}		{ int temp = zzMarkedPos - 2;
-						  addToken(zzStartRead, temp, Token.FUNCTION);
-						  addToken(zzMarkedPos-1, zzMarkedPos-1, Token.SEPARATOR);
+						  addToken(zzStartRead, temp, TokenTypes.FUNCTION);
+						  addToken(zzMarkedPos-1, zzMarkedPos-1, TokenTypes.SEPARATOR);
 						  zzStartRead = zzCurrentPos = zzMarkedPos;
 						}
-	{CSS_Number}		{ addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
+	{CSS_Number}		{ addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT); }
 	\"					{ start = zzMarkedPos-1; cssPrevState = zzLexicalState; yybegin(CSS_STRING); }
 	\'					{ start = zzMarkedPos-1; cssPrevState = zzLexicalState; yybegin(CSS_CHAR_LITERAL); }
-	")"					{ /* End of a function */ addToken(Token.SEPARATOR); }
-	[;]					{ addToken(Token.OPERATOR); yybegin(CSS_PROPERTY); }
-	[,\.]				{ addToken(Token.IDENTIFIER); }
-	"}"					{ addToken(Token.SEPARATOR); yybegin(CSS); }
-	{Whitespace}		{ addToken(Token.WHITESPACE); }
+	")"					{ /* End of a function */ addToken(TokenTypes.SEPARATOR); }
+	[;]					{ addToken(TokenTypes.OPERATOR); yybegin(CSS_PROPERTY); }
+	[,\.]				{ addToken(TokenTypes.IDENTIFIER); }
+	"}"					{ addToken(TokenTypes.SEPARATOR); yybegin(CSS); }
+	{Whitespace}		{ addToken(TokenTypes.WHITESPACE); }
 	{CSS_MlcStart}		{ start = zzMarkedPos-2; cssPrevState = zzLexicalState; yybegin(CSS_C_STYLE_COMMENT); }
-	.					{ /*System.out.println("css_value: " + yytext());*/ addToken(Token.IDENTIFIER); }
+	.					{ /*System.out.println("css_value: " + yytext());*/ addToken(TokenTypes.IDENTIFIER); }
 	"\n" |
 	<<EOF>>				{ addEndToken(INTERNAL_CSS_VALUE); return firstToken; }
 }
@@ -1467,33 +1467,33 @@ CSS_Number					= ({CSS_Digits}|{CSS_Hex})
 <CSS_STRING> {
 	[^\n\\\"]+			{}
 	\\.?				{ /* Skip escaped chars. */ }
-	\"					{ addToken(start,zzStartRead, Token.LITERAL_STRING_DOUBLE_QUOTE); yybegin(cssPrevState); }
+	\"					{ addToken(start,zzStartRead, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); yybegin(cssPrevState); }
 	\n |
-	<<EOF>>				{ addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); addEndToken(INTERNAL_CSS_STRING - cssPrevState); return firstToken; }
+	<<EOF>>				{ addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); addEndToken(INTERNAL_CSS_STRING - cssPrevState); return firstToken; }
 }
 
 <CSS_CHAR_LITERAL> {
 	[^\n\\\']+			{}
 	\\.?				{ /* Skip escaped chars. */ }
-	\'					{ addToken(start,zzStartRead, Token.LITERAL_CHAR); yybegin(cssPrevState); }
+	\'					{ addToken(start,zzStartRead, TokenTypes.LITERAL_CHAR); yybegin(cssPrevState); }
 	\n |
-	<<EOF>>				{ addToken(start,zzStartRead-1, Token.LITERAL_CHAR); addEndToken(INTERNAL_CSS_CHAR - cssPrevState); return firstToken; }
+	<<EOF>>				{ addToken(start,zzStartRead-1, TokenTypes.LITERAL_CHAR); addEndToken(INTERNAL_CSS_CHAR - cssPrevState); return firstToken; }
 }
 
 <CSS_C_STYLE_COMMENT> {
 	[^hwf\n\*]+			{}
-	{URL}				{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos; }
+	{URL}				{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos; }
 	[hwf]				{}
-	{CSS_MlcEnd}		{ addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE); yybegin(cssPrevState); }
+	{CSS_MlcEnd}		{ addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE); yybegin(cssPrevState); }
 	\*					{}
 	\n |
-	<<EOF>>				{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addEndToken(INTERNAL_CSS_MLC - cssPrevState); return firstToken; }
+	<<EOF>>				{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addEndToken(INTERNAL_CSS_MLC - cssPrevState); return firstToken; }
 }
 
 
 <JAVA_EXPRESSION> {
 
-	"%>"							{ addToken(Token.MARKUP_TAG_DELIMITER); start = zzMarkedPos; yybegin(jspInState); }
+	"%>"							{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); start = zzMarkedPos; yybegin(jspInState); }
 
 	/* Keywords */
 	"abstract"|
@@ -1537,14 +1537,14 @@ CSS_Number					= ({CSS_Digits}|{CSS_Hex})
 	"try"	 |
 	"void"	 |
 	"volatile" |
-	"while"					{ addToken(Token.RESERVED_WORD); }
-	"return"				{ addToken(Token.RESERVED_WORD_2); }
+	"while"					{ addToken(TokenTypes.RESERVED_WORD); }
+	"return"				{ addToken(TokenTypes.RESERVED_WORD_2); }
 
 	/* Data types. */
-	{PrimitiveTypes}			{ addToken(Token.DATA_TYPE); }
+	{PrimitiveTypes}			{ addToken(TokenTypes.DATA_TYPE); }
 
 	/* Booleans. */
-	{BooleanLiteral}			{ addToken(Token.LITERAL_BOOLEAN); }
+	{BooleanLiteral}			{ addToken(TokenTypes.LITERAL_BOOLEAN); }
 
 	/* java.lang classes */
 	"Appendable" |
@@ -1869,64 +1869,64 @@ CSS_Number					= ({CSS_Digits}|{CSS_Hex})
     "UnknownFormatConversionException" |
     "UnknownFormatFlagsException" |
 
-    "ServiceConfigurationError" 		{ addToken(Token.FUNCTION); }
+    "ServiceConfigurationError" 		{ addToken(TokenTypes.FUNCTION); }
 
 	{LineTerminator}				{ addEndToken(INTERNAL_IN_JAVA_EXPRESSION - jspInState); return firstToken; }
 
-	{JIdentifier}					{ addToken(Token.IDENTIFIER); }
+	{JIdentifier}					{ addToken(TokenTypes.IDENTIFIER); }
 
-	{WhiteSpace}+					{ addToken(Token.WHITESPACE); }
+	{WhiteSpace}+					{ addToken(TokenTypes.WHITESPACE); }
 
 	/* String/Character literals. */
-	{JCharLiteral}					{ addToken(Token.LITERAL_CHAR); }
-	{JUnclosedCharLiteral}			{ addToken(Token.ERROR_CHAR); addEndToken(INTERNAL_IN_JAVA_EXPRESSION - jspInState); return firstToken; }
-	{JErrorCharLiteral}				{ addToken(Token.ERROR_CHAR); }
-	{JStringLiteral}				{ addToken(Token.LITERAL_STRING_DOUBLE_QUOTE); }
-	{JUnclosedStringLiteral}			{ addToken(Token.ERROR_STRING_DOUBLE); addEndToken(INTERNAL_IN_JAVA_EXPRESSION - jspInState); return firstToken; }
-	{JErrorStringLiteral}			{ addToken(Token.ERROR_STRING_DOUBLE); }
+	{JCharLiteral}					{ addToken(TokenTypes.LITERAL_CHAR); }
+	{JUnclosedCharLiteral}			{ addToken(TokenTypes.ERROR_CHAR); addEndToken(INTERNAL_IN_JAVA_EXPRESSION - jspInState); return firstToken; }
+	{JErrorCharLiteral}				{ addToken(TokenTypes.ERROR_CHAR); }
+	{JStringLiteral}				{ addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); }
+	{JUnclosedStringLiteral}			{ addToken(TokenTypes.ERROR_STRING_DOUBLE); addEndToken(INTERNAL_IN_JAVA_EXPRESSION - jspInState); return firstToken; }
+	{JErrorStringLiteral}			{ addToken(TokenTypes.ERROR_STRING_DOUBLE); }
 
 	/* Comment literals. */
-	"/**/"						{ addToken(Token.COMMENT_MULTILINE); }
+	"/**/"						{ addToken(TokenTypes.COMMENT_MULTILINE); }
 	{MLCBegin}					{ start = zzMarkedPos-2; yybegin(JAVA_MLC); }
 	{DocCommentBegin}				{ start = zzMarkedPos-3; yybegin(JAVA_DOCCOMMENT); }
-	{LineCommentBegin}.*			{ addToken(Token.COMMENT_EOL); addEndToken(INTERNAL_IN_JAVA_EXPRESSION - jspInState); return firstToken; }
+	{LineCommentBegin}.*			{ addToken(TokenTypes.COMMENT_EOL); addEndToken(INTERNAL_IN_JAVA_EXPRESSION - jspInState); return firstToken; }
 
 	/* Annotations. */
-	{Annotation}					{ addToken(Token.ANNOTATION); }
+	{Annotation}					{ addToken(TokenTypes.ANNOTATION); }
 
 	/* Separators. */
-	{Separator}					{ addToken(Token.SEPARATOR); }
-	{Separator2}					{ addToken(Token.IDENTIFIER); }
+	{Separator}					{ addToken(TokenTypes.SEPARATOR); }
+	{Separator2}					{ addToken(TokenTypes.IDENTIFIER); }
 
 	/* Operators. */
-	{Operator}					{ addToken(Token.OPERATOR); }
+	{Operator}					{ addToken(TokenTypes.OPERATOR); }
 
 	/* Numbers */
-	{IntegerLiteral}				{ addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
-	{BinaryLiteral}					{ addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
-	{HexLiteral}					{ addToken(Token.LITERAL_NUMBER_HEXADECIMAL); }
-	{FloatLiteral}					{ addToken(Token.LITERAL_NUMBER_FLOAT); }
-	{ErrorNumberFormat}				{ addToken(Token.ERROR_NUMBER_FORMAT); }
+	{IntegerLiteral}				{ addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT); }
+	{BinaryLiteral}					{ addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT); }
+	{HexLiteral}					{ addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL); }
+	{FloatLiteral}					{ addToken(TokenTypes.LITERAL_NUMBER_FLOAT); }
+	{ErrorNumberFormat}				{ addToken(TokenTypes.ERROR_NUMBER_FORMAT); }
 
-	{ErrorIdentifier}				{ addToken(Token.ERROR_IDENTIFIER); }
+	{ErrorIdentifier}				{ addToken(TokenTypes.ERROR_IDENTIFIER); }
 
 	/* Ended with a line not in a string or comment. */
 	<<EOF>>						{ addEndToken(INTERNAL_IN_JAVA_EXPRESSION - jspInState); return firstToken; }
 
 	/* Catch any other (unhandled) characters and flag them as bad. */
-	.							{ addToken(Token.ERROR_IDENTIFIER); }
+	.							{ addToken(TokenTypes.ERROR_IDENTIFIER); }
 
 }
 
 
 <JAVA_MLC> {
 	[^hwf\n\*]+				{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos; }
 	[hwf]					{}
-	{MLCEnd}					{ yybegin(JAVA_EXPRESSION); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE); }
+	{MLCEnd}					{ yybegin(JAVA_EXPRESSION); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE); }
 	\*						{}
 	\n |
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_JAVA_MLC - jspInState); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_JAVA_MLC - jspInState); return firstToken; }
 }
 
 
@@ -1936,9 +1936,9 @@ CSS_Number					= ({CSS_Digits}|{CSS_Hex})
 	{URL}						{
                                     int temp=zzStartRead;
                                     if (start <= zzStartRead - 1) {
-                                        addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION);
+                                        addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION);
                                     }
-                                    addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_DOCUMENTATION);
+                                    addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_DOCUMENTATION);
                                     start = zzMarkedPos;
                                 }
 	[hwf]						{}
@@ -1946,26 +1946,26 @@ CSS_Number					= ({CSS_Digits}|{CSS_Hex})
 	"@"{BlockTag}				{
                                     int temp=zzStartRead;
                                     if (start <= zzStartRead - 1) {
-                                        addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION);
+                                        addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION);
                                     }
-                                    addToken(temp,zzMarkedPos-1, Token.COMMENT_KEYWORD);
+                                    addToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_KEYWORD);
                                     start = zzMarkedPos; }
 	"@"							{}
 	"{@"{InlineTag}[^\}]*"}"	{
                                     int temp=zzStartRead;
                                     if (start <= zzStartRead - 1) {
-                                        addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION);
+                                        addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION);
                                     }
-                                    addToken(temp,zzMarkedPos-1, Token.COMMENT_KEYWORD);
+                                    addToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_KEYWORD);
                                     start = zzMarkedPos;
                                 }
 	"{"							{}
-	\n							{ addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addEndToken(INTERNAL_IN_JAVA_DOCCOMMENT - jspInState); return firstToken; }
-	"<"[/]?({Letter}[^\>]*)?">"	{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, Token.COMMENT_MARKUP); start = zzMarkedPos; }
+	\n							{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addEndToken(INTERNAL_IN_JAVA_DOCCOMMENT - jspInState); return firstToken; }
+	"<"[/]?({Letter}[^\>]*)?">"	{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MARKUP); start = zzMarkedPos; }
 	\<							{}
-	{MLCEnd}					{ yybegin(JAVA_EXPRESSION); addToken(start,zzStartRead+1, Token.COMMENT_DOCUMENTATION); }
+	{MLCEnd}					{ yybegin(JAVA_EXPRESSION); addToken(start,zzStartRead+1, TokenTypes.COMMENT_DOCUMENTATION); }
 	\*							{}
-	<<EOF>>						{ yybegin(JAVA_EXPRESSION); addToken(start,zzEndRead, Token.COMMENT_DOCUMENTATION); addEndToken(INTERNAL_IN_JAVA_DOCCOMMENT - jspInState); return firstToken; }
+	<<EOF>>						{ yybegin(JAVA_EXPRESSION); addToken(start,zzEndRead, TokenTypes.COMMENT_DOCUMENTATION); addEndToken(INTERNAL_IN_JAVA_DOCCOMMENT - jspInState); return firstToken; }
 
 }
 
@@ -1973,18 +1973,18 @@ CSS_Number					= ({CSS_Digits}|{CSS_Hex})
 <JSP_DIRECTIVE> {
 	"include" |
 	"page" |
-	"taglib"					{ addToken(Token.RESERVED_WORD); }
-	"/"						{ addToken(Token.RESERVED_WORD); }
-	{InTagIdentifier}			{ addToken(Token.IDENTIFIER); }
-	{Whitespace}+				{ addToken(Token.WHITESPACE); }
-	"="						{ addToken(Token.OPERATOR); }
-	"%>"						{ yybegin(YYINITIAL); addToken(Token.MARKUP_TAG_DELIMITER); }
-	"%"						{ addToken(Token.IDENTIFIER); }
-	">"						{ addToken(Token.IDENTIFIER); /* Needed as InTagIdentifier ignores it. */ }
-	{UnclosedStringLiteral}		{ addToken(Token.ERROR_STRING_DOUBLE); }
-	{StringLiteral}			{ addToken(Token.LITERAL_STRING_DOUBLE_QUOTE); }
-	{UnclosedCharLiteral}		{ addToken(Token.ERROR_CHAR); }
-	{CharLiteral}				{ addToken(Token.LITERAL_CHAR); }
+	"taglib"					{ addToken(TokenTypes.RESERVED_WORD); }
+	"/"						{ addToken(TokenTypes.RESERVED_WORD); }
+	{InTagIdentifier}			{ addToken(TokenTypes.IDENTIFIER); }
+	{Whitespace}+				{ addToken(TokenTypes.WHITESPACE); }
+	"="						{ addToken(TokenTypes.OPERATOR); }
+	"%>"						{ yybegin(YYINITIAL); addToken(TokenTypes.MARKUP_TAG_DELIMITER); }
+	"%"						{ addToken(TokenTypes.IDENTIFIER); }
+	">"						{ addToken(TokenTypes.IDENTIFIER); /* Needed as InTagIdentifier ignores it. */ }
+	{UnclosedStringLiteral}		{ addToken(TokenTypes.ERROR_STRING_DOUBLE); }
+	{StringLiteral}			{ addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); }
+	{UnclosedCharLiteral}		{ addToken(TokenTypes.ERROR_CHAR); }
+	{CharLiteral}				{ addToken(TokenTypes.LITERAL_CHAR); }
 	<<EOF>>					{ addToken(zzMarkedPos,zzMarkedPos, INTERNAL_IN_JSP_DIRECTIVE); return firstToken; }
 }
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/JSPTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/JSPTokenMaker.java
@@ -6873,8 +6873,8 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
 
 	@Override
 	public boolean getMarkOccurrencesOfTokenType(int type) {
-		return type==Token.FUNCTION || type==Token.VARIABLE ||
-				type==Token.MARKUP_TAG_NAME;
+		return type==TokenTypes.FUNCTION || type==TokenTypes.VARIABLE ||
+				type==TokenTypes.MARKUP_TAG_NAME;
 	}
 
 
@@ -6919,13 +6919,13 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
 		// Start off in the proper state.
 		int state;
 		switch (initialTokenType) {
-			case Token.MARKUP_COMMENT:
+			case TokenTypes.MARKUP_COMMENT:
 				state = COMMENT;
 				break;
-			case Token.PREPROCESSOR:
+			case TokenTypes.PREPROCESSOR:
 				state = PI;
 				break;
-			case Token.VARIABLE:
+			case TokenTypes.VARIABLE:
 				state = DTD;
 				break;
 			case INTERNAL_INTAG:
@@ -7048,7 +7048,7 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
 					}
 				}
 				else {
-					state = Token.NULL;
+					state = TokenTypes.NULL;
 				}
 				break;
 		}
@@ -7354,15 +7354,15 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
 
       switch (zzAction < 0 ? zzAction : ZZ_ACTION[zzAction]) {
         case 66:
-          { addToken(Token.OPERATOR); yybegin(CSS_VALUE);
+          { addToken(TokenTypes.OPERATOR); yybegin(CSS_VALUE);
           }
         case 142: break;
         case 94:
-          { addToken(Token.ERROR_NUMBER_FORMAT);
+          { addToken(TokenTypes.ERROR_NUMBER_FORMAT);
           }
         case 143: break;
         case 76:
-          { addToken(start,zzStartRead-1, Token.LITERAL_CHAR); addEndToken(INTERNAL_CSS_CHAR - cssPrevState); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.LITERAL_CHAR); addEndToken(INTERNAL_CSS_CHAR - cssPrevState); return firstToken;
           }
         case 144: break;
         case 23:
@@ -7370,11 +7370,11 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 145: break;
         case 10:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead, Token.MARKUP_DTD);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.MARKUP_DTD);
           }
         case 146: break;
         case 62:
-          { addToken(Token.SEPARATOR); yybegin(CSS_PROPERTY);
+          { addToken(TokenTypes.SEPARATOR); yybegin(CSS_PROPERTY);
           }
         case 147: break;
         case 122:
@@ -7382,15 +7382,15 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 148: break;
         case 4:
-          { addToken(Token.MARKUP_TAG_DELIMITER); yybegin(INTAG);
+          { addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(INTAG);
           }
         case 149: break;
         case 135:
-          { addToken(Token.RESERVED_WORD_2);
+          { addToken(TokenTypes.RESERVED_WORD_2);
           }
         case 150: break;
         case 112:
-          { addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE); yybegin(cssPrevState);
+          { addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE); yybegin(cssPrevState);
           }
         case 151: break;
         case 109:
@@ -7398,41 +7398,41 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 152: break;
         case 5:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 153: break;
         case 115:
           { int count = yylength();
-									addToken(zzStartRead,zzStartRead+1, Token.MARKUP_TAG_DELIMITER);
+									addToken(zzStartRead,zzStartRead+1, TokenTypes.MARKUP_TAG_DELIMITER);
 									zzMarkedPos -= (count-2); //yypushback(count-2);
 									yybegin(INTAG_CHECK_TAG_NAME);
           }
         case 154: break;
         case 111:
-          { addToken(Token.REGEX);
+          { addToken(TokenTypes.REGEX);
           }
         case 155: break;
         case 43:
-          { addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_JS_MLC); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_JS_MLC); return firstToken;
           }
         case 156: break;
         case 137:
           { yybegin(YYINITIAL, LANG_INDEX_DEFAULT);
-						  addToken(zzStartRead,zzStartRead+1, Token.MARKUP_TAG_DELIMITER);
-						  addToken(zzMarkedPos-6,zzMarkedPos-2, Token.MARKUP_TAG_NAME);
-						  addToken(zzMarkedPos-1,zzMarkedPos-1, Token.MARKUP_TAG_DELIMITER);
+						  addToken(zzStartRead,zzStartRead+1, TokenTypes.MARKUP_TAG_DELIMITER);
+						  addToken(zzMarkedPos-6,zzMarkedPos-2, TokenTypes.MARKUP_TAG_NAME);
+						  addToken(zzMarkedPos-1,zzMarkedPos-1, TokenTypes.MARKUP_TAG_DELIMITER);
           }
         case 157: break;
         case 121:
-          { addToken(Token.FUNCTION);
+          { addToken(TokenTypes.FUNCTION);
           }
         case 158: break;
         case 101:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, Token.COMMENT_MARKUP); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MARKUP); start = zzMarkedPos;
           }
         case 159: break;
         case 8:
-          { addToken(start,zzStartRead-1, Token.MARKUP_PROCESSING_INSTRUCTION); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.MARKUP_PROCESSING_INSTRUCTION); return firstToken;
           }
         case 160: break;
         case 124:
@@ -7445,7 +7445,7 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 161: break;
         case 37:
-          { addToken(start,zzStartRead-1, Token.ERROR_STRING_DOUBLE); addEndToken(INTERNAL_IN_JS); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.ERROR_STRING_DOUBLE); addEndToken(INTERNAL_IN_JS); return firstToken;
           }
         case 162: break;
         case 58:
@@ -7456,7 +7456,7 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
           { if (!varDepths.empty()) {
 								varDepths.pop();
 								if (varDepths.empty()) {
-									addToken(start,zzStartRead, Token.VARIABLE);
+									addToken(start,zzStartRead, TokenTypes.VARIABLE);
 									start = zzMarkedPos;
 									yybegin(JS_TEMPLATE_LITERAL);
 								}
@@ -7464,7 +7464,7 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 164: break;
         case 53:
-          { addToken(Token.ERROR_CHAR);
+          { addToken(TokenTypes.ERROR_CHAR);
           }
         case 165: break;
         case 81:
@@ -7485,13 +7485,13 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
         case 169: break;
         case 85:
           { int count = yylength();
-									addToken(zzStartRead,zzStartRead, Token.MARKUP_TAG_DELIMITER);
+									addToken(zzStartRead,zzStartRead, TokenTypes.MARKUP_TAG_DELIMITER);
 									zzMarkedPos -= (count-1); //yypushback(count-1);
 									yybegin(INTAG_CHECK_TAG_NAME);
           }
         case 170: break;
         case 130:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead+3, Token.MARKUP_COMMENT);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead+3, TokenTypes.MARKUP_COMMENT);
           }
         case 171: break;
         case 97:
@@ -7499,23 +7499,23 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 172: break;
         case 91:
-          { addToken(Token.MARKUP_TAG_DELIMITER); yybegin(YYINITIAL);
+          { addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(YYINITIAL);
           }
         case 173: break;
         case 29:
-          { yybegin(INTAG_STYLE); addToken(start,zzStartRead, Token.MARKUP_TAG_ATTRIBUTE_VALUE);
+          { yybegin(INTAG_STYLE); addToken(start,zzStartRead, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE);
           }
         case 174: break;
         case 127:
-          { if(JavaScriptTokenMaker.isJavaScriptCompatible("1.6")){ addToken(Token.RESERVED_WORD);} else {addToken(Token.IDENTIFIER);}
+          { if(JavaScriptTokenMaker.isJavaScriptCompatible("1.6")){ addToken(TokenTypes.RESERVED_WORD);} else {addToken(TokenTypes.IDENTIFIER);}
           }
         case 175: break;
         case 119:
-          { if(JavaScriptTokenMaker.isJavaScriptCompatible("1.7")){ addToken(Token.RESERVED_WORD);} else {addToken(Token.IDENTIFIER);}
+          { if(JavaScriptTokenMaker.isJavaScriptCompatible("1.7")){ addToken(TokenTypes.RESERVED_WORD);} else {addToken(TokenTypes.IDENTIFIER);}
           }
         case 176: break;
         case 68:
-          { /*System.out.println("css_value: " + yytext());*/ addToken(Token.IDENTIFIER);
+          { /*System.out.println("css_value: " + yytext());*/ addToken(TokenTypes.IDENTIFIER);
           }
         case 177: break;
         case 17:
@@ -7523,11 +7523,11 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 178: break;
         case 28:
-          { addToken(Token.MARKUP_TAG_DELIMITER); yybegin(CSS, LANG_INDEX_CSS);
+          { addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(CSS, LANG_INDEX_CSS);
           }
         case 179: break;
         case 113:
-          { addToken(start, zzStartRead - 1, Token.LITERAL_BACKQUOTE);
+          { addToken(start, zzStartRead - 1, TokenTypes.LITERAL_BACKQUOTE);
 								start = zzMarkedPos-2;
 								if (varDepths==null) {
 									varDepths = new Stack<>();
@@ -7540,7 +7540,7 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 180: break;
         case 77:
-          { addToken(start,zzStartRead, Token.LITERAL_CHAR); yybegin(cssPrevState);
+          { addToken(start,zzStartRead, TokenTypes.LITERAL_CHAR); yybegin(cssPrevState);
           }
         case 181: break;
         case 114:
@@ -7552,20 +7552,20 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 183: break;
         case 55:
-          { addToken(Token.IDENTIFIER); /* Needed as InTagIdentifier ignores it. */
+          { addToken(TokenTypes.IDENTIFIER); /* Needed as InTagIdentifier ignores it. */
           }
         case 184: break;
         case 139:
           { yybegin(YYINITIAL);
 							  int temp = zzStartRead;
-							  addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE);
-							  addToken(temp,temp+1, Token.MARKUP_TAG_DELIMITER);
-							  addToken(zzMarkedPos-7,zzMarkedPos-2, Token.MARKUP_TAG_NAME);
-							  addToken(zzMarkedPos-1,zzMarkedPos-1, Token.MARKUP_TAG_DELIMITER);
+							  addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE);
+							  addToken(temp,temp+1, TokenTypes.MARKUP_TAG_DELIMITER);
+							  addToken(zzMarkedPos-7,zzMarkedPos-2, TokenTypes.MARKUP_TAG_NAME);
+							  addToken(zzMarkedPos-1,zzMarkedPos-1, TokenTypes.MARKUP_TAG_DELIMITER);
           }
         case 185: break;
         case 7:
-          { addToken(start,zzStartRead-1, Token.MARKUP_COMMENT); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.MARKUP_COMMENT); return firstToken;
           }
         case 186: break;
         case 99:
@@ -7573,33 +7573,33 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 187: break;
         case 25:
-          { yybegin(INTAG_SCRIPT); addToken(start,zzStartRead, Token.MARKUP_TAG_ATTRIBUTE_VALUE);
+          { yybegin(INTAG_SCRIPT); addToken(start,zzStartRead, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE);
           }
         case 188: break;
         case 38:
-          { int type = validJSString ? Token.LITERAL_STRING_DOUBLE_QUOTE : Token.ERROR_STRING_DOUBLE; addToken(start,zzStartRead, type); yybegin(JAVASCRIPT);
+          { int type = validJSString ? TokenTypes.LITERAL_STRING_DOUBLE_QUOTE : TokenTypes.ERROR_STRING_DOUBLE; addToken(start,zzStartRead, type); yybegin(JAVASCRIPT);
           }
         case 189: break;
         case 125:
-          { addToken(Token.COMMENT_MULTILINE);
+          { addToken(TokenTypes.COMMENT_MULTILINE);
           }
         case 190: break;
         case 48:
-          { addToken(Token.ERROR_STRING_DOUBLE); addEndToken(INTERNAL_IN_JAVA_EXPRESSION - jspInState); return firstToken;
+          { addToken(TokenTypes.ERROR_STRING_DOUBLE); addEndToken(INTERNAL_IN_JAVA_EXPRESSION - jspInState); return firstToken;
           }
         case 191: break;
         case 134:
-          { addToken(zzStartRead,zzStartRead, Token.MARKUP_TAG_DELIMITER);
-								  addToken(zzMarkedPos-5,zzMarkedPos-1, Token.MARKUP_TAG_NAME);
+          { addToken(zzStartRead,zzStartRead, TokenTypes.MARKUP_TAG_DELIMITER);
+								  addToken(zzMarkedPos-5,zzMarkedPos-1, TokenTypes.MARKUP_TAG_NAME);
 								  start = zzMarkedPos; cssPrevState = zzLexicalState; yybegin(INTAG_STYLE);
           }
         case 192: break;
         case 133:
           { int temp=zzStartRead;
                                     if (start <= zzStartRead - 1) {
-                                        addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION);
+                                        addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION);
                                     }
-                                    addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_DOCUMENTATION);
+                                    addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_DOCUMENTATION);
                                     start = zzMarkedPos;
           }
         case 193: break;
@@ -7613,32 +7613,32 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
         case 195: break;
         case 140:
           { int temp = zzStartRead;
-							  addToken(start,zzStartRead-1, Token.COMMENT_EOL);
+							  addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL);
 							  yybegin(YYINITIAL, LANG_INDEX_DEFAULT);
-							  addToken(temp,temp+1, Token.MARKUP_TAG_DELIMITER);
-							  addToken(zzMarkedPos-7,zzMarkedPos-2, Token.MARKUP_TAG_NAME);
-							  addToken(zzMarkedPos-1,zzMarkedPos-1, Token.MARKUP_TAG_DELIMITER);
+							  addToken(temp,temp+1, TokenTypes.MARKUP_TAG_DELIMITER);
+							  addToken(zzMarkedPos-7,zzMarkedPos-2, TokenTypes.MARKUP_TAG_NAME);
+							  addToken(zzMarkedPos-1,zzMarkedPos-1, TokenTypes.MARKUP_TAG_DELIMITER);
           }
         case 196: break;
         case 72:
           { int temp = zzMarkedPos - 2;
-						  addToken(zzStartRead, temp, Token.FUNCTION);
-						  addToken(zzMarkedPos-1, zzMarkedPos-1, Token.SEPARATOR);
+						  addToken(zzStartRead, temp, TokenTypes.FUNCTION);
+						  addToken(zzMarkedPos-1, zzMarkedPos-1, TokenTypes.SEPARATOR);
 						  zzStartRead = zzCurrentPos = zzMarkedPos;
           }
         case 197: break;
         case 63:
-          { /*System.out.println("css_property: " + yytext());*/ addToken(Token.IDENTIFIER);
+          { /*System.out.println("css_property: " + yytext());*/ addToken(TokenTypes.IDENTIFIER);
           }
         case 198: break;
         case 9:
-          { addToken(start,zzStartRead-1, Token.MARKUP_DTD); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.MARKUP_DTD); return firstToken;
           }
         case 199: break;
         case 118:
           { boolean highlightedAsRegex = false;
 										if (firstToken==null) {
-											addToken(Token.REGEX);
+											addToken(TokenTypes.REGEX);
 											highlightedAsRegex = true;
 										}
 										else {
@@ -7646,7 +7646,7 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
 											// the previous token, highlight it as such.
 											Token t = firstToken.getLastNonCommentNonWhitespaceToken();
 											if (RSyntaxUtilities.regexCanFollowInJavaScript(t)) {
-												addToken(Token.REGEX);
+												addToken(TokenTypes.REGEX);
 												highlightedAsRegex = true;
 											}
 										}
@@ -7654,13 +7654,13 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
 										// individual tokens.
 										if (!highlightedAsRegex) {
 											int temp = zzStartRead + 1;
-											addToken(zzStartRead, zzStartRead, Token.OPERATOR);
+											addToken(zzStartRead, zzStartRead, TokenTypes.OPERATOR);
 											zzStartRead = zzCurrentPos = zzMarkedPos = temp;
 										}
           }
         case 200: break;
         case 141:
-          { addToken(Token.PREPROCESSOR);
+          { addToken(TokenTypes.PREPROCESSOR);
           }
         case 201: break;
         case 75:
@@ -7673,30 +7673,30 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
         case 203: break;
         case 83:
           { // TODO: This isn't right.  The expression and its depth should continue to the next line.
-							addToken(start,zzStartRead-1, Token.VARIABLE); addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_INVALID); return firstToken;
+							addToken(start,zzStartRead-1, TokenTypes.VARIABLE); addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_INVALID); return firstToken;
           }
         case 204: break;
         case 102:
-          { yybegin(JAVA_EXPRESSION); addToken(start,zzStartRead+1, Token.COMMENT_DOCUMENTATION);
+          { yybegin(JAVA_EXPRESSION); addToken(start,zzStartRead+1, TokenTypes.COMMENT_DOCUMENTATION);
           }
         case 205: break;
         case 138:
           { yybegin(YYINITIAL, LANG_INDEX_DEFAULT);
-								  addToken(zzStartRead,zzStartRead+1, Token.MARKUP_TAG_DELIMITER);
-								  addToken(zzMarkedPos-7,zzMarkedPos-2, Token.MARKUP_TAG_NAME);
-								  addToken(zzMarkedPos-1,zzMarkedPos-1, Token.MARKUP_TAG_DELIMITER);
+								  addToken(zzStartRead,zzStartRead+1, TokenTypes.MARKUP_TAG_DELIMITER);
+								  addToken(zzMarkedPos-7,zzMarkedPos-2, TokenTypes.MARKUP_TAG_NAME);
+								  addToken(zzMarkedPos-1,zzMarkedPos-1, TokenTypes.MARKUP_TAG_DELIMITER);
           }
         case 206: break;
         case 89:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.MARKUP_PROCESSING_INSTRUCTION);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.MARKUP_PROCESSING_INSTRUCTION);
           }
         case 207: break;
         case 100:
-          { yybegin(JAVASCRIPT); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE);
+          { yybegin(JAVASCRIPT); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE);
           }
         case 208: break;
         case 86:
-          { addToken(Token.MARKUP_TAG_DELIMITER); jspInState = zzLexicalState; yybegin(JAVA_EXPRESSION);
+          { addToken(TokenTypes.MARKUP_TAG_DELIMITER); jspInState = zzLexicalState; yybegin(JAVA_EXPRESSION);
           }
         case 209: break;
         case 31:
@@ -7704,27 +7704,27 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 210: break;
         case 67:
-          { addToken(Token.SEPARATOR); /* helps with auto-closing curlies when editing CSS */
+          { addToken(TokenTypes.SEPARATOR); /* helps with auto-closing curlies when editing CSS */
           }
         case 211: break;
         case 40:
-          { addToken(start,zzStartRead-1, Token.ERROR_CHAR); addEndToken(INTERNAL_IN_JS); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.ERROR_CHAR); addEndToken(INTERNAL_IN_JS); return firstToken;
           }
         case 212: break;
         case 45:
-          { addToken(start,zzStartRead-1, Token.MARKUP_COMMENT); addEndToken(INTERNAL_IN_HIDDEN_COMMENT); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.MARKUP_COMMENT); addEndToken(INTERNAL_IN_HIDDEN_COMMENT); return firstToken;
           }
         case 213: break;
         case 12:
-          { addToken(Token.OPERATOR);
+          { addToken(TokenTypes.OPERATOR);
           }
         case 214: break;
         case 70:
-          { addToken(Token.OPERATOR); yybegin(CSS_PROPERTY);
+          { addToken(TokenTypes.OPERATOR); yybegin(CSS_PROPERTY);
           }
         case 215: break;
         case 49:
-          { addToken(Token.ERROR_CHAR); addEndToken(INTERNAL_IN_JAVA_EXPRESSION - jspInState); return firstToken;
+          { addToken(TokenTypes.ERROR_CHAR); addEndToken(INTERNAL_IN_JAVA_EXPRESSION - jspInState); return firstToken;
           }
         case 216: break;
         case 123:
@@ -7732,15 +7732,15 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 217: break;
         case 117:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead+2, Token.MARKUP_COMMENT);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead+2, TokenTypes.MARKUP_COMMENT);
           }
         case 218: break;
         case 110:
-          { addToken(Token.VARIABLE);
+          { addToken(TokenTypes.VARIABLE);
           }
         case 219: break;
         case 56:
-          { /*System.out.println("CSS: " + yytext());*/ addToken(Token.IDENTIFIER);
+          { /*System.out.println("CSS: " + yytext());*/ addToken(TokenTypes.IDENTIFIER);
           }
         case 220: break;
         case 105:
@@ -7748,31 +7748,31 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 221: break;
         case 82:
-          { int type = validJSString ? Token.LITERAL_BACKQUOTE : Token.ERROR_STRING_DOUBLE; addToken(start,zzStartRead, type); yybegin(JAVASCRIPT);
+          { int type = validJSString ? TokenTypes.LITERAL_BACKQUOTE : TokenTypes.ERROR_STRING_DOUBLE; addToken(start,zzStartRead, type); yybegin(JAVASCRIPT);
           }
         case 222: break;
         case 2:
-          { addToken(Token.IDENTIFIER);
+          { addToken(TokenTypes.IDENTIFIER);
           }
         case 223: break;
         case 128:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos;
           }
         case 224: break;
         case 24:
-          { addToken(Token.MARKUP_TAG_DELIMITER); yybegin(JAVASCRIPT, LANG_INDEX_JS);
+          { addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(JAVASCRIPT, LANG_INDEX_JS);
           }
         case 225: break;
         case 104:
-          { addToken(Token.COMMENT_EOL); addEndToken(INTERNAL_IN_JAVA_EXPRESSION - jspInState); return firstToken;
+          { addToken(TokenTypes.COMMENT_EOL); addEndToken(INTERNAL_IN_JAVA_EXPRESSION - jspInState); return firstToken;
           }
         case 226: break;
         case 129:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos;
           }
         case 227: break;
         case 65:
-          { addToken(Token.SEPARATOR); yybegin(CSS);
+          { addToken(TokenTypes.SEPARATOR); yybegin(CSS);
           }
         case 228: break;
         case 32:
@@ -7780,11 +7780,11 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 229: break;
         case 46:
-          { addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addEndToken(INTERNAL_IN_JAVA_DOCCOMMENT - jspInState); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addEndToken(INTERNAL_IN_JAVA_DOCCOMMENT - jspInState); return firstToken;
           }
         case 230: break;
         case 74:
-          { addToken(start,zzStartRead, Token.LITERAL_STRING_DOUBLE_QUOTE); yybegin(cssPrevState);
+          { addToken(start,zzStartRead, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); yybegin(cssPrevState);
           }
         case 231: break;
         case 64:
@@ -7792,15 +7792,15 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 232: break;
         case 52:
-          { addToken(Token.ERROR_STRING_DOUBLE);
+          { addToken(TokenTypes.ERROR_STRING_DOUBLE);
           }
         case 233: break;
         case 41:
-          { int type = validJSString ? Token.LITERAL_CHAR : Token.ERROR_CHAR; addToken(start,zzStartRead, type); yybegin(JAVASCRIPT);
+          { int type = validJSString ? TokenTypes.LITERAL_CHAR : TokenTypes.ERROR_CHAR; addToken(start,zzStartRead, type); yybegin(JAVASCRIPT);
           }
         case 234: break;
         case 116:
-          { addToken(Token.MARKUP_TAG_DELIMITER); yybegin(JSP_DIRECTIVE);
+          { addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(JSP_DIRECTIVE);
           }
         case 235: break;
         case 33:
@@ -7812,23 +7812,23 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 237: break;
         case 96:
-          { addToken(Token.LITERAL_NUMBER_HEXADECIMAL);
+          { addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL);
           }
         case 238: break;
         case 107:
-          { yybegin(JAVA_EXPRESSION); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE);
+          { yybegin(JAVA_EXPRESSION); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE);
           }
         case 239: break;
         case 51:
-          { addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_JAVA_MLC - jspInState); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_JAVA_MLC - jspInState); return firstToken;
           }
         case 240: break;
         case 50:
-          { addToken(Token.ANNOTATION);
+          { addToken(TokenTypes.ANNOTATION);
           }
         case 241: break;
         case 30:
-          { addToken(Token.ERROR_IDENTIFIER);
+          { addToken(TokenTypes.ERROR_IDENTIFIER);
           }
         case 242: break;
         case 69:
@@ -7836,15 +7836,15 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 243: break;
         case 131:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.MARKUP_COMMENT); addHyperlinkToken(temp,zzMarkedPos-1, Token.MARKUP_COMMENT); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.MARKUP_COMMENT); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.MARKUP_COMMENT); start = zzMarkedPos;
           }
         case 244: break;
         case 6:
-          { addToken(Token.MARKUP_ENTITY_REFERENCE);
+          { addToken(TokenTypes.MARKUP_ENTITY_REFERENCE);
           }
         case 245: break;
         case 126:
-          { addToken(Token.LITERAL_BOOLEAN);
+          { addToken(TokenTypes.LITERAL_BOOLEAN);
           }
         case 246: break;
         case 18:
@@ -7864,21 +7864,21 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 250: break;
         case 54:
-          { addToken(Token.RESERVED_WORD);
+          { addToken(TokenTypes.RESERVED_WORD);
           }
         case 251: break;
         case 106:
-          { addToken(Token.MARKUP_TAG_DELIMITER); start = zzMarkedPos; yybegin(jspInState);
+          { addToken(TokenTypes.MARKUP_TAG_DELIMITER); start = zzMarkedPos; yybegin(jspInState);
           }
         case 252: break;
         case 39:
           { /* Line ending in '\' => continue to next line. */
 								if (validJSString) {
-									addToken(start,zzStartRead, Token.LITERAL_STRING_DOUBLE_QUOTE);
+									addToken(start,zzStartRead, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
 									addEndToken(INTERNAL_IN_JS_STRING_VALID);
 								}
 								else {
-									addToken(start,zzStartRead, Token.ERROR_STRING_DOUBLE);
+									addToken(start,zzStartRead, TokenTypes.ERROR_STRING_DOUBLE);
 									addEndToken(INTERNAL_IN_JS_STRING_INVALID);
 								}
 								return firstToken;
@@ -7889,15 +7889,15 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 254: break;
         case 108:
-          { addToken(Token.LITERAL_CHAR);
+          { addToken(TokenTypes.LITERAL_CHAR);
           }
         case 255: break;
         case 16:
-          { yybegin(YYINITIAL); addToken(Token.MARKUP_TAG_DELIMITER);
+          { yybegin(YYINITIAL); addToken(TokenTypes.MARKUP_TAG_DELIMITER);
           }
         case 256: break;
         case 60:
-          { addToken(Token.DATA_TYPE);
+          { addToken(TokenTypes.DATA_TYPE);
           }
         case 257: break;
         case 47:
@@ -7905,45 +7905,45 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 258: break;
         case 35:
-          { addToken(Token.SEPARATOR);
+          { addToken(TokenTypes.SEPARATOR);
           }
         case 259: break;
         case 80:
           { if (validJSString) {
-									addToken(start,zzStartRead, Token.LITERAL_BACKQUOTE);
+									addToken(start,zzStartRead, TokenTypes.LITERAL_BACKQUOTE);
 									addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_VALID);
 								}
 								else {
-									addToken(start,zzStartRead, Token.ERROR_STRING_DOUBLE);
+									addToken(start,zzStartRead, TokenTypes.ERROR_STRING_DOUBLE);
 									addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_INVALID);
 								}
 								return firstToken;
           }
         case 260: break;
         case 73:
-          { addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); addEndToken(INTERNAL_CSS_STRING - cssPrevState); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); addEndToken(INTERNAL_CSS_STRING - cssPrevState); return firstToken;
           }
         case 261: break;
         case 71:
-          { /* End of a function */ addToken(Token.SEPARATOR);
+          { /* End of a function */ addToken(TokenTypes.SEPARATOR);
           }
         case 262: break;
         case 19:
-          { addToken(Token.MARKUP_TAG_NAME);
+          { addToken(TokenTypes.MARKUP_TAG_NAME);
           }
         case 263: break;
         case 11:
-          { addToken(Token.MARKUP_TAG_ATTRIBUTE);
+          { addToken(TokenTypes.MARKUP_TAG_ATTRIBUTE);
           }
         case 264: break;
         case 42:
           { /* Line ending in '\' => continue to next line. */
 								if (validJSString) {
-									addToken(start,zzStartRead, Token.LITERAL_CHAR);
+									addToken(start,zzStartRead, TokenTypes.LITERAL_CHAR);
 									addEndToken(INTERNAL_IN_JS_CHAR_VALID);
 								}
 								else {
-									addToken(start,zzStartRead, Token.ERROR_CHAR);
+									addToken(start,zzStartRead, TokenTypes.ERROR_CHAR);
 									addEndToken(INTERNAL_IN_JS_CHAR_INVALID);
 								}
 								return firstToken;
@@ -7954,7 +7954,7 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 266: break;
         case 95:
-          { addToken(Token.LITERAL_NUMBER_FLOAT);
+          { addToken(TokenTypes.LITERAL_NUMBER_FLOAT);
           }
         case 267: break;
         case 14:
@@ -7964,26 +7964,26 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
         case 132:
           { int temp=zzStartRead;
                                     if (start <= zzStartRead - 1) {
-                                        addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION);
+                                        addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION);
                                     }
-                                    addToken(temp,zzMarkedPos-1, Token.COMMENT_KEYWORD);
+                                    addToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_KEYWORD);
                                     start = zzMarkedPos;
           }
         case 269: break;
         case 103:
-          { addToken(Token.LITERAL_STRING_DOUBLE_QUOTE);
+          { addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
           }
         case 270: break;
         case 78:
-          { addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addEndToken(INTERNAL_CSS_MLC - cssPrevState); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addEndToken(INTERNAL_CSS_MLC - cssPrevState); return firstToken;
           }
         case 271: break;
         case 15:
-          { addToken(Token.MARKUP_TAG_DELIMITER);
+          { addToken(TokenTypes.MARKUP_TAG_DELIMITER);
           }
         case 272: break;
         case 34:
-          { addToken(Token.LITERAL_NUMBER_DECIMAL_INT);
+          { addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT);
           }
         case 273: break;
         case 87:
@@ -7992,22 +7992,22 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
         case 274: break;
         case 79:
           { if (validJSString) {
-									addToken(start, zzStartRead - 1, Token.LITERAL_BACKQUOTE);
+									addToken(start, zzStartRead - 1, TokenTypes.LITERAL_BACKQUOTE);
 									addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_VALID);
 								}
 								else {
-									addToken(start,zzStartRead - 1, Token.ERROR_STRING_DOUBLE);
+									addToken(start,zzStartRead - 1, TokenTypes.ERROR_STRING_DOUBLE);
 									addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_INVALID);
 								}
 								return firstToken;
           }
         case 275: break;
         case 90:
-          { int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addToken(temp, zzMarkedPos-1, Token.MARKUP_TAG_DELIMITER); jspInState = zzLexicalState; yybegin(JAVA_EXPRESSION);
+          { int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addToken(temp, zzMarkedPos-1, TokenTypes.MARKUP_TAG_DELIMITER); jspInState = zzLexicalState; yybegin(JAVA_EXPRESSION);
           }
         case 276: break;
         case 21:
-          { addToken(start,zzStartRead, Token.MARKUP_TAG_ATTRIBUTE_VALUE); yybegin(INTAG);
+          { addToken(start,zzStartRead, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); yybegin(INTAG);
           }
         case 277: break;
         case 22:
@@ -8015,16 +8015,16 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 278: break;
         case 44:
-          { addToken(start,zzStartRead-1, Token.COMMENT_EOL); addEndToken(INTERNAL_IN_JS); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addEndToken(INTERNAL_IN_JS); return firstToken;
           }
         case 279: break;
         case 61:
-          { /* Unknown pseudo class */ addToken(Token.DATA_TYPE);
+          { /* Unknown pseudo class */ addToken(TokenTypes.DATA_TYPE);
           }
         case 280: break;
         case 136:
-          { addToken(zzStartRead,zzStartRead, Token.MARKUP_TAG_DELIMITER);
-								  addToken(zzMarkedPos-6,zzMarkedPos-1, Token.MARKUP_TAG_NAME);
+          { addToken(zzStartRead,zzStartRead, TokenTypes.MARKUP_TAG_DELIMITER);
+								  addToken(zzMarkedPos-6,zzMarkedPos-1, TokenTypes.MARKUP_TAG_NAME);
 								  start = zzMarkedPos; yybegin(INTAG_SCRIPT);
           }
         case 281: break;
@@ -8037,11 +8037,11 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
             zzAtEOF = true;
             switch (zzLexicalState) {
             case INATTR_SINGLE_SCRIPT: {
-              addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE_QUOTE_SCRIPT); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE_QUOTE_SCRIPT); return firstToken;
             }
             case 2749: break;
             case JS_CHAR: {
-              addToken(start,zzStartRead-1, Token.ERROR_CHAR); addEndToken(INTERNAL_IN_JS); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.ERROR_CHAR); addEndToken(INTERNAL_IN_JS); return firstToken;
             }
             case 2750: break;
             case JAVA_EXPRESSION: {
@@ -8049,23 +8049,23 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
             }
             case 2751: break;
             case CSS_STRING: {
-              addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); addEndToken(INTERNAL_CSS_STRING - cssPrevState); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); addEndToken(INTERNAL_CSS_STRING - cssPrevState); return firstToken;
             }
             case 2752: break;
             case HIDDEN_COMMENT: {
-              addToken(start,zzStartRead-1, Token.MARKUP_COMMENT); addEndToken(INTERNAL_IN_HIDDEN_COMMENT); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_COMMENT); addEndToken(INTERNAL_IN_HIDDEN_COMMENT); return firstToken;
             }
             case 2753: break;
             case JS_MLC: {
-              addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_JS_MLC); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_JS_MLC); return firstToken;
             }
             case 2754: break;
             case CSS_CHAR_LITERAL: {
-              addToken(start,zzStartRead-1, Token.LITERAL_CHAR); addEndToken(INTERNAL_CSS_CHAR - cssPrevState); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.LITERAL_CHAR); addEndToken(INTERNAL_CSS_CHAR - cssPrevState); return firstToken;
             }
             case 2755: break;
             case JAVA_DOCCOMMENT: {
-              yybegin(JAVA_EXPRESSION); addToken(start,zzEndRead, Token.COMMENT_DOCUMENTATION); addEndToken(INTERNAL_IN_JAVA_DOCCOMMENT - jspInState); return firstToken;
+              yybegin(JAVA_EXPRESSION); addToken(start,zzEndRead, TokenTypes.COMMENT_DOCUMENTATION); addEndToken(INTERNAL_IN_JAVA_DOCCOMMENT - jspInState); return firstToken;
             }
             case 2756: break;
             case INTAG_SCRIPT: {
@@ -8074,7 +8074,7 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
             case 2757: break;
             case JS_TEMPLATE_LITERAL_EXPR: {
               // TODO: This isn't right.  The expression and its depth should continue to the next line.
-							addToken(start,zzStartRead-1, Token.VARIABLE); addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_INVALID); return firstToken;
+							addToken(start,zzStartRead-1, TokenTypes.VARIABLE); addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_INVALID); return firstToken;
             }
             case 2758: break;
             case CSS_PROPERTY: {
@@ -8082,7 +8082,7 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
             }
             case 2759: break;
             case CSS_C_STYLE_COMMENT: {
-              addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addEndToken(INTERNAL_CSS_MLC - cssPrevState); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addEndToken(INTERNAL_CSS_MLC - cssPrevState); return firstToken;
             }
             case 2760: break;
             case CSS: {
@@ -8098,15 +8098,15 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
             }
             case 2763: break;
             case COMMENT: {
-              addToken(start,zzStartRead-1, Token.MARKUP_COMMENT); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_COMMENT); return firstToken;
             }
             case 2764: break;
             case INATTR_DOUBLE_SCRIPT: {
-              addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE_QUOTE_SCRIPT); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE_QUOTE_SCRIPT); return firstToken;
             }
             case 2765: break;
             case PI: {
-              addToken(start,zzStartRead-1, Token.MARKUP_PROCESSING_INSTRUCTION); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_PROCESSING_INSTRUCTION); return firstToken;
             }
             case 2766: break;
             case JAVASCRIPT: {
@@ -8122,32 +8122,32 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
             }
             case 2769: break;
             case INATTR_SINGLE_STYLE: {
-              addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE_QUOTE_STYLE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE_QUOTE_STYLE); return firstToken;
             }
             case 2770: break;
             case DTD: {
-              addToken(start,zzStartRead-1, Token.MARKUP_DTD); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_DTD); return firstToken;
             }
             case 2771: break;
             case JS_EOL_COMMENT: {
-              addToken(start,zzStartRead-1, Token.COMMENT_EOL); addEndToken(INTERNAL_IN_JS); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addEndToken(INTERNAL_IN_JS); return firstToken;
             }
             case 2772: break;
             case INATTR_DOUBLE_STYLE: {
-              addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE_QUOTE_STYLE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE_QUOTE_STYLE); return firstToken;
             }
             case 2773: break;
             case INATTR_SINGLE: {
-              addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE); return firstToken;
             }
             case 2774: break;
             case JS_TEMPLATE_LITERAL: {
               if (validJSString) {
-									addToken(start, zzStartRead - 1, Token.LITERAL_BACKQUOTE);
+									addToken(start, zzStartRead - 1, TokenTypes.LITERAL_BACKQUOTE);
 									addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_VALID);
 								}
 								else {
-									addToken(start,zzStartRead - 1, Token.ERROR_STRING_DOUBLE);
+									addToken(start,zzStartRead - 1, TokenTypes.ERROR_STRING_DOUBLE);
 									addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_INVALID);
 								}
 								return firstToken;
@@ -8158,15 +8158,15 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
             }
             case 2776: break;
             case INATTR_DOUBLE: {
-              addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE); return firstToken;
             }
             case 2777: break;
             case JS_STRING: {
-              addToken(start,zzStartRead-1, Token.ERROR_STRING_DOUBLE); addEndToken(INTERNAL_IN_JS); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.ERROR_STRING_DOUBLE); addEndToken(INTERNAL_IN_JS); return firstToken;
             }
             case 2778: break;
             case JAVA_MLC: {
-              addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_JAVA_MLC - jspInState); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_JAVA_MLC - jspInState); return firstToken;
             }
             case 2779: break;
             case INTAG_STYLE: {

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/JavaScriptTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/JavaScriptTokenMaker.flex
@@ -618,47 +618,47 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"void" |
 	"while" |
 	"with" |
-    "yield"                     { addToken(Token.RESERVED_WORD); }
-	"return"					{ addToken(Token.RESERVED_WORD_2); }
+    "yield"                     { addToken(TokenTypes.RESERVED_WORD); }
+	"return"					{ addToken(TokenTypes.RESERVED_WORD_2); }
 	
 	//e4X
-	"each" 						{if(e4xSupported){ addToken(Token.RESERVED_WORD);} else {addToken(Token.IDENTIFIER);} }
+	"each" 						{if(e4xSupported){ addToken(TokenTypes.RESERVED_WORD);} else {addToken(TokenTypes.IDENTIFIER);} }
 	//JavaScript 1.7
-	"let" 						{if(isJavaScriptCompatible("1.7")){ addToken(Token.RESERVED_WORD);} else {addToken(Token.IDENTIFIER);} }
+	"let" 						{if(isJavaScriptCompatible("1.7")){ addToken(TokenTypes.RESERVED_WORD);} else {addToken(TokenTypes.IDENTIFIER);} }
 	// e4x miscellaneous
-	{JS_E4xAttribute}			{ addToken(isE4xSupported() ? Token.MARKUP_TAG_ATTRIBUTE : Token.ERROR_IDENTIFIER); }
+	{JS_E4xAttribute}			{ addToken(isE4xSupported() ? TokenTypes.MARKUP_TAG_ATTRIBUTE : TokenTypes.ERROR_IDENTIFIER); }
 	
 	// Reserved (but not yet used) ECMA keywords.
-	"abstract"					{ addToken(Token.RESERVED_WORD); }
-	"boolean"						{ addToken(Token.DATA_TYPE); }
-	"byte"						{ addToken(Token.DATA_TYPE); }
-	"char"						{ addToken(Token.DATA_TYPE); }
-	"default"						{ addToken(Token.RESERVED_WORD); }
-	"double"						{ addToken(Token.DATA_TYPE); }
-	"enum"						{ addToken(Token.RESERVED_WORD); }
-	"final"						{ addToken(Token.RESERVED_WORD); }
-	"float"						{ addToken(Token.DATA_TYPE); }
-	"goto"						{ addToken(Token.RESERVED_WORD); }
-	"implements"					{ addToken(Token.RESERVED_WORD); }
-	"int"						{ addToken(Token.DATA_TYPE); }
-	"interface"					{ addToken(Token.RESERVED_WORD); }
-	"long"						{ addToken(Token.DATA_TYPE); }
-	"native"						{ addToken(Token.RESERVED_WORD); }
-	"package"						{ addToken(Token.RESERVED_WORD); }
-	"private"						{ addToken(Token.RESERVED_WORD); }
-	"protected"					{ addToken(Token.RESERVED_WORD); }
-	"public"						{ addToken(Token.RESERVED_WORD); }
-	"short"						{ addToken(Token.DATA_TYPE); }
-	"synchronized"					{ addToken(Token.RESERVED_WORD); }
-	"throws"						{ addToken(Token.RESERVED_WORD); }
-	"transient"					{ addToken(Token.RESERVED_WORD); }
-	"volatile"					{ addToken(Token.RESERVED_WORD); }
+	"abstract"					{ addToken(TokenTypes.RESERVED_WORD); }
+	"boolean"						{ addToken(TokenTypes.DATA_TYPE); }
+	"byte"						{ addToken(TokenTypes.DATA_TYPE); }
+	"char"						{ addToken(TokenTypes.DATA_TYPE); }
+	"default"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"double"						{ addToken(TokenTypes.DATA_TYPE); }
+	"enum"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"final"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"float"						{ addToken(TokenTypes.DATA_TYPE); }
+	"goto"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"implements"					{ addToken(TokenTypes.RESERVED_WORD); }
+	"int"						{ addToken(TokenTypes.DATA_TYPE); }
+	"interface"					{ addToken(TokenTypes.RESERVED_WORD); }
+	"long"						{ addToken(TokenTypes.DATA_TYPE); }
+	"native"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"package"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"private"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"protected"					{ addToken(TokenTypes.RESERVED_WORD); }
+	"public"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"short"						{ addToken(TokenTypes.DATA_TYPE); }
+	"synchronized"					{ addToken(TokenTypes.RESERVED_WORD); }
+	"throws"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"transient"					{ addToken(TokenTypes.RESERVED_WORD); }
+	"volatile"					{ addToken(TokenTypes.RESERVED_WORD); }
 
 	// Literals.
 	"false" |
-	"true"						{ addToken(Token.LITERAL_BOOLEAN); }
-	"NaN"						{ addToken(Token.RESERVED_WORD); }
-	"Infinity"					{ addToken(Token.RESERVED_WORD); }
+	"true"						{ addToken(TokenTypes.LITERAL_BOOLEAN); }
+	"NaN"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"Infinity"					{ addToken(TokenTypes.RESERVED_WORD); }
 
 	// Functions.
 	"eval" |
@@ -667,11 +667,11 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"escape" |
 	"unescape" |
 	"isNaN" |
-	"isFinite"						{ addToken(Token.FUNCTION); }
+	"isFinite"						{ addToken(TokenTypes.FUNCTION); }
 
 	{LineTerminator}				{ addNullToken(); return firstToken; }
-	{JS_Identifier}					{ addToken(Token.IDENTIFIER); }
-	{Whitespace}					{ addToken(Token.WHITESPACE); }
+	{JS_Identifier}					{ addToken(TokenTypes.IDENTIFIER); }
+	{Whitespace}					{ addToken(TokenTypes.WHITESPACE); }
 
 	/* String/Character literals. */
 	[\']							{ start = zzMarkedPos-1; validJSString = true; yybegin(JS_CHAR); }
@@ -679,7 +679,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	[\`]							{ start = zzMarkedPos-1; validJSString = true; yybegin(JS_TEMPLATE_LITERAL); }
 
 	/* Comment literals. */
-	"/**/"							{ addToken(Token.COMMENT_MULTILINE); }
+	"/**/"							{ addToken(TokenTypes.COMMENT_MULTILINE); }
 	{JS_MLCBegin}					{ start = zzMarkedPos-2; yybegin(JS_MLC); }
 	{JS_DocCommentBegin}			{ start = zzMarkedPos-3; yybegin(JS_DOCCOMMENT); }
 	{JS_LineCommentBegin}			{ start = zzMarkedPos-2; yybegin(JS_EOL_COMMENT); }
@@ -688,7 +688,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	{JS_Regex}						{
 										boolean highlightedAsRegex = false;
 										if (firstToken==null) {
-											addToken(Token.REGEX);
+											addToken(TokenTypes.REGEX);
 											highlightedAsRegex = true;
 										}
 										else {
@@ -696,7 +696,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 											// the previous token, highlight it as such.
 											Token t = firstToken.getLastNonCommentNonWhitespaceToken();
 											if (RSyntaxUtilities.regexCanFollowInJavaScript(t)) {
-												addToken(Token.REGEX);
+												addToken(TokenTypes.REGEX);
 												highlightedAsRegex = true;
 											}
 										}
@@ -704,14 +704,14 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 										// individual tokens.
 										if (!highlightedAsRegex) {
 											int temp = zzStartRead + 1;
-											addToken(zzStartRead, zzStartRead, Token.OPERATOR);
+											addToken(zzStartRead, zzStartRead, TokenTypes.OPERATOR);
 											zzStartRead = zzCurrentPos = zzMarkedPos = temp;
 										}
 									}
 
 	/* Separators. */
-	{JS_Separator}					{ addToken(Token.SEPARATOR); }
-	{JS_Separator2}					{ addToken(Token.IDENTIFIER); }
+	{JS_Separator}					{ addToken(TokenTypes.SEPARATOR); }
+	{JS_Separator2}					{ addToken(TokenTypes.IDENTIFIER); }
 
 	/* Operators. */
 	[\+]?"="{Whitespace}*"<"		{
@@ -719,10 +719,10 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 										int operatorLen = yycharat(0)=='+' ? 2 : 1;
 										int yylen = yylength(); // Cache before first addToken() invalidates it
 										//System.out.println("'" + yytext() + "': " + yylength() + ", " + (operatorLen+1));
-										addToken(zzStartRead,zzStartRead+operatorLen-1, Token.OPERATOR);
+										addToken(zzStartRead,zzStartRead+operatorLen-1, TokenTypes.OPERATOR);
 										if (yylen>operatorLen+1) {
 											//System.out.println((start+operatorLen) + ", " + (zzMarkedPos-2));
-											addToken(start+operatorLen,zzMarkedPos-2, Token.WHITESPACE);
+											addToken(start+operatorLen,zzMarkedPos-2, TokenTypes.WHITESPACE);
 										}
 										zzStartRead = zzCurrentPos = zzMarkedPos = zzMarkedPos - 1;
 										if (isE4xSupported()) {
@@ -732,21 +732,21 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 										// Found e4x (or syntax error) but option not enabled;
 										// Scanning will continue at "<" as operator
 									}
-	{JS_Operator}					{ addToken(Token.OPERATOR); }
+	{JS_Operator}					{ addToken(TokenTypes.OPERATOR); }
 
 	/* Numbers */
-	{JS_IntegerLiteral}				{ addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
-	{JS_HexLiteral}				{ addToken(Token.LITERAL_NUMBER_HEXADECIMAL); }
-	{JS_FloatLiteral}				{ addToken(Token.LITERAL_NUMBER_FLOAT); }
-	{JS_ErrorNumberFormat}			{ addToken(Token.ERROR_NUMBER_FORMAT); }
+	{JS_IntegerLiteral}				{ addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT); }
+	{JS_HexLiteral}				{ addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL); }
+	{JS_FloatLiteral}				{ addToken(TokenTypes.LITERAL_NUMBER_FLOAT); }
+	{JS_ErrorNumberFormat}			{ addToken(TokenTypes.ERROR_NUMBER_FORMAT); }
 
-	{JS_ErrorIdentifier}			{ addToken(Token.ERROR_IDENTIFIER); }
+	{JS_ErrorIdentifier}			{ addToken(TokenTypes.ERROR_IDENTIFIER); }
 
 	/* Ended with a line not in a string or comment. */
 	<<EOF>>						{ addNullToken(); return firstToken; }
 
 	/* Catch any other (unhandled) characters and flag them as bad. */
-	.							{ addToken(Token.ERROR_IDENTIFIER); }
+	.							{ addToken(TokenTypes.ERROR_IDENTIFIER); }
 
 }
 
@@ -759,18 +759,18 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	\\.						{ /* Skip all escaped chars. */ }
 	\\						{ /* Line ending in '\' => continue to next line. */
 								if (validJSString) {
-									addToken(start,zzStartRead, Token.LITERAL_STRING_DOUBLE_QUOTE);
+									addToken(start,zzStartRead, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
 									addEndToken(INTERNAL_IN_JS_STRING_VALID);
 								}
 								else {
-									addToken(start,zzStartRead, Token.ERROR_STRING_DOUBLE);
+									addToken(start,zzStartRead, TokenTypes.ERROR_STRING_DOUBLE);
 									addEndToken(INTERNAL_IN_JS_STRING_INVALID);
 								}
 								return firstToken;
 							}
-	\"						{ int type = validJSString ? Token.LITERAL_STRING_DOUBLE_QUOTE : Token.ERROR_STRING_DOUBLE; addToken(start,zzStartRead, type); yybegin(YYINITIAL); }
+	\"						{ int type = validJSString ? TokenTypes.LITERAL_STRING_DOUBLE_QUOTE : TokenTypes.ERROR_STRING_DOUBLE; addToken(start,zzStartRead, type); yybegin(YYINITIAL); }
 	\n |
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
 }
 
 <JS_CHAR> {
@@ -782,18 +782,18 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	\\.						{ /* Skip all escaped chars. */ }
 	\\						{ /* Line ending in '\' => continue to next line. */
 								if (validJSString) {
-									addToken(start,zzStartRead, Token.LITERAL_CHAR);
+									addToken(start,zzStartRead, TokenTypes.LITERAL_CHAR);
 									addEndToken(INTERNAL_IN_JS_CHAR_VALID);
 								}
 								else {
-									addToken(start,zzStartRead, Token.ERROR_CHAR);
+									addToken(start,zzStartRead, TokenTypes.ERROR_CHAR);
 									addEndToken(INTERNAL_IN_JS_CHAR_INVALID);
 								}
 								return firstToken;
 							}
-	\'						{ int type = validJSString ? Token.LITERAL_CHAR : Token.ERROR_CHAR; addToken(start,zzStartRead, type); yybegin(YYINITIAL); }
+	\'						{ int type = validJSString ? TokenTypes.LITERAL_CHAR : TokenTypes.ERROR_CHAR; addToken(start,zzStartRead, type); yybegin(YYINITIAL); }
 	\n |
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.ERROR_CHAR); addNullToken(); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.ERROR_CHAR); addNullToken(); return firstToken; }
 }
 
 <JS_TEMPLATE_LITERAL> {
@@ -805,7 +805,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	\\.						{ /* Skip all escaped chars. */ }
 
 	{JS_TemplateLiteralExprStart}	{
-								addToken(start, zzStartRead - 1, Token.LITERAL_BACKQUOTE);
+								addToken(start, zzStartRead - 1, TokenTypes.LITERAL_BACKQUOTE);
 								start = zzMarkedPos-2;
 								if (varDepths==null) {
 									varDepths = new Stack<>();
@@ -818,18 +818,18 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 							}
 	"$"						{ /* Skip valid '$' that is not part of template literal expression start */ }
 	
-	\`						{ int type = validJSString ? Token.LITERAL_BACKQUOTE : Token.ERROR_STRING_DOUBLE; addToken(start,zzStartRead, type); yybegin(YYINITIAL); }
+	\`						{ int type = validJSString ? TokenTypes.LITERAL_BACKQUOTE : TokenTypes.ERROR_STRING_DOUBLE; addToken(start,zzStartRead, type); yybegin(YYINITIAL); }
 
 	/* Line ending in '\' => continue to next line, though not necessary in template strings. */
 	\\ |
 	\n |
 	<<EOF>>					{
 								if (validJSString) {
-									addToken(start, zzStartRead - 1, Token.LITERAL_BACKQUOTE);
+									addToken(start, zzStartRead - 1, TokenTypes.LITERAL_BACKQUOTE);
 									addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_VALID);
 								}
 								else {
-									addToken(start,zzStartRead - 1, Token.ERROR_STRING_DOUBLE);
+									addToken(start,zzStartRead - 1, TokenTypes.ERROR_STRING_DOUBLE);
 									addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_INVALID);
 								}
 								return firstToken;
@@ -842,7 +842,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 							if (!varDepths.empty()) {
 								varDepths.pop();
 								if (varDepths.empty()) {
-									addToken(start,zzStartRead, Token.VARIABLE);
+									addToken(start,zzStartRead, TokenTypes.VARIABLE);
 									start = zzMarkedPos;
 									yybegin(JS_TEMPLATE_LITERAL);
 								}
@@ -853,109 +853,109 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	\n |
 	<<EOF>>				{
 							// TODO: This isn't right.  The expression and its depth should continue to the next line.
-							addToken(start,zzStartRead-1, Token.VARIABLE); addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_INVALID); return firstToken;
+							addToken(start,zzStartRead-1, TokenTypes.VARIABLE); addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_INVALID); return firstToken;
 						}
 }
 
 <JS_MLC> {
 	// JavaScript MLC's.  This state is essentially Java's MLC state.
 	[^hwf\n\*]+			{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos; }
 	[hwf]					{}
-	{JS_MLCEnd}				{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE); }
+	{JS_MLCEnd}				{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE); }
 	\*						{}
 	\n |
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_JS_MLC); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_JS_MLC); return firstToken; }
 }
 
 <JS_DOCCOMMENT> {
 	[^hwf\@\{\n\<\*]+			{}
-	{URL}						{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_DOCUMENTATION); start = zzMarkedPos; }
+	{URL}						{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_DOCUMENTATION); start = zzMarkedPos; }
 	[hwf]						{}
 
-	"@"{JS_BlockTag}			{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, Token.COMMENT_KEYWORD); start = zzMarkedPos; }
+	"@"{JS_BlockTag}			{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_KEYWORD); start = zzMarkedPos; }
 	"@"							{}
-	"{@"{JS_InlineTag}[^\}]*"}"	{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, Token.COMMENT_KEYWORD); start = zzMarkedPos; }
+	"{@"{JS_InlineTag}[^\}]*"}"	{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_KEYWORD); start = zzMarkedPos; }
 	"{"							{}
-	\n							{ addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addEndToken(INTERNAL_IN_JS_COMMENT_DOCUMENTATION); return firstToken; }
-	"<"[/]?({Letter}[^\>]*)?">"	{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, Token.COMMENT_MARKUP); start = zzMarkedPos; }
+	\n							{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addEndToken(INTERNAL_IN_JS_COMMENT_DOCUMENTATION); return firstToken; }
+	"<"[/]?({Letter}[^\>]*)?">"	{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MARKUP); start = zzMarkedPos; }
 	\<							{}
-	{JS_MLCEnd}					{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_DOCUMENTATION); }
+	{JS_MLCEnd}					{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_DOCUMENTATION); }
 	\*							{}
-	<<EOF>>						{ yybegin(YYINITIAL); addToken(start,zzEndRead, Token.COMMENT_DOCUMENTATION); addEndToken(INTERNAL_IN_JS_COMMENT_DOCUMENTATION); return firstToken; }
+	<<EOF>>						{ yybegin(YYINITIAL); addToken(start,zzEndRead, TokenTypes.COMMENT_DOCUMENTATION); addEndToken(INTERNAL_IN_JS_COMMENT_DOCUMENTATION); return firstToken; }
 }
 
 <JS_EOL_COMMENT> {
 	[^hwf\n]+				{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos; }
 	[hwf]					{}
 	\n |
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken; }
 }
 
 <E4X> {
 	"<!--"						{ start = zzStartRead; e4x_prevState = zzLexicalState; yybegin(E4X_COMMENT); }
-	{e4x_CDataBegin}			{ addToken(Token.MARKUP_CDATA_DELIMITER); start = zzMarkedPos; yybegin(E4X_CDATA); }
+	{e4x_CDataBegin}			{ addToken(TokenTypes.MARKUP_CDATA_DELIMITER); start = zzMarkedPos; yybegin(E4X_CDATA); }
 	"<!"						{ start = zzMarkedPos-2; e4x_inInternalDtd = false; yybegin(E4X_DTD); }
 	"<?"						{ start = zzMarkedPos-2; yybegin(E4X_PI); }
 	"<"{e4x_TagName}			{
 									int count = yylength();
-									addToken(zzStartRead,zzStartRead, Token.MARKUP_TAG_DELIMITER);
-									addToken(zzMarkedPos-(count-1), zzMarkedPos-1, Token.MARKUP_TAG_NAME);
+									addToken(zzStartRead,zzStartRead, TokenTypes.MARKUP_TAG_DELIMITER);
+									addToken(zzMarkedPos-(count-1), zzMarkedPos-1, TokenTypes.MARKUP_TAG_NAME);
 									yybegin(E4X_INTAG);
 								}
 	"</"{e4x_TagName}			{
 									int count = yylength();
-									addToken(zzStartRead,zzStartRead+1, Token.MARKUP_TAG_DELIMITER);
-									addToken(zzMarkedPos-(count-2), zzMarkedPos-1, Token.MARKUP_TAG_NAME);
+									addToken(zzStartRead,zzStartRead+1, TokenTypes.MARKUP_TAG_DELIMITER);
+									addToken(zzMarkedPos-(count-2), zzMarkedPos-1, TokenTypes.MARKUP_TAG_NAME);
 									yybegin(E4X_INTAG);
 								}
-	"<"							{ addToken(Token.MARKUP_TAG_DELIMITER); yybegin(E4X_INTAG); }
-	"</"						{ addToken(Token.MARKUP_TAG_DELIMITER); yybegin(E4X_INTAG); }
-	{e4x_Identifier}			{ addToken(Token.IDENTIFIER); }
-	{e4x_EndXml}				{ yybegin(YYINITIAL, LANG_INDEX_DEFAULT); addToken(Token.IDENTIFIER); }
-	{e4x_EntityReference}				{ addToken(Token.MARKUP_ENTITY_REFERENCE); }
-	{Whitespace}				{ addToken(Token.WHITESPACE); }
+	"<"							{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(E4X_INTAG); }
+	"</"						{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(E4X_INTAG); }
+	{e4x_Identifier}			{ addToken(TokenTypes.IDENTIFIER); }
+	{e4x_EndXml}				{ yybegin(YYINITIAL, LANG_INDEX_DEFAULT); addToken(TokenTypes.IDENTIFIER); }
+	{e4x_EntityReference}				{ addToken(TokenTypes.MARKUP_ENTITY_REFERENCE); }
+	{Whitespace}				{ addToken(TokenTypes.WHITESPACE); }
 	{LineTerminator} |
 	<<EOF>>						{ addEndToken(INTERNAL_E4X); return firstToken; }
 }
 
 <E4X_COMMENT> {
 	[^hwf\n\-]+					{}
-	{URL}						{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.MARKUP_COMMENT); addHyperlinkToken(temp,zzMarkedPos-1, Token.MARKUP_COMMENT); start = zzMarkedPos; }
+	{URL}						{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.MARKUP_COMMENT); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.MARKUP_COMMENT); start = zzMarkedPos; }
 	[hwf]						{}
-	"-->"						{ int temp = zzMarkedPos; addToken(start,zzStartRead+2, Token.MARKUP_COMMENT); start = temp; yybegin(e4x_prevState); }
+	"-->"						{ int temp = zzMarkedPos; addToken(start,zzStartRead+2, TokenTypes.MARKUP_COMMENT); start = temp; yybegin(e4x_prevState); }
 	"-"							{}
 	{LineTerminator} |
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.MARKUP_COMMENT); addEndToken(INTERNAL_E4X_COMMENT - e4x_prevState); return firstToken; }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_COMMENT); addEndToken(INTERNAL_E4X_COMMENT - e4x_prevState); return firstToken; }
 }
 
 <E4X_PI> {
 	[^\n\?]+					{}
-	"?>"						{ yybegin(E4X); addToken(start,zzStartRead+1, Token.MARKUP_PROCESSING_INSTRUCTION); }
+	"?>"						{ yybegin(E4X); addToken(start,zzStartRead+1, TokenTypes.MARKUP_PROCESSING_INSTRUCTION); }
 	"?"							{}
 	{LineTerminator} |
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.MARKUP_PROCESSING_INSTRUCTION); addEndToken(INTERNAL_E4X_MARKUP_PROCESSING_INSTRUCTION); return firstToken; }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_PROCESSING_INSTRUCTION); addEndToken(INTERNAL_E4X_MARKUP_PROCESSING_INSTRUCTION); return firstToken; }
 }
 
 <E4X_DTD> {
 	[^\n\[\]<>]+				{}
-	"<!--"						{ int temp = zzStartRead; addToken(start,zzStartRead-1, Token.MARKUP_DTD); start = temp; e4x_prevState = zzLexicalState; yybegin(E4X_COMMENT); }
+	"<!--"						{ int temp = zzStartRead; addToken(start,zzStartRead-1, TokenTypes.MARKUP_DTD); start = temp; e4x_prevState = zzLexicalState; yybegin(E4X_COMMENT); }
 	"<"							{}
 	"["							{ e4x_inInternalDtd = true; }
 	"]"							{ e4x_inInternalDtd = false; }
-	">"							{ if (!e4x_inInternalDtd) { yybegin(E4X); addToken(start,zzStartRead, Token.MARKUP_DTD); } }
+	">"							{ if (!e4x_inInternalDtd) { yybegin(E4X); addToken(start,zzStartRead, TokenTypes.MARKUP_DTD); } }
 	{LineTerminator} |
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.MARKUP_DTD); addEndToken(e4x_inInternalDtd ? INTERNAL_E4X_DTD_INTERNAL : INTERNAL_E4X_DTD); return firstToken; }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_DTD); addEndToken(e4x_inInternalDtd ? INTERNAL_E4X_DTD_INTERNAL : INTERNAL_E4X_DTD); return firstToken; }
 }
 
 <E4X_INTAG> {
-	{e4x_InTagIdentifier}		{ addToken(Token.MARKUP_TAG_ATTRIBUTE); }
-	{Whitespace}				{ addToken(Token.WHITESPACE); }
-	"="							{ addToken(Token.OPERATOR); }
-	"/"							{ addToken(Token.MARKUP_TAG_DELIMITER); /* Not valid but we'll still accept it */ }
-	"/>"						{ yybegin(E4X); addToken(Token.MARKUP_TAG_DELIMITER); }
-	">"							{ yybegin(E4X); addToken(Token.MARKUP_TAG_DELIMITER); }
+	{e4x_InTagIdentifier}		{ addToken(TokenTypes.MARKUP_TAG_ATTRIBUTE); }
+	{Whitespace}				{ addToken(TokenTypes.WHITESPACE); }
+	"="							{ addToken(TokenTypes.OPERATOR); }
+	"/"							{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); /* Not valid but we'll still accept it */ }
+	"/>"						{ yybegin(E4X); addToken(TokenTypes.MARKUP_TAG_DELIMITER); }
+	">"							{ yybegin(E4X); addToken(TokenTypes.MARKUP_TAG_DELIMITER); }
 	[\"]						{ start = zzMarkedPos-1; yybegin(E4X_INATTR_DOUBLE); }
 	[\']						{ start = zzMarkedPos-1; yybegin(E4X_INATTR_SINGLE); }
 	<<EOF>>						{ addToken(start,zzStartRead-1, INTERNAL_E4X_INTAG); return firstToken; }
@@ -963,19 +963,19 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 
 <E4X_INATTR_DOUBLE> {
 	[^\"]*						{}
-	[\"]						{ yybegin(E4X_INTAG); addToken(start,zzStartRead, Token.MARKUP_TAG_ATTRIBUTE_VALUE); }
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_E4X_ATTR_DOUBLE); return firstToken; }
+	[\"]						{ yybegin(E4X_INTAG); addToken(start,zzStartRead, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_E4X_ATTR_DOUBLE); return firstToken; }
 }
 
 <E4X_INATTR_SINGLE> {
 	[^\']*						{}
-	[\']						{ yybegin(E4X_INTAG); addToken(start,zzStartRead, Token.MARKUP_TAG_ATTRIBUTE_VALUE); }
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_E4X_ATTR_SINGLE); return firstToken; }
+	[\']						{ yybegin(E4X_INTAG); addToken(start,zzStartRead, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_E4X_ATTR_SINGLE); return firstToken; }
 }
 
 <E4X_CDATA> {
 	[^\]]+						{}
-	{e4x_CDataEnd}				{ int temp=zzStartRead; yybegin(E4X); addToken(start,zzStartRead-1, Token.MARKUP_CDATA); addToken(temp,zzMarkedPos-1, Token.MARKUP_CDATA_DELIMITER); }
+	{e4x_CDataEnd}				{ int temp=zzStartRead; yybegin(E4X); addToken(start,zzStartRead-1, TokenTypes.MARKUP_CDATA); addToken(temp,zzMarkedPos-1, TokenTypes.MARKUP_CDATA_DELIMITER); }
 	"]"							{}
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.MARKUP_CDATA); addEndToken(INTERNAL_E4X_MARKUP_CDATA); return firstToken; }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_CDATA); addEndToken(INTERNAL_E4X_MARKUP_CDATA); return firstToken; }
 }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/JavaScriptTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/JavaScriptTokenMaker.java
@@ -1784,10 +1784,10 @@ public class JavaScriptTokenMaker extends AbstractJFlexCTokenMaker {
 										int operatorLen = yycharat(0)=='+' ? 2 : 1;
 										int yylen = yylength(); // Cache before first addToken() invalidates it
 										//System.out.println("'" + yytext() + "': " + yylength() + ", " + (operatorLen+1));
-										addToken(zzStartRead,zzStartRead+operatorLen-1, Token.OPERATOR);
+										addToken(zzStartRead,zzStartRead+operatorLen-1, TokenTypes.OPERATOR);
 										if (yylen>operatorLen+1) {
 											//System.out.println((start+operatorLen) + ", " + (zzMarkedPos-2));
-											addToken(start+operatorLen,zzMarkedPos-2, Token.WHITESPACE);
+											addToken(start+operatorLen,zzMarkedPos-2, TokenTypes.WHITESPACE);
 										}
 										zzStartRead = zzCurrentPos = zzMarkedPos = zzMarkedPos - 1;
 										if (isE4xSupported()) {
@@ -1803,42 +1803,42 @@ public class JavaScriptTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 84: break;
         case 42:
-          { addToken(Token.ERROR_NUMBER_FORMAT);
+          { addToken(TokenTypes.ERROR_NUMBER_FORMAT);
           }
         case 85: break;
         case 80:
-          { addToken(Token.RESERVED_WORD_2);
+          { addToken(TokenTypes.RESERVED_WORD_2);
           }
         case 86: break;
         case 27:
-          { addToken(start,zzStartRead-1, Token.MARKUP_DTD); addEndToken(e4x_inInternalDtd ? INTERNAL_E4X_DTD_INTERNAL : INTERNAL_E4X_DTD); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.MARKUP_DTD); addEndToken(e4x_inInternalDtd ? INTERNAL_E4X_DTD_INTERNAL : INTERNAL_E4X_DTD); return firstToken;
           }
         case 87: break;
         case 39:
-          { int type = validJSString ? Token.LITERAL_BACKQUOTE : Token.ERROR_STRING_DOUBLE; addToken(start,zzStartRead, type); yybegin(YYINITIAL);
+          { int type = validJSString ? TokenTypes.LITERAL_BACKQUOTE : TokenTypes.ERROR_STRING_DOUBLE; addToken(start,zzStartRead, type); yybegin(YYINITIAL);
           }
         case 88: break;
         case 3:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 89: break;
         case 18:
-          { addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_JS_MLC); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_JS_MLC); return firstToken;
           }
         case 90: break;
         case 72:
-          { addToken(Token.FUNCTION);
+          { addToken(TokenTypes.FUNCTION);
           }
         case 91: break;
         case 55:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, Token.COMMENT_MARKUP); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MARKUP); start = zzMarkedPos;
           }
         case 92: break;
         case 41:
           { if (!varDepths.empty()) {
 								varDepths.pop();
 								if (varDepths.empty()) {
-									addToken(start,zzStartRead, Token.VARIABLE);
+									addToken(start,zzStartRead, TokenTypes.VARIABLE);
 									start = zzMarkedPos;
 									yybegin(JS_TEMPLATE_LITERAL);
 								}
@@ -1854,7 +1854,7 @@ public class JavaScriptTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 95: break;
         case 25:
-          { addToken(start,zzStartRead-1, Token.MARKUP_COMMENT); addEndToken(INTERNAL_E4X_COMMENT - e4x_prevState); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.MARKUP_COMMENT); addEndToken(INTERNAL_E4X_COMMENT - e4x_prevState); return firstToken;
           }
         case 96: break;
         case 50:
@@ -1862,7 +1862,7 @@ public class JavaScriptTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 97: break;
         case 12:
-          { addToken(start,zzStartRead-1, Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
           }
         case 98: break;
         case 77:
@@ -1870,11 +1870,11 @@ public class JavaScriptTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 99: break;
         case 68:
-          { int temp=zzStartRead; yybegin(E4X); addToken(start,zzStartRead-1, Token.MARKUP_CDATA); addToken(temp,zzMarkedPos-1, Token.MARKUP_CDATA_DELIMITER);
+          { int temp=zzStartRead; yybegin(E4X); addToken(start,zzStartRead-1, TokenTypes.MARKUP_CDATA); addToken(temp,zzMarkedPos-1, TokenTypes.MARKUP_CDATA_DELIMITER);
           }
         case 100: break;
         case 60:
-          { addToken(start, zzStartRead - 1, Token.LITERAL_BACKQUOTE);
+          { addToken(start, zzStartRead - 1, TokenTypes.LITERAL_BACKQUOTE);
 								start = zzMarkedPos-2;
 								if (varDepths==null) {
 									varDepths = new Stack<>();
@@ -1895,7 +1895,7 @@ public class JavaScriptTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 103: break;
         case 69:
-          { addToken(Token.COMMENT_MULTILINE);
+          { addToken(TokenTypes.COMMENT_MULTILINE);
           }
         case 104: break;
         case 58:
@@ -1903,17 +1903,17 @@ public class JavaScriptTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 105: break;
         case 36:
-          { yybegin(E4X_INTAG); addToken(start,zzStartRead, Token.MARKUP_TAG_ATTRIBUTE_VALUE);
+          { yybegin(E4X_INTAG); addToken(start,zzStartRead, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE);
           }
         case 106: break;
         case 14:
-          { int type = validJSString ? Token.LITERAL_STRING_DOUBLE_QUOTE : Token.ERROR_STRING_DOUBLE; addToken(start,zzStartRead, type); yybegin(YYINITIAL);
+          { int type = validJSString ? TokenTypes.LITERAL_STRING_DOUBLE_QUOTE : TokenTypes.ERROR_STRING_DOUBLE; addToken(start,zzStartRead, type); yybegin(YYINITIAL);
           }
         case 107: break;
         case 62:
           { boolean highlightedAsRegex = false;
 										if (firstToken==null) {
-											addToken(Token.REGEX);
+											addToken(TokenTypes.REGEX);
 											highlightedAsRegex = true;
 										}
 										else {
@@ -1921,7 +1921,7 @@ public class JavaScriptTokenMaker extends AbstractJFlexCTokenMaker {
 											// the previous token, highlight it as such.
 											Token t = firstToken.getLastNonCommentNonWhitespaceToken();
 											if (RSyntaxUtilities.regexCanFollowInJavaScript(t)) {
-												addToken(Token.REGEX);
+												addToken(TokenTypes.REGEX);
 												highlightedAsRegex = true;
 											}
 										}
@@ -1929,17 +1929,17 @@ public class JavaScriptTokenMaker extends AbstractJFlexCTokenMaker {
 										// individual tokens.
 										if (!highlightedAsRegex) {
 											int temp = zzStartRead + 1;
-											addToken(zzStartRead, zzStartRead, Token.OPERATOR);
+											addToken(zzStartRead, zzStartRead, TokenTypes.OPERATOR);
 											zzStartRead = zzCurrentPos = zzMarkedPos = temp;
 										}
           }
         case 108: break;
         case 20:
-          { addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
           }
         case 109: break;
         case 24:
-          { yybegin(YYINITIAL, LANG_INDEX_DEFAULT); addToken(Token.IDENTIFIER);
+          { yybegin(YYINITIAL, LANG_INDEX_DEFAULT); addToken(TokenTypes.IDENTIFIER);
           }
         case 110: break;
         case 51:
@@ -1948,62 +1948,62 @@ public class JavaScriptTokenMaker extends AbstractJFlexCTokenMaker {
         case 111: break;
         case 40:
           { // TODO: This isn't right.  The expression and its depth should continue to the next line.
-							addToken(start,zzStartRead-1, Token.VARIABLE); addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_INVALID); return firstToken;
+							addToken(start,zzStartRead-1, TokenTypes.VARIABLE); addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_INVALID); return firstToken;
           }
         case 112: break;
         case 79:
-          { int temp = zzStartRead; addToken(start,zzStartRead-1, Token.MARKUP_DTD); start = temp; e4x_prevState = zzLexicalState; yybegin(E4X_COMMENT);
+          { int temp = zzStartRead; addToken(start,zzStartRead-1, TokenTypes.MARKUP_DTD); start = temp; e4x_prevState = zzLexicalState; yybegin(E4X_COMMENT);
           }
         case 113: break;
         case 71:
-          { if(e4xSupported){ addToken(Token.RESERVED_WORD);} else {addToken(Token.IDENTIFIER);}
+          { if(e4xSupported){ addToken(TokenTypes.RESERVED_WORD);} else {addToken(TokenTypes.IDENTIFIER);}
           }
         case 114: break;
         case 66:
           { int count = yylength();
-									addToken(zzStartRead,zzStartRead+1, Token.MARKUP_TAG_DELIMITER);
-									addToken(zzMarkedPos-(count-2), zzMarkedPos-1, Token.MARKUP_TAG_NAME);
+									addToken(zzStartRead,zzStartRead+1, TokenTypes.MARKUP_TAG_DELIMITER);
+									addToken(zzMarkedPos-(count-2), zzMarkedPos-1, TokenTypes.MARKUP_TAG_NAME);
 									yybegin(E4X_INTAG);
           }
         case 115: break;
         case 67:
-          { int temp = zzMarkedPos; addToken(start,zzStartRead+2, Token.MARKUP_COMMENT); start = temp; yybegin(e4x_prevState);
+          { int temp = zzMarkedPos; addToken(start,zzStartRead+2, TokenTypes.MARKUP_COMMENT); start = temp; yybegin(e4x_prevState);
           }
         case 116: break;
         case 7:
-          { addToken(Token.OPERATOR);
+          { addToken(TokenTypes.OPERATOR);
           }
         case 117: break;
         case 59:
-          { yybegin(E4X); addToken(start,zzStartRead+1, Token.MARKUP_PROCESSING_INSTRUCTION);
+          { yybegin(E4X); addToken(start,zzStartRead+1, TokenTypes.MARKUP_PROCESSING_INSTRUCTION);
           }
         case 118: break;
         case 54:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_DOCUMENTATION);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_DOCUMENTATION);
           }
         case 119: break;
         case 19:
-          { addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addEndToken(INTERNAL_IN_JS_COMMENT_DOCUMENTATION); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addEndToken(INTERNAL_IN_JS_COMMENT_DOCUMENTATION); return firstToken;
           }
         case 120: break;
         case 26:
-          { addToken(start,zzStartRead-1, Token.MARKUP_PROCESSING_INSTRUCTION); addEndToken(INTERNAL_E4X_MARKUP_PROCESSING_INSTRUCTION); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.MARKUP_PROCESSING_INSTRUCTION); addEndToken(INTERNAL_E4X_MARKUP_PROCESSING_INSTRUCTION); return firstToken;
           }
         case 121: break;
         case 5:
-          { addToken(Token.IDENTIFIER);
+          { addToken(TokenTypes.IDENTIFIER);
           }
         case 122: break;
         case 73:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos;
           }
         case 123: break;
         case 48:
-          { addToken(isE4xSupported() ? Token.MARKUP_TAG_ATTRIBUTE : Token.ERROR_IDENTIFIER);
+          { addToken(isE4xSupported() ? TokenTypes.MARKUP_TAG_ATTRIBUTE : TokenTypes.ERROR_IDENTIFIER);
           }
         case 124: break;
         case 76:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos;
           }
         case 125: break;
         case 63:
@@ -2027,7 +2027,7 @@ public class JavaScriptTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 130: break;
         case 75:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_DOCUMENTATION); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_DOCUMENTATION); start = zzMarkedPos;
           }
         case 131: break;
         case 46:
@@ -2035,39 +2035,39 @@ public class JavaScriptTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 132: break;
         case 44:
-          { addToken(Token.LITERAL_NUMBER_HEXADECIMAL);
+          { addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL);
           }
         case 133: break;
         case 81:
-          { addToken(Token.MARKUP_CDATA_DELIMITER); start = zzMarkedPos; yybegin(E4X_CDATA);
+          { addToken(TokenTypes.MARKUP_CDATA_DELIMITER); start = zzMarkedPos; yybegin(E4X_CDATA);
           }
         case 134: break;
         case 32:
-          { addToken(Token.MARKUP_TAG_DELIMITER); /* Not valid but we'll still accept it */
+          { addToken(TokenTypes.MARKUP_TAG_DELIMITER); /* Not valid but we'll still accept it */
           }
         case 135: break;
         case 2:
-          { addToken(Token.ERROR_IDENTIFIER);
+          { addToken(TokenTypes.ERROR_IDENTIFIER);
           }
         case 136: break;
         case 78:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.MARKUP_COMMENT); addHyperlinkToken(temp,zzMarkedPos-1, Token.MARKUP_COMMENT); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.MARKUP_COMMENT); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.MARKUP_COMMENT); start = zzMarkedPos;
           }
         case 137: break;
         case 33:
-          { yybegin(E4X); addToken(Token.MARKUP_TAG_DELIMITER);
+          { yybegin(E4X); addToken(TokenTypes.MARKUP_TAG_DELIMITER);
           }
         case 138: break;
         case 23:
-          { addToken(Token.MARKUP_ENTITY_REFERENCE);
+          { addToken(TokenTypes.MARKUP_ENTITY_REFERENCE);
           }
         case 139: break;
         case 64:
-          { if(isJavaScriptCompatible("1.7")){ addToken(Token.RESERVED_WORD);} else {addToken(Token.IDENTIFIER);}
+          { if(isJavaScriptCompatible("1.7")){ addToken(TokenTypes.RESERVED_WORD);} else {addToken(TokenTypes.IDENTIFIER);}
           }
         case 140: break;
         case 70:
-          { addToken(Token.LITERAL_BOOLEAN);
+          { addToken(TokenTypes.LITERAL_BOOLEAN);
           }
         case 141: break;
         case 4:
@@ -2075,61 +2075,61 @@ public class JavaScriptTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 142: break;
         case 49:
-          { addToken(Token.RESERVED_WORD);
+          { addToken(TokenTypes.RESERVED_WORD);
           }
         case 143: break;
         case 13:
           { /* Line ending in '\' => continue to next line. */
 								if (validJSString) {
-									addToken(start,zzStartRead, Token.LITERAL_STRING_DOUBLE_QUOTE);
+									addToken(start,zzStartRead, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
 									addEndToken(INTERNAL_IN_JS_STRING_VALID);
 								}
 								else {
-									addToken(start,zzStartRead, Token.ERROR_STRING_DOUBLE);
+									addToken(start,zzStartRead, TokenTypes.ERROR_STRING_DOUBLE);
 									addEndToken(INTERNAL_IN_JS_STRING_INVALID);
 								}
 								return firstToken;
           }
         case 144: break;
         case 53:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE);
           }
         case 145: break;
         case 65:
-          { addToken(Token.DATA_TYPE);
+          { addToken(TokenTypes.DATA_TYPE);
           }
         case 146: break;
         case 22:
-          { addToken(Token.MARKUP_TAG_DELIMITER); yybegin(E4X_INTAG);
+          { addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(E4X_INTAG);
           }
         case 147: break;
         case 8:
-          { addToken(Token.SEPARATOR);
+          { addToken(TokenTypes.SEPARATOR);
           }
         case 148: break;
         case 31:
-          { addToken(Token.MARKUP_TAG_ATTRIBUTE);
+          { addToken(TokenTypes.MARKUP_TAG_ATTRIBUTE);
           }
         case 149: break;
         case 16:
           { /* Line ending in '\' => continue to next line. */
 								if (validJSString) {
-									addToken(start,zzStartRead, Token.LITERAL_CHAR);
+									addToken(start,zzStartRead, TokenTypes.LITERAL_CHAR);
 									addEndToken(INTERNAL_IN_JS_CHAR_VALID);
 								}
 								else {
-									addToken(start,zzStartRead, Token.ERROR_CHAR);
+									addToken(start,zzStartRead, TokenTypes.ERROR_CHAR);
 									addEndToken(INTERNAL_IN_JS_CHAR_INVALID);
 								}
 								return firstToken;
           }
         case 150: break;
         case 74:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, Token.COMMENT_KEYWORD); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_KEYWORD); start = zzMarkedPos;
           }
         case 151: break;
         case 17:
-          { int type = validJSString ? Token.LITERAL_CHAR : Token.ERROR_CHAR; addToken(start,zzStartRead, type); yybegin(YYINITIAL);
+          { int type = validJSString ? TokenTypes.LITERAL_CHAR : TokenTypes.ERROR_CHAR; addToken(start,zzStartRead, type); yybegin(YYINITIAL);
           }
         case 152: break;
         case 45:
@@ -2142,21 +2142,21 @@ public class JavaScriptTokenMaker extends AbstractJFlexCTokenMaker {
         case 154: break;
         case 56:
           { int count = yylength();
-									addToken(zzStartRead,zzStartRead, Token.MARKUP_TAG_DELIMITER);
-									addToken(zzMarkedPos-(count-1), zzMarkedPos-1, Token.MARKUP_TAG_NAME);
+									addToken(zzStartRead,zzStartRead, TokenTypes.MARKUP_TAG_DELIMITER);
+									addToken(zzMarkedPos-(count-1), zzMarkedPos-1, TokenTypes.MARKUP_TAG_NAME);
 									yybegin(E4X_INTAG);
           }
         case 155: break;
         case 43:
-          { addToken(Token.LITERAL_NUMBER_FLOAT);
+          { addToken(TokenTypes.LITERAL_NUMBER_FLOAT);
           }
         case 156: break;
         case 28:
-          { if (!e4x_inInternalDtd) { yybegin(E4X); addToken(start,zzStartRead, Token.MARKUP_DTD); }
+          { if (!e4x_inInternalDtd) { yybegin(E4X); addToken(start,zzStartRead, TokenTypes.MARKUP_DTD); }
           }
         case 157: break;
         case 6:
-          { addToken(Token.LITERAL_NUMBER_DECIMAL_INT);
+          { addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT);
           }
         case 158: break;
         case 30:
@@ -2165,18 +2165,18 @@ public class JavaScriptTokenMaker extends AbstractJFlexCTokenMaker {
         case 159: break;
         case 37:
           { if (validJSString) {
-									addToken(start, zzStartRead - 1, Token.LITERAL_BACKQUOTE);
+									addToken(start, zzStartRead - 1, TokenTypes.LITERAL_BACKQUOTE);
 									addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_VALID);
 								}
 								else {
-									addToken(start,zzStartRead - 1, Token.ERROR_STRING_DOUBLE);
+									addToken(start,zzStartRead - 1, TokenTypes.ERROR_STRING_DOUBLE);
 									addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_INVALID);
 								}
 								return firstToken;
           }
         case 160: break;
         case 15:
-          { addToken(start,zzStartRead-1, Token.ERROR_CHAR); addNullToken(); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.ERROR_CHAR); addNullToken(); return firstToken;
           }
         case 161: break;
         case 1:
@@ -2188,7 +2188,7 @@ public class JavaScriptTokenMaker extends AbstractJFlexCTokenMaker {
             zzAtEOF = true;
             switch (zzLexicalState) {
             case JS_STRING: {
-              addToken(start,zzStartRead-1, Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
             }
             case 642: break;
             case E4X: {
@@ -2200,56 +2200,56 @@ public class JavaScriptTokenMaker extends AbstractJFlexCTokenMaker {
             }
             case 644: break;
             case E4X_PI: {
-              addToken(start,zzStartRead-1, Token.MARKUP_PROCESSING_INSTRUCTION); addEndToken(INTERNAL_E4X_MARKUP_PROCESSING_INSTRUCTION); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_PROCESSING_INSTRUCTION); addEndToken(INTERNAL_E4X_MARKUP_PROCESSING_INSTRUCTION); return firstToken;
             }
             case 645: break;
             case JS_MLC: {
-              addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_JS_MLC); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_JS_MLC); return firstToken;
             }
             case 646: break;
             case JS_CHAR: {
-              addToken(start,zzStartRead-1, Token.ERROR_CHAR); addNullToken(); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.ERROR_CHAR); addNullToken(); return firstToken;
             }
             case 647: break;
             case JS_EOL_COMMENT: {
-              addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
             }
             case 648: break;
             case E4X_COMMENT: {
-              addToken(start,zzStartRead-1, Token.MARKUP_COMMENT); addEndToken(INTERNAL_E4X_COMMENT - e4x_prevState); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_COMMENT); addEndToken(INTERNAL_E4X_COMMENT - e4x_prevState); return firstToken;
             }
             case 649: break;
             case JS_DOCCOMMENT: {
-              yybegin(YYINITIAL); addToken(start,zzEndRead, Token.COMMENT_DOCUMENTATION); addEndToken(INTERNAL_IN_JS_COMMENT_DOCUMENTATION); return firstToken;
+              yybegin(YYINITIAL); addToken(start,zzEndRead, TokenTypes.COMMENT_DOCUMENTATION); addEndToken(INTERNAL_IN_JS_COMMENT_DOCUMENTATION); return firstToken;
             }
             case 650: break;
             case E4X_DTD: {
-              addToken(start,zzStartRead-1, Token.MARKUP_DTD); addEndToken(e4x_inInternalDtd ? INTERNAL_E4X_DTD_INTERNAL : INTERNAL_E4X_DTD); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_DTD); addEndToken(e4x_inInternalDtd ? INTERNAL_E4X_DTD_INTERNAL : INTERNAL_E4X_DTD); return firstToken;
             }
             case 651: break;
             case JS_TEMPLATE_LITERAL: {
               if (validJSString) {
-									addToken(start, zzStartRead - 1, Token.LITERAL_BACKQUOTE);
+									addToken(start, zzStartRead - 1, TokenTypes.LITERAL_BACKQUOTE);
 									addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_VALID);
 								}
 								else {
-									addToken(start,zzStartRead - 1, Token.ERROR_STRING_DOUBLE);
+									addToken(start,zzStartRead - 1, TokenTypes.ERROR_STRING_DOUBLE);
 									addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_INVALID);
 								}
 								return firstToken;
             }
             case 652: break;
             case E4X_INATTR_SINGLE: {
-              addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_E4X_ATTR_SINGLE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_E4X_ATTR_SINGLE); return firstToken;
             }
             case 653: break;
             case E4X_INATTR_DOUBLE: {
-              addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_E4X_ATTR_DOUBLE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_E4X_ATTR_DOUBLE); return firstToken;
             }
             case 654: break;
             case JS_TEMPLATE_LITERAL_EXPR: {
               // TODO: This isn't right.  The expression and its depth should continue to the next line.
-							addToken(start,zzStartRead-1, Token.VARIABLE); addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_INVALID); return firstToken;
+							addToken(start,zzStartRead-1, TokenTypes.VARIABLE); addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_INVALID); return firstToken;
             }
             case 655: break;
             case YYINITIAL: {
@@ -2257,7 +2257,7 @@ public class JavaScriptTokenMaker extends AbstractJFlexCTokenMaker {
             }
             case 656: break;
             case E4X_CDATA: {
-              addToken(start,zzStartRead-1, Token.MARKUP_CDATA); addEndToken(INTERNAL_E4X_MARKUP_CDATA); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_CDATA); addEndToken(INTERNAL_E4X_MARKUP_CDATA); return firstToken;
             }
             case 657: break;
             default:

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/JsonTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/JsonTokenMaker.flex
@@ -276,41 +276,41 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 
 <YYINITIAL> {
 
-	"null"	 					{ addToken(Token.RESERVED_WORD); }
-	{Key}/([ \t\f]*):			{ addToken(Token.VARIABLE); }
-	{BooleanLiteral}			{ addToken(Token.LITERAL_BOOLEAN); }
-	{Identifier}				{ addToken(Token.IDENTIFIER); }
-	{Whitespace}				{ addToken(Token.WHITESPACE); }
-	{StringLiteral}				{ addToken(Token.LITERAL_STRING_DOUBLE_QUOTE); }
-	{UnclosedStringLiteral}		{ addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
-	{ErrorStringLiteral}		{ addToken(Token.ERROR_STRING_DOUBLE); }
-	{Separator}					{ addToken(Token.SEPARATOR); }
-	{Separator2}				{ addToken(Token.IDENTIFIER); }
-	{IntegerLiteral}			{ addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
-	{FloatLiteral}				{ addToken(Token.LITERAL_NUMBER_FLOAT); }
+	"null"	 					{ addToken(TokenTypes.RESERVED_WORD); }
+	{Key}/([ \t\f]*):			{ addToken(TokenTypes.VARIABLE); }
+	{BooleanLiteral}			{ addToken(TokenTypes.LITERAL_BOOLEAN); }
+	{Identifier}				{ addToken(TokenTypes.IDENTIFIER); }
+	{Whitespace}				{ addToken(TokenTypes.WHITESPACE); }
+	{StringLiteral}				{ addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); }
+	{UnclosedStringLiteral}		{ addToken(TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
+	{ErrorStringLiteral}		{ addToken(TokenTypes.ERROR_STRING_DOUBLE); }
+	{Separator}					{ addToken(TokenTypes.SEPARATOR); }
+	{Separator2}				{ addToken(TokenTypes.IDENTIFIER); }
+	{IntegerLiteral}			{ addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT); }
+	{FloatLiteral}				{ addToken(TokenTypes.LITERAL_NUMBER_FLOAT); }
 
 	{LineCommentBegin}			{
 									if (highlightEolComments) {
 										start = zzMarkedPos-2; yybegin(EOL_COMMENT);
 									}
 									else {
-										addToken(Token.IDENTIFIER);
+										addToken(TokenTypes.IDENTIFIER);
 									}
 								}
-	"/"							{ addToken(Token.IDENTIFIER); }
+	"/"							{ addToken(TokenTypes.IDENTIFIER); }
 
 	\n |
 	<<EOF>>						{ addNullToken(); return firstToken; }
 
 	/* Catch any other (unhandled) characters and flag them as identifiers. */
-	.							{ addToken(Token.IDENTIFIER); }
+	.							{ addToken(TokenTypes.IDENTIFIER); }
 
 }
 
 <EOL_COMMENT> {
 	[^hwf\n]+				{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos; }
 	[hwf]					{}
 	\n |
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken; }
 }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/JsonTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/JsonTokenMaker.java
@@ -696,39 +696,39 @@ public class JsonTokenMaker extends AbstractJFlexCTokenMaker {
 
       switch (zzAction < 0 ? zzAction : ZZ_ACTION[zzAction]) {
         case 13:
-          { addToken(Token.RESERVED_WORD);
+          { addToken(TokenTypes.RESERVED_WORD);
           }
         case 16: break;
         case 1:
-          { addToken(Token.IDENTIFIER);
+          { addToken(TokenTypes.IDENTIFIER);
           }
         case 17: break;
         case 10:
-          { addToken(Token.LITERAL_NUMBER_FLOAT);
+          { addToken(TokenTypes.LITERAL_NUMBER_FLOAT);
           }
         case 18: break;
         case 8:
-          { addToken(Token.LITERAL_STRING_DOUBLE_QUOTE);
+          { addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
           }
         case 19: break;
         case 12:
-          { addToken(Token.VARIABLE);
+          { addToken(TokenTypes.VARIABLE);
           }
         case 20: break;
         case 2:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 21: break;
         case 15:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos;
           }
         case 22: break;
         case 3:
-          { addToken(Token.LITERAL_NUMBER_DECIMAL_INT);
+          { addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT);
           }
         case 23: break;
         case 14:
-          { addToken(Token.LITERAL_BOOLEAN);
+          { addToken(TokenTypes.LITERAL_BOOLEAN);
           }
         case 24: break;
         case 9:
@@ -736,20 +736,20 @@ public class JsonTokenMaker extends AbstractJFlexCTokenMaker {
 										start = zzMarkedPos-2; yybegin(EOL_COMMENT);
 									}
 									else {
-										addToken(Token.IDENTIFIER);
+										addToken(TokenTypes.IDENTIFIER);
 									}
           }
         case 25: break;
         case 4:
-          { addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
+          { addToken(TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
           }
         case 26: break;
         case 7:
-          { addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
           }
         case 27: break;
         case 11:
-          { addToken(Token.ERROR_STRING_DOUBLE);
+          { addToken(TokenTypes.ERROR_STRING_DOUBLE);
           }
         case 28: break;
         case 6:
@@ -757,7 +757,7 @@ public class JsonTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 29: break;
         case 5:
-          { addToken(Token.SEPARATOR);
+          { addToken(TokenTypes.SEPARATOR);
           }
         case 30: break;
         default:
@@ -765,7 +765,7 @@ public class JsonTokenMaker extends AbstractJFlexCTokenMaker {
             zzAtEOF = true;
             switch (zzLexicalState) {
             case EOL_COMMENT: {
-              addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
             }
             case 57: break;
             case YYINITIAL: {

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/KotlinTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/KotlinTokenMaker.flex
@@ -145,18 +145,18 @@ import org.fife.ui.rsyntaxtextarea.*;
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = Token.NULL;
+		int state = TokenTypes.NULL;
 		switch (initialTokenType) {
-			case Token.COMMENT_MULTILINE:
+			case TokenTypes.COMMENT_MULTILINE:
 				state = MLC;
 				start = text.offset;
 				break;
-			case Token.COMMENT_DOCUMENTATION:
+			case TokenTypes.COMMENT_DOCUMENTATION:
 				state = DOCCOMMENT;
 				start = text.offset;
 				break;
 			default:
-				state = Token.NULL;
+				state = TokenTypes.NULL;
 		}
 
 		s = text;
@@ -330,7 +330,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"val" |
 	"var" |
 	"when" |
-	"while"					{ addToken(Token.RESERVED_WORD); }
+	"while"					{ addToken(TokenTypes.RESERVED_WORD); }
 
     /* Soft keywords */
     "by" |
@@ -380,9 +380,9 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
     "sealed" |
     "suspend" |
     "tailrec" |
-    "vararg"                 { addToken(Token.RESERVED_WORD); }
+    "vararg"                 { addToken(TokenTypes.RESERVED_WORD); }
 
-	"return"				{ addToken(Token.RESERVED_WORD_2); }
+	"return"				{ addToken(TokenTypes.RESERVED_WORD_2); }
 
 	/* Data types. */
 	"Any" |
@@ -396,10 +396,10 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"Double" |
 	"Float" |
 	"Char" |
-	"Array"                    { addToken(Token.DATA_TYPE); }
+	"Array"                    { addToken(TokenTypes.DATA_TYPE); }
 
 	/* Booleans. */
-	{BooleanLiteral}			{ addToken(Token.LITERAL_BOOLEAN); }
+	{BooleanLiteral}			{ addToken(TokenTypes.LITERAL_BOOLEAN); }
 
 	/* java.lang interfaces */
 	"Appendable" |
@@ -738,52 +738,52 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
     "UnknownFormatConversionException" |
     "UnknownFormatFlagsException" |
 
-    "ServiceConfigurationError" 		{ addToken(Token.FUNCTION); }
+    "ServiceConfigurationError" 		{ addToken(TokenTypes.FUNCTION); }
 
 	{LineTerminator}				{ addNullToken(); return firstToken; }
 
-	{Identifier}					{ addToken(Token.IDENTIFIER); }
+	{Identifier}					{ addToken(TokenTypes.IDENTIFIER); }
 
-	{WhiteSpace}+					{ addToken(Token.WHITESPACE); }
+	{WhiteSpace}+					{ addToken(TokenTypes.WHITESPACE); }
 
 	/* String/Character literals. */
-	{CharLiteral}					{ addToken(Token.LITERAL_CHAR); }
-	{UnclosedCharLiteral}			{ addToken(Token.ERROR_CHAR); addNullToken(); return firstToken; }
-	{ErrorCharLiteral}				{ addToken(Token.ERROR_CHAR); }
-	{StringLiteral}				{ addToken(Token.LITERAL_STRING_DOUBLE_QUOTE); }
-	{UnclosedStringLiteral}			{ addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
-	{ErrorStringLiteral}			{ addToken(Token.ERROR_STRING_DOUBLE); }
+	{CharLiteral}					{ addToken(TokenTypes.LITERAL_CHAR); }
+	{UnclosedCharLiteral}			{ addToken(TokenTypes.ERROR_CHAR); addNullToken(); return firstToken; }
+	{ErrorCharLiteral}				{ addToken(TokenTypes.ERROR_CHAR); }
+	{StringLiteral}				{ addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); }
+	{UnclosedStringLiteral}			{ addToken(TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
+	{ErrorStringLiteral}			{ addToken(TokenTypes.ERROR_STRING_DOUBLE); }
 
 	/* Comment literals. */
-	"/**/"						{ addToken(Token.COMMENT_MULTILINE); }
+	"/**/"						{ addToken(TokenTypes.COMMENT_MULTILINE); }
 	{MLCBegin}					{ start = zzMarkedPos-2; yybegin(MLC); }
 	{DocCommentBegin}				{ start = zzMarkedPos-3; yybegin(DOCCOMMENT); }
 	{LineCommentBegin}			{ start = zzMarkedPos-2; yybegin(EOL_COMMENT); }
 
 	/* Annotations. */
-	{Annotation}					{ addToken(Token.ANNOTATION); }
+	{Annotation}					{ addToken(TokenTypes.ANNOTATION); }
 
 	/* Separators. */
-	{Separator}					{ addToken(Token.SEPARATOR); }
-	{Separator2}					{ addToken(Token.IDENTIFIER); }
+	{Separator}					{ addToken(TokenTypes.SEPARATOR); }
+	{Separator2}					{ addToken(TokenTypes.IDENTIFIER); }
 
 	/* Operators. */
-	{Operator}					{ addToken(Token.OPERATOR); }
+	{Operator}					{ addToken(TokenTypes.OPERATOR); }
 
 	/* Numbers */
-	{IntegerLiteral}				{ addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
-	{BinaryLiteral}					{ addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
-	{HexLiteral}					{ addToken(Token.LITERAL_NUMBER_HEXADECIMAL); }
-	{FloatLiteral}					{ addToken(Token.LITERAL_NUMBER_FLOAT); }
-	{ErrorNumberFormat}				{ addToken(Token.ERROR_NUMBER_FORMAT); }
+	{IntegerLiteral}				{ addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT); }
+	{BinaryLiteral}					{ addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT); }
+	{HexLiteral}					{ addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL); }
+	{FloatLiteral}					{ addToken(TokenTypes.LITERAL_NUMBER_FLOAT); }
+	{ErrorNumberFormat}				{ addToken(TokenTypes.ERROR_NUMBER_FORMAT); }
 
-	{ErrorIdentifier}				{ addToken(Token.ERROR_IDENTIFIER); }
+	{ErrorIdentifier}				{ addToken(TokenTypes.ERROR_IDENTIFIER); }
 
 	/* Ended with a line not in a string or comment. */
 	<<EOF>>						{ addNullToken(); return firstToken; }
 
 	/* Catch any other (unhandled) characters and flag them as identifiers. */
-	.							{ addToken(Token.ERROR_IDENTIFIER); }
+	.							{ addToken(TokenTypes.ERROR_IDENTIFIER); }
 
 }
 
@@ -791,13 +791,13 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 <MLC> {
 
 	[^hwf\n\*]+				{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos; }
 	[hwf]					{}
 
-	\n						{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken; }
-	{MLCEnd}					{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE); }
+	\n						{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken; }
+	{MLCEnd}					{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE); }
 	\*						{}
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken; }
 
 }
 
@@ -808,9 +808,9 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	{URL}						{
                                     int temp = zzStartRead;
                                     if (start <= zzStartRead - 1) {
-                                        addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION);
+                                        addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION);
                                     }
-                                    addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_DOCUMENTATION);
+                                    addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_DOCUMENTATION);
                                     start = zzMarkedPos;
                                 }
 	[hwf]						{}
@@ -818,36 +818,36 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"@"{BlockTag}				{
                                     int temp = zzStartRead;
                                     if (start <= zzStartRead - 1) {
-                                        addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION);
+                                        addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION);
                                     }
-                                    addToken(temp,zzMarkedPos-1, Token.COMMENT_KEYWORD);
+                                    addToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_KEYWORD);
                                     start = zzMarkedPos;
                                 }
 	"@"							{}
 	"{@"{InlineTag}[^\}]*"}"	{
                                     int temp = zzStartRead;
                                     if (start <= zzStartRead - 1) {
-                                        addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION);
+                                        addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION);
                                     }
-                                    addToken(temp,zzMarkedPos-1, Token.COMMENT_KEYWORD);
+                                    addToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_KEYWORD);
                                     start = zzMarkedPos;
                                 }
 	"{"							{}
-	\n							{ addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); return firstToken; }
-	"<"[/]?({Letter}[^\>]*)?">"	{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, Token.COMMENT_MARKUP); start = zzMarkedPos; }
+	\n							{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); return firstToken; }
+	"<"[/]?({Letter}[^\>]*)?">"	{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MARKUP); start = zzMarkedPos; }
 	\<							{}
-	{MLCEnd}					{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_DOCUMENTATION); }
+	{MLCEnd}					{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_DOCUMENTATION); }
 	\*							{}
-	<<EOF>>						{ yybegin(YYINITIAL); addToken(start,zzEndRead, Token.COMMENT_DOCUMENTATION); return firstToken; }
+	<<EOF>>						{ yybegin(YYINITIAL); addToken(start,zzEndRead, TokenTypes.COMMENT_DOCUMENTATION); return firstToken; }
 
 }
 
 
 <EOL_COMMENT> {
 	[^hwf\n]+				{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos; }
 	[hwf]					{}
-	\n						{ addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken; }
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken; }
+	\n						{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken; }
 
 }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/KotlinTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/KotlinTokenMaker.java
@@ -5186,18 +5186,18 @@ public class KotlinTokenMaker extends AbstractJFlexCTokenMaker {
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = Token.NULL;
+		int state = TokenTypes.NULL;
 		switch (initialTokenType) {
-			case Token.COMMENT_MULTILINE:
+			case TokenTypes.COMMENT_MULTILINE:
 				state = MLC;
 				start = text.offset;
 				break;
-			case Token.COMMENT_DOCUMENTATION:
+			case TokenTypes.COMMENT_DOCUMENTATION:
 				state = DOCCOMMENT;
 				start = text.offset;
 				break;
 			default:
-				state = Token.NULL;
+				state = TokenTypes.NULL;
 		}
 
 		s = text;
@@ -5477,64 +5477,64 @@ public class KotlinTokenMaker extends AbstractJFlexCTokenMaker {
 
       switch (zzAction < 0 ? zzAction : ZZ_ACTION[zzAction]) {
         case 2:
-          { addToken(Token.IDENTIFIER);
+          { addToken(TokenTypes.IDENTIFIER);
           }
         case 38: break;
         case 32:
-          { addToken(Token.LITERAL_BOOLEAN);
+          { addToken(TokenTypes.LITERAL_BOOLEAN);
           }
         case 39: break;
         case 13:
-          { addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); return firstToken;
           }
         case 40: break;
         case 18:
-          { addToken(Token.ERROR_CHAR);
+          { addToken(TokenTypes.ERROR_CHAR);
           }
         case 41: break;
         case 15:
-          { addToken(Token.ERROR_NUMBER_FORMAT);
+          { addToken(TokenTypes.ERROR_NUMBER_FORMAT);
           }
         case 42: break;
         case 4:
-          { addToken(Token.ERROR_CHAR); addNullToken(); return firstToken;
+          { addToken(TokenTypes.ERROR_CHAR); addNullToken(); return firstToken;
           }
         case 43: break;
         case 19:
-          { addToken(Token.LITERAL_STRING_DOUBLE_QUOTE);
+          { addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
           }
         case 44: break;
         case 10:
-          { addToken(Token.ANNOTATION);
+          { addToken(TokenTypes.ANNOTATION);
           }
         case 45: break;
         case 30:
-          { addToken(Token.FUNCTION);
+          { addToken(TokenTypes.FUNCTION);
           }
         case 46: break;
         case 6:
-          { addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
+          { addToken(TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
           }
         case 47: break;
         case 1:
-          { addToken(Token.ERROR_IDENTIFIER);
+          { addToken(TokenTypes.ERROR_IDENTIFIER);
           }
         case 48: break;
         case 26:
-          { addToken(Token.LITERAL_CHAR);
+          { addToken(TokenTypes.LITERAL_CHAR);
           }
         case 49: break;
         case 35:
           { int temp = zzStartRead;
                                     if (start <= zzStartRead - 1) {
-                                        addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION);
+                                        addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION);
                                     }
-                                    addToken(temp,zzMarkedPos-1, Token.COMMENT_KEYWORD);
+                                    addToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_KEYWORD);
                                     start = zzMarkedPos;
           }
         case 50: break;
         case 17:
-          { addToken(Token.LITERAL_NUMBER_HEXADECIMAL);
+          { addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL);
           }
         case 51: break;
         case 21:
@@ -5542,36 +5542,36 @@ public class KotlinTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 52: break;
         case 7:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 53: break;
         case 24:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_DOCUMENTATION);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_DOCUMENTATION);
           }
         case 54: break;
         case 29:
-          { addToken(Token.DATA_TYPE);
+          { addToken(TokenTypes.DATA_TYPE);
           }
         case 55: break;
         case 23:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE);
           }
         case 56: break;
         case 3:
-          { addToken(Token.LITERAL_NUMBER_DECIMAL_INT);
+          { addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT);
           }
         case 57: break;
         case 34:
           { int temp = zzStartRead;
                                     if (start <= zzStartRead - 1) {
-                                        addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION);
+                                        addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION);
                                     }
-                                    addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_DOCUMENTATION);
+                                    addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_DOCUMENTATION);
                                     start = zzMarkedPos;
           }
         case 58: break;
         case 25:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, Token.COMMENT_MARKUP); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MARKUP); start = zzMarkedPos;
           }
         case 59: break;
         case 28:
@@ -5579,23 +5579,23 @@ public class KotlinTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 60: break;
         case 22:
-          { addToken(Token.RESERVED_WORD);
+          { addToken(TokenTypes.RESERVED_WORD);
           }
         case 61: break;
         case 33:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos;
           }
         case 62: break;
         case 37:
-          { addToken(Token.RESERVED_WORD_2);
+          { addToken(TokenTypes.RESERVED_WORD_2);
           }
         case 63: break;
         case 14:
-          { addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
           }
         case 64: break;
         case 9:
-          { addToken(Token.SEPARATOR);
+          { addToken(TokenTypes.SEPARATOR);
           }
         case 65: break;
         case 5:
@@ -5603,19 +5603,19 @@ public class KotlinTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 66: break;
         case 12:
-          { addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken;
           }
         case 67: break;
         case 8:
-          { addToken(Token.OPERATOR);
+          { addToken(TokenTypes.OPERATOR);
           }
         case 68: break;
         case 16:
-          { addToken(Token.LITERAL_NUMBER_FLOAT);
+          { addToken(TokenTypes.LITERAL_NUMBER_FLOAT);
           }
         case 69: break;
         case 36:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos;
           }
         case 70: break;
         case 20:
@@ -5623,7 +5623,7 @@ public class KotlinTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 71: break;
         case 31:
-          { addToken(Token.COMMENT_MULTILINE);
+          { addToken(TokenTypes.COMMENT_MULTILINE);
           }
         case 72: break;
         case 11:
@@ -5631,7 +5631,7 @@ public class KotlinTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 73: break;
         case 27:
-          { addToken(Token.ERROR_STRING_DOUBLE);
+          { addToken(TokenTypes.ERROR_STRING_DOUBLE);
           }
         case 74: break;
         default:
@@ -5639,11 +5639,11 @@ public class KotlinTokenMaker extends AbstractJFlexCTokenMaker {
             zzAtEOF = true;
             switch (zzLexicalState) {
             case EOL_COMMENT: {
-              addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
             }
             case 2009: break;
             case DOCCOMMENT: {
-              yybegin(YYINITIAL); addToken(start,zzEndRead, Token.COMMENT_DOCUMENTATION); return firstToken;
+              yybegin(YYINITIAL); addToken(start,zzEndRead, TokenTypes.COMMENT_DOCUMENTATION); return firstToken;
             }
             case 2010: break;
             case YYINITIAL: {
@@ -5651,7 +5651,7 @@ public class KotlinTokenMaker extends AbstractJFlexCTokenMaker {
             }
             case 2011: break;
             case MLC: {
-              addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken;
             }
             case 2012: break;
             default:

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/LatexTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/LatexTokenMaker.flex
@@ -153,7 +153,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = Token.NULL;
+		int state = TokenTypes.NULL;
 
 		s = text;
 		try {
@@ -233,25 +233,25 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 
 <YYINITIAL> {
 
-	([\\]{AnyChar}+)			{ addToken(Token.FUNCTION); }
+	([\\]{AnyChar}+)			{ addToken(TokenTypes.FUNCTION); }
 	([\\]%)						{ int temp = zzStartRead;
-									addToken(temp, temp, Token.SEPARATOR);
-									addToken(temp + 1, temp + 1, Token.IDENTIFIER);
+									addToken(temp, temp, TokenTypes.SEPARATOR);
+									addToken(temp + 1, temp + 1, TokenTypes.IDENTIFIER);
 								}
-	[\{\}]						{ addToken(Token.SEPARATOR); }
+	[\{\}]						{ addToken(TokenTypes.SEPARATOR); }
 	("\\begin{"{AnyChar}+"}")   { int temp = zzStartRead;
-							addToken(temp, temp+5, Token.RESERVED_WORD);
-							addToken(temp+6, temp+6, Token.SEPARATOR);
-							addToken(temp+7, zzMarkedPos-2, Token.RESERVED_WORD);
-							addToken(zzMarkedPos-1, zzMarkedPos-1, Token.SEPARATOR);
+							addToken(temp, temp+5, TokenTypes.RESERVED_WORD);
+							addToken(temp+6, temp+6, TokenTypes.SEPARATOR);
+							addToken(temp+7, zzMarkedPos-2, TokenTypes.RESERVED_WORD);
+							addToken(zzMarkedPos-1, zzMarkedPos-1, TokenTypes.SEPARATOR);
 								}
 	("\\end{"{AnyChar}+"}")		{ int temp = zzStartRead;
-							addToken(temp, temp+3, Token.RESERVED_WORD);
-							addToken(temp+4, temp+4, Token.SEPARATOR);
-							addToken(temp+5, zzMarkedPos-2, Token.RESERVED_WORD);
-							addToken(zzMarkedPos-1, zzMarkedPos-1, Token.SEPARATOR);
+							addToken(temp, temp+3, TokenTypes.RESERVED_WORD);
+							addToken(temp+4, temp+4, TokenTypes.SEPARATOR);
+							addToken(temp+5, zzMarkedPos-2, TokenTypes.RESERVED_WORD);
+							addToken(zzMarkedPos-1, zzMarkedPos-1, TokenTypes.SEPARATOR);
 								}
-	{Whitespace}				{ addToken(Token.WHITESPACE); }
+	{Whitespace}				{ addToken(TokenTypes.WHITESPACE); }
 
 	{LineCommentBegin}			{ start = zzMarkedPos-1; yybegin(EOL_COMMENT); }
 
@@ -260,15 +260,15 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 
 	/* Catch any other (unhandled) characters and flag them as identifiers. */
 	{AnyChar}+ |
-	.							{ addToken(Token.IDENTIFIER); }
+	.							{ addToken(TokenTypes.IDENTIFIER); }
 
 }
 
 
 <EOL_COMMENT> {
 	[^hwf\n]+				{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos; }
 	[hwf]					{}
 	\n |
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken; }
 }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/LatexTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/LatexTokenMaker.java
@@ -17,6 +17,7 @@ import javax.swing.text.Segment;
 import org.fife.ui.rsyntaxtextarea.AbstractJFlexTokenMaker;
 import org.fife.ui.rsyntaxtextarea.Token;
 import org.fife.ui.rsyntaxtextarea.TokenImpl;
+import org.fife.ui.rsyntaxtextarea.TokenTypes;
 
 
 /**
@@ -365,7 +366,7 @@ public class LatexTokenMaker extends AbstractJFlexTokenMaker {
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = Token.NULL;
+		int state = TokenTypes.NULL;
 
 		s = text;
 		try {
@@ -645,27 +646,27 @@ public class LatexTokenMaker extends AbstractJFlexTokenMaker {
 
       switch (zzAction < 0 ? zzAction : ZZ_ACTION[zzAction]) {
         case 1:
-          { addToken(Token.IDENTIFIER);
+          { addToken(TokenTypes.IDENTIFIER);
           }
         case 13: break;
         case 8:
-          { addToken(Token.FUNCTION);
+          { addToken(TokenTypes.FUNCTION);
           }
         case 14: break;
         case 2:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 15: break;
         case 12:
           { int temp = zzStartRead;
-							addToken(temp, temp+5, Token.RESERVED_WORD);
-							addToken(temp+6, temp+6, Token.SEPARATOR);
-							addToken(temp+7, zzMarkedPos-2, Token.RESERVED_WORD);
-							addToken(zzMarkedPos-1, zzMarkedPos-1, Token.SEPARATOR);
+							addToken(temp, temp+5, TokenTypes.RESERVED_WORD);
+							addToken(temp+6, temp+6, TokenTypes.SEPARATOR);
+							addToken(temp+7, zzMarkedPos-2, TokenTypes.RESERVED_WORD);
+							addToken(zzMarkedPos-1, zzMarkedPos-1, TokenTypes.SEPARATOR);
           }
         case 16: break;
         case 10:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos;
           }
         case 17: break;
         case 3:
@@ -674,10 +675,10 @@ public class LatexTokenMaker extends AbstractJFlexTokenMaker {
         case 18: break;
         case 11:
           { int temp = zzStartRead;
-							addToken(temp, temp+3, Token.RESERVED_WORD);
-							addToken(temp+4, temp+4, Token.SEPARATOR);
-							addToken(temp+5, zzMarkedPos-2, Token.RESERVED_WORD);
-							addToken(zzMarkedPos-1, zzMarkedPos-1, Token.SEPARATOR);
+							addToken(temp, temp+3, TokenTypes.RESERVED_WORD);
+							addToken(temp+4, temp+4, TokenTypes.SEPARATOR);
+							addToken(temp+5, zzMarkedPos-2, TokenTypes.RESERVED_WORD);
+							addToken(zzMarkedPos-1, zzMarkedPos-1, TokenTypes.SEPARATOR);
           }
         case 19: break;
         case 5:
@@ -685,13 +686,13 @@ public class LatexTokenMaker extends AbstractJFlexTokenMaker {
           }
         case 20: break;
         case 7:
-          { addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
           }
         case 21: break;
         case 9:
           { int temp = zzStartRead;
-									addToken(temp, temp, Token.SEPARATOR);
-									addToken(temp + 1, temp + 1, Token.IDENTIFIER);
+									addToken(temp, temp, TokenTypes.SEPARATOR);
+									addToken(temp + 1, temp + 1, TokenTypes.IDENTIFIER);
           }
         case 22: break;
         case 6:
@@ -699,7 +700,7 @@ public class LatexTokenMaker extends AbstractJFlexTokenMaker {
           }
         case 23: break;
         case 4:
-          { addToken(Token.SEPARATOR);
+          { addToken(TokenTypes.SEPARATOR);
           }
         case 24: break;
         default:
@@ -707,7 +708,7 @@ public class LatexTokenMaker extends AbstractJFlexTokenMaker {
             zzAtEOF = true;
             switch (zzLexicalState) {
             case EOL_COMMENT: {
-              addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
             }
             case 44: break;
             case YYINITIAL: {

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/LispTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/LispTokenMaker.flex
@@ -149,18 +149,18 @@ import org.fife.ui.rsyntaxtextarea.*;
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = Token.NULL;
+		int state = TokenTypes.NULL;
 		switch (initialTokenType) {
-			case Token.COMMENT_MULTILINE:
+			case TokenTypes.COMMENT_MULTILINE:
 				state = MLC;
 				start = text.offset;
 				break;
-			case Token.LITERAL_STRING_DOUBLE_QUOTE:
+			case TokenTypes.LITERAL_STRING_DOUBLE_QUOTE:
 				state = STRING;
 				start = text.offset;
 				break;
 			default:
-				state = Token.NULL;
+				state = TokenTypes.NULL;
 		}
 
 		s = text;
@@ -292,7 +292,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"defstruct" |
 	"deftype" |
 	"defun" |
-	"defvar"						{ addToken(Token.RESERVED_WORD); }
+	"defvar"						{ addToken(TokenTypes.RESERVED_WORD); }
 
 	"abort" |
 	"assert" |
@@ -365,62 +365,62 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"with-package-iterator" |
 	"with-simple-restart" |
 	"with-slots" |
-	"with-standard-io-syntax"		{ addToken(Token.RESERVED_WORD); }
+	"with-standard-io-syntax"		{ addToken(TokenTypes.RESERVED_WORD); }
 
 	{LineTerminator}				{ addNullToken(); return firstToken; }
-	{Identifier}					{ addToken(Token.IDENTIFIER); }
-	{WhiteSpace}+					{ addToken(Token.WHITESPACE); }
+	{Identifier}					{ addToken(TokenTypes.IDENTIFIER); }
+	{WhiteSpace}+					{ addToken(TokenTypes.WHITESPACE); }
 	[\"]							{ start = zzMarkedPos-1; yybegin(STRING); }
 	{MLCBegin}					{ start = zzMarkedPos-2; yybegin(MLC); }
 	{LineCommentBegin}			{ start = zzMarkedPos-1; yybegin(EOL_COMMENT); }
-	{Separator}					{ addToken(Token.SEPARATOR); }
-	{Operator}					{ addToken(Token.OPERATOR); }
+	{Separator}					{ addToken(TokenTypes.SEPARATOR); }
+	{Operator}					{ addToken(TokenTypes.OPERATOR); }
 
 	/* Numbers */
-	{IntegerLiteral}				{ addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
-	{HexLiteral}					{ addToken(Token.LITERAL_NUMBER_HEXADECIMAL); }
-	{FloatLiteral}					{ addToken(Token.LITERAL_NUMBER_FLOAT); }
-	{ErrorNumberFormat}				{ addToken(Token.ERROR_NUMBER_FORMAT); }
+	{IntegerLiteral}				{ addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT); }
+	{HexLiteral}					{ addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL); }
+	{FloatLiteral}					{ addToken(TokenTypes.LITERAL_NUMBER_FLOAT); }
+	{ErrorNumberFormat}				{ addToken(TokenTypes.ERROR_NUMBER_FORMAT); }
 
-	{ErrorIdentifier}				{ addToken(Token.ERROR_IDENTIFIER); }
+	{ErrorIdentifier}				{ addToken(TokenTypes.ERROR_IDENTIFIER); }
 
 	/* Ended with a line not in a string or comment. */
 	<<EOF>>						{ addNullToken(); return firstToken; }
 
 	/* Catch any other (unhandled) characters and flag them as bad. */
-	.							{ addToken(Token.ERROR_IDENTIFIER); }
+	.							{ addToken(TokenTypes.ERROR_IDENTIFIER); }
 
 }
 
 
 <STRING> {
 	[^\n\\\"]+			{}
-	\n					{ addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken; }
+	\n					{ addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken; }
 	\\.?					{ /* Skip escaped chars. */ }
-	\"					{ yybegin(YYINITIAL); addToken(start,zzStartRead, Token.LITERAL_STRING_DOUBLE_QUOTE); }
-	<<EOF>>				{ addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken; }
+	\"					{ yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); }
+	<<EOF>>				{ addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken; }
 }
 
 
 <MLC> {
 
 	[^hwf\n\|]+				{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos; }
 	[hwf]					{}
 
-	\n						{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken; }
-	{MLCEnd}					{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE); }
+	\n						{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken; }
+	{MLCEnd}					{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE); }
 	\|						{}
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken; }
 
 }
 
 
 <EOL_COMMENT> {
 	[^hwf\n]+				{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos; }
 	[hwf]					{}
-	\n						{ addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken; }
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken; }
+	\n						{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken; }
 
 }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/LispTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/LispTokenMaker.java
@@ -886,18 +886,18 @@ public class LispTokenMaker extends AbstractJFlexTokenMaker {
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = Token.NULL;
+		int state = TokenTypes.NULL;
 		switch (initialTokenType) {
-			case Token.COMMENT_MULTILINE:
+			case TokenTypes.COMMENT_MULTILINE:
 				state = MLC;
 				start = text.offset;
 				break;
-			case Token.LITERAL_STRING_DOUBLE_QUOTE:
+			case TokenTypes.LITERAL_STRING_DOUBLE_QUOTE:
 				state = STRING;
 				start = text.offset;
 				break;
 			default:
-				state = Token.NULL;
+				state = TokenTypes.NULL;
 		}
 
 		s = text;
@@ -1182,7 +1182,7 @@ public final void yybegin(int newState) {
           }
         case 24: break;
         case 21:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE);
           }
         case 25: break;
         case 19:
@@ -1190,31 +1190,31 @@ public final void yybegin(int newState) {
           }
         case 26: break;
         case 5:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 27: break;
         case 18:
-          { addToken(Token.LITERAL_NUMBER_HEXADECIMAL);
+          { addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL);
           }
         case 28: break;
         case 17:
-          { addToken(Token.LITERAL_NUMBER_FLOAT);
+          { addToken(TokenTypes.LITERAL_NUMBER_FLOAT);
           }
         case 29: break;
         case 20:
-          { addToken(Token.RESERVED_WORD);
+          { addToken(TokenTypes.RESERVED_WORD);
           }
         case 30: break;
         case 8:
-          { addToken(Token.SEPARATOR);
+          { addToken(TokenTypes.SEPARATOR);
           }
         case 31: break;
         case 2:
-          { addToken(Token.IDENTIFIER);
+          { addToken(TokenTypes.IDENTIFIER);
           }
         case 32: break;
         case 15:
-          { addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
           }
         case 33: break;
         case 11:
@@ -1222,23 +1222,23 @@ public final void yybegin(int newState) {
           }
         case 34: break;
         case 1:
-          { addToken(Token.ERROR_IDENTIFIER);
+          { addToken(TokenTypes.ERROR_IDENTIFIER);
           }
         case 35: break;
         case 12:
-          { addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
           }
         case 36: break;
         case 23:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos;
           }
         case 37: break;
         case 22:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos;
           }
         case 38: break;
         case 16:
-          { addToken(Token.ERROR_NUMBER_FORMAT);
+          { addToken(TokenTypes.ERROR_NUMBER_FORMAT);
           }
         case 39: break;
         case 9:
@@ -1250,15 +1250,15 @@ public final void yybegin(int newState) {
           }
         case 41: break;
         case 3:
-          { addToken(Token.LITERAL_NUMBER_DECIMAL_INT);
+          { addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT);
           }
         case 42: break;
         case 6:
-          { addToken(Token.OPERATOR);
+          { addToken(TokenTypes.OPERATOR);
           }
         case 43: break;
         case 13:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead, Token.LITERAL_STRING_DOUBLE_QUOTE);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
           }
         case 44: break;
         case 10:
@@ -1266,7 +1266,7 @@ public final void yybegin(int newState) {
           }
         case 45: break;
         case 14:
-          { addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken;
           }
         case 46: break;
         default:
@@ -1274,11 +1274,11 @@ public final void yybegin(int newState) {
             zzAtEOF = true;
             switch (zzLexicalState) {
             case EOL_COMMENT: {
-              addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
             }
             case 513: break;
             case STRING: {
-              addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
             }
             case 514: break;
             case YYINITIAL: {
@@ -1286,7 +1286,7 @@ public final void yybegin(int newState) {
             }
             case 515: break;
             case MLC: {
-              addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken;
             }
             case 516: break;
             default:

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/LuaTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/LuaTokenMaker.flex
@@ -134,18 +134,18 @@ import org.fife.ui.rsyntaxtextarea.*;
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = Token.NULL;
+		int state = TokenTypes.NULL;
 		switch (initialTokenType) {
-			case Token.COMMENT_MULTILINE:
+			case TokenTypes.COMMENT_MULTILINE:
 				state = MLC;
 				start = text.offset;
 				break;
-			case Token.LITERAL_STRING_DOUBLE_QUOTE:
+			case TokenTypes.LITERAL_STRING_DOUBLE_QUOTE:
 				state = LONGSTRING;
 				start = text.offset;
 				break;
 			default:
-				state = Token.NULL;
+				state = TokenTypes.NULL;
 		}
 
 		s = text;
@@ -260,14 +260,14 @@ Identifier				= ({Letter}({Letter}|{Digit})*)
 <YYINITIAL> "return" |
 <YYINITIAL> "then" |
 <YYINITIAL> "until" |
-<YYINITIAL> "while" { addToken(Token.RESERVED_WORD); }
+<YYINITIAL> "while" { addToken(TokenTypes.RESERVED_WORD); }
 
 /* Data types. */
 <YYINITIAL> "<number>" |
 <YYINITIAL> "<name>" |
 <YYINITIAL> "<string>" |
 <YYINITIAL> "<eof>" |
-<YYINITIAL> "NULL"					{ addToken(Token.DATA_TYPE); }
+<YYINITIAL> "NULL"					{ addToken(TokenTypes.DATA_TYPE); }
 
 /* Functions. */
 <YYINITIAL> "_G" |
@@ -298,23 +298,23 @@ Identifier				= ({Letter}({Letter}|{Digit})*)
 <YYINITIAL> "tostring" |
 <YYINITIAL> "type" |
 <YYINITIAL> "unpack" |
-<YYINITIAL> "xpcall"				{ addToken(Token.FUNCTION); }
+<YYINITIAL> "xpcall"				{ addToken(TokenTypes.FUNCTION); }
 
 /* Booleans. */
-<YYINITIAL> {BooleanLiteral}			{ addToken(Token.LITERAL_BOOLEAN); }
+<YYINITIAL> {BooleanLiteral}			{ addToken(TokenTypes.LITERAL_BOOLEAN); }
 
 
 <YYINITIAL> {
 
 	{LineTerminator}				{ addNullToken(); return firstToken; }
 
-	{WhiteSpace}+					{ addToken(Token.WHITESPACE); }
+	{WhiteSpace}+					{ addToken(TokenTypes.WHITESPACE); }
 
 	/* String/Character literals. */
-	{CharLiteral}					{ addToken(Token.LITERAL_CHAR); }
-	{UnclosedCharLiteral}			{ addToken(Token.ERROR_CHAR); addNullToken(); return firstToken; }
-	{StringLiteral}				{ addToken(Token.LITERAL_STRING_DOUBLE_QUOTE); }
-	{UnclosedStringLiteral}			{ addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
+	{CharLiteral}					{ addToken(TokenTypes.LITERAL_CHAR); }
+	{UnclosedCharLiteral}			{ addToken(TokenTypes.ERROR_CHAR); addNullToken(); return firstToken; }
+	{StringLiteral}				{ addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); }
+	{UnclosedStringLiteral}			{ addToken(TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
 	{LongStringBegin}				{ start = zzMarkedPos-2; yybegin(LONGSTRING); }
 
 	/* Comment literals. */
@@ -322,47 +322,47 @@ Identifier				= ({Letter}({Letter}|{Digit})*)
 	{LineCommentBegin}				{ start = zzMarkedPos-2; yybegin(LINECOMMENT); }
 
 	/* Separators. */
-	{Separator}					{ addToken(Token.SEPARATOR); }
-	{Separator2}					{ addToken(Token.IDENTIFIER); }
+	{Separator}					{ addToken(TokenTypes.SEPARATOR); }
+	{Separator2}					{ addToken(TokenTypes.IDENTIFIER); }
 
 	/* Operators. */
-	{Operator}					{ addToken(Token.OPERATOR); }
+	{Operator}					{ addToken(TokenTypes.OPERATOR); }
 
 	/* Identifiers - Comes after Operators for "and", "not" and "or". */
-	{Identifier}					{ addToken(Token.IDENTIFIER); }
+	{Identifier}					{ addToken(TokenTypes.IDENTIFIER); }
 
 	/* Numbers */
-	{Number}						{ addToken(Token.LITERAL_NUMBER_FLOAT); }
+	{Number}						{ addToken(TokenTypes.LITERAL_NUMBER_FLOAT); }
 
 	/* Ended with a line not in a string or comment. */
 	<<EOF>>						{ addNullToken(); return firstToken; }
 
 	/* Catch any other (unhandled) characters. */
-	.							{ addToken(Token.IDENTIFIER); }
+	.							{ addToken(TokenTypes.IDENTIFIER); }
 
 }
 
 
 <MLC> {
 	[^\n\]]+					{}
-	\n						{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken; }
-	{LongStringEnd}			{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE); }
+	\n						{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken; }
+	{LongStringEnd}			{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE); }
 	\]						{}
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken; }
 }
 
 
 <LONGSTRING> {
 	[^\n\]]+					{}
-	\n						{ addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken; }
-	{LongStringEnd}			{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.LITERAL_STRING_DOUBLE_QUOTE); }
+	\n						{ addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken; }
+	{LongStringEnd}			{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); }
 	\]						{}
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken; }
 }
 
 
 <LINECOMMENT> {
 	[^\n]+					{}
-	\n						{ addToken(start,zzStartRead-1, Token.COMMENT_EOL); return firstToken; }
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_EOL); return firstToken; }
+	\n						{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); return firstToken; }
 }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/LuaTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/LuaTokenMaker.java
@@ -550,18 +550,18 @@ public class LuaTokenMaker extends AbstractJFlexTokenMaker {
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = Token.NULL;
+		int state = TokenTypes.NULL;
 		switch (initialTokenType) {
-			case Token.COMMENT_MULTILINE:
+			case TokenTypes.COMMENT_MULTILINE:
 				state = MLC;
 				start = text.offset;
 				break;
-			case Token.LITERAL_STRING_DOUBLE_QUOTE:
+			case TokenTypes.LITERAL_STRING_DOUBLE_QUOTE:
 				state = LONGSTRING;
 				start = text.offset;
 				break;
 			default:
-				state = Token.NULL;
+				state = TokenTypes.NULL;
 		}
 
 		s = text;
@@ -845,7 +845,7 @@ public class LuaTokenMaker extends AbstractJFlexTokenMaker {
           }
         case 24: break;
         case 13:
-          { addToken(Token.LITERAL_CHAR);
+          { addToken(TokenTypes.LITERAL_CHAR);
           }
         case 25: break;
         case 15:
@@ -853,19 +853,19 @@ public class LuaTokenMaker extends AbstractJFlexTokenMaker {
           }
         case 26: break;
         case 19:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE);
           }
         case 27: break;
         case 4:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 28: break;
         case 2:
-          { addToken(Token.LITERAL_NUMBER_FLOAT);
+          { addToken(TokenTypes.LITERAL_NUMBER_FLOAT);
           }
         case 29: break;
         case 17:
-          { addToken(Token.RESERVED_WORD);
+          { addToken(TokenTypes.RESERVED_WORD);
           }
         case 30: break;
         case 21:
@@ -873,51 +873,51 @@ public class LuaTokenMaker extends AbstractJFlexTokenMaker {
           }
         case 31: break;
         case 7:
-          { addToken(Token.SEPARATOR);
+          { addToken(TokenTypes.SEPARATOR);
           }
         case 32: break;
         case 1:
-          { addToken(Token.IDENTIFIER);
+          { addToken(TokenTypes.IDENTIFIER);
           }
         case 33: break;
         case 18:
-          { addToken(Token.FUNCTION);
+          { addToken(TokenTypes.FUNCTION);
           }
         case 34: break;
         case 5:
-          { addToken(Token.ERROR_CHAR); addNullToken(); return firstToken;
+          { addToken(TokenTypes.ERROR_CHAR); addNullToken(); return firstToken;
           }
         case 35: break;
         case 6:
-          { addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
+          { addToken(TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
           }
         case 36: break;
         case 23:
-          { addToken(Token.DATA_TYPE);
+          { addToken(TokenTypes.DATA_TYPE);
           }
         case 37: break;
         case 22:
-          { addToken(Token.LITERAL_BOOLEAN);
+          { addToken(TokenTypes.LITERAL_BOOLEAN);
           }
         case 38: break;
         case 20:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.LITERAL_STRING_DOUBLE_QUOTE);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
           }
         case 39: break;
         case 14:
-          { addToken(Token.LITERAL_STRING_DOUBLE_QUOTE);
+          { addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
           }
         case 40: break;
         case 11:
-          { addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
           }
         case 41: break;
         case 12:
-          { addToken(start,zzStartRead-1, Token.COMMENT_EOL); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); return firstToken;
           }
         case 42: break;
         case 8:
-          { addToken(Token.OPERATOR);
+          { addToken(TokenTypes.OPERATOR);
           }
         case 43: break;
         case 16:
@@ -929,7 +929,7 @@ public class LuaTokenMaker extends AbstractJFlexTokenMaker {
           }
         case 45: break;
         case 10:
-          { addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken;
           }
         case 46: break;
         default:
@@ -941,15 +941,15 @@ public class LuaTokenMaker extends AbstractJFlexTokenMaker {
             }
             case 204: break;
             case LONGSTRING: {
-              addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
             }
             case 205: break;
             case LINECOMMENT: {
-              addToken(start,zzStartRead-1, Token.COMMENT_EOL); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); return firstToken;
             }
             case 206: break;
             case MLC: {
-              addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken;
             }
             case 207: break;
             default:

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/MakefileTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/MakefileTokenMaker.flex
@@ -128,7 +128,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 	 *         enabled.
 	 */
 	public boolean getMarkOccurrencesOfTokenType(int type) {
-		return type==Token.IDENTIFIER || type==Token.VARIABLE;
+		return type==TokenTypes.IDENTIFIER || type==TokenTypes.VARIABLE;
 	}
 
 
@@ -152,7 +152,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 		s = text;
 		try {
 			yyreset(zzReader);
-			yybegin(Token.NULL);
+			yybegin(TokenTypes.NULL);
 			return yylex();
 		} catch (IOException ioe) {
 			ioe.printStackTrace();
@@ -266,41 +266,41 @@ Operator				= ([\:\+\?]?"=")
 	"define" |
 	"endef" |
 	"ifdef" |
-	"ifndef"					{ addToken(Token.RESERVED_WORD); }
+	"ifndef"					{ addToken(TokenTypes.RESERVED_WORD); }
 
 	{LineTerminator}				{ addNullToken(); return firstToken; }
 
-	{Label}							{ addToken(Token.PREPROCESSOR); }
-	{Identifier}					{ addToken(Token.IDENTIFIER); }
+	{Label}							{ addToken(TokenTypes.PREPROCESSOR); }
+	{Identifier}					{ addToken(TokenTypes.IDENTIFIER); }
 
-	{WhiteSpace}+					{ addToken(Token.WHITESPACE); }
+	{WhiteSpace}+					{ addToken(TokenTypes.WHITESPACE); }
 
 	/* String/Character literals. */
-	{CharLiteral}					{ addToken(Token.LITERAL_CHAR); }
-	{UnclosedCharLiteral}			{ addToken(Token.ERROR_CHAR); addNullToken(); return firstToken; }
-	{StringLiteral}					{ addToken(Token.LITERAL_STRING_DOUBLE_QUOTE); }
-	{UnclosedStringLiteral}			{ addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
-	{BacktickLiteral}				{ addToken(Token.LITERAL_BACKQUOTE); }
-	{BacktickLiteral}				{ addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
+	{CharLiteral}					{ addToken(TokenTypes.LITERAL_CHAR); }
+	{UnclosedCharLiteral}			{ addToken(TokenTypes.ERROR_CHAR); addNullToken(); return firstToken; }
+	{StringLiteral}					{ addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); }
+	{UnclosedStringLiteral}			{ addToken(TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
+	{BacktickLiteral}				{ addToken(TokenTypes.LITERAL_BACKQUOTE); }
+	{BacktickLiteral}				{ addToken(TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
 
 	/* Variables. */
 	{CurlyVarStart}					{ if (varDepths==null) { varDepths = new Stack<>(); } else { varDepths.clear(); } varDepths.push(Boolean.TRUE); start = zzMarkedPos-2; yybegin(VAR); }
 	{ParenVarStart}					{ if (varDepths==null) { varDepths = new Stack<>(); } else { varDepths.clear(); } varDepths.push(Boolean.FALSE); start = zzMarkedPos-2; yybegin(VAR); }
 
 	/* Comment literals. */
-	{LineCommentBegin}.*			{ addToken(Token.COMMENT_EOL); addNullToken(); return firstToken; }
+	{LineCommentBegin}.*			{ addToken(TokenTypes.COMMENT_EOL); addNullToken(); return firstToken; }
 
 	/* Operators. */
-	{Operator}					{ addToken(Token.OPERATOR); }
+	{Operator}					{ addToken(TokenTypes.OPERATOR); }
 
 	/* Numbers */
-	{IntegerLiteral}				{ addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
+	{IntegerLiteral}				{ addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT); }
 
 	/* Ended with a line not in a string or comment. */
 	<<EOF>>						{ addNullToken(); return firstToken; }
 
 	/* Catch-all for anything else. */
-	.							{ addToken(Token.IDENTIFIER); }
+	.							{ addToken(TokenTypes.IDENTIFIER); }
 
 }
 
@@ -310,7 +310,7 @@ Operator				= ([\:\+\?]?"=")
 							if (!varDepths.empty() && Boolean.TRUE.equals(varDepths.peek())) {
 								varDepths.pop();
 								if (varDepths.empty()) {
-									addToken(start,zzStartRead, Token.VARIABLE); yybegin(YYINITIAL);
+									addToken(start,zzStartRead, TokenTypes.VARIABLE); yybegin(YYINITIAL);
 								}
 							}
 						}
@@ -318,13 +318,13 @@ Operator				= ([\:\+\?]?"=")
 							if (!varDepths.empty() && Boolean.FALSE.equals(varDepths.peek())) {
 								varDepths.pop();
 								if (varDepths.empty()) {
-									addToken(start,zzStartRead, Token.VARIABLE); yybegin(YYINITIAL);
+									addToken(start,zzStartRead, TokenTypes.VARIABLE); yybegin(YYINITIAL);
 								}
 							}
 						}
 	"${"				{ varDepths.push(Boolean.TRUE); }
 	"$("				{ varDepths.push(Boolean.FALSE); }
 	"$"					{}
-	"#".*				{ int temp1 = zzStartRead; int temp2 = zzMarkedPos; addToken(start,zzStartRead-1, Token.VARIABLE); addToken(temp1, temp2-1, Token.COMMENT_EOL); addNullToken(); return firstToken; }
-	<<EOF>>				{ addToken(start,zzStartRead-1, Token.VARIABLE); addNullToken(); return firstToken; }
+	"#".*				{ int temp1 = zzStartRead; int temp2 = zzMarkedPos; addToken(start,zzStartRead-1, TokenTypes.VARIABLE); addToken(temp1, temp2-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken; }
+	<<EOF>>				{ addToken(start,zzStartRead-1, TokenTypes.VARIABLE); addNullToken(); return firstToken; }
 }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/MakefileTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/MakefileTokenMaker.java
@@ -416,7 +416,7 @@ public class MakefileTokenMaker extends AbstractJFlexTokenMaker {
 	 *         enabled.
 	 */
 	public boolean getMarkOccurrencesOfTokenType(int type) {
-		return type==Token.IDENTIFIER || type==Token.VARIABLE;
+		return type==TokenTypes.IDENTIFIER || type==TokenTypes.VARIABLE;
 	}
 
 
@@ -440,7 +440,7 @@ public class MakefileTokenMaker extends AbstractJFlexTokenMaker {
 		s = text;
 		try {
 			yyreset(zzReader);
-			yybegin(Token.NULL);
+			yybegin(TokenTypes.NULL);
 			return yylex();
 		} catch (IOException ioe) {
 			ioe.printStackTrace();
@@ -714,7 +714,7 @@ public class MakefileTokenMaker extends AbstractJFlexTokenMaker {
 
       switch (zzAction < 0 ? zzAction : ZZ_ACTION[zzAction]) {
         case 13:
-          { addToken(Token.PREPROCESSOR);
+          { addToken(TokenTypes.PREPROCESSOR);
           }
         case 22: break;
         case 3:
@@ -722,15 +722,15 @@ public class MakefileTokenMaker extends AbstractJFlexTokenMaker {
           }
         case 23: break;
         case 16:
-          { addToken(Token.LITERAL_CHAR);
+          { addToken(TokenTypes.LITERAL_CHAR);
           }
         case 24: break;
         case 4:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 25: break;
         case 21:
-          { addToken(Token.RESERVED_WORD);
+          { addToken(TokenTypes.RESERVED_WORD);
           }
         case 26: break;
         case 20:
@@ -738,7 +738,7 @@ public class MakefileTokenMaker extends AbstractJFlexTokenMaker {
           }
         case 27: break;
         case 18:
-          { addToken(Token.LITERAL_BACKQUOTE);
+          { addToken(TokenTypes.LITERAL_BACKQUOTE);
           }
         case 28: break;
         case 19:
@@ -746,23 +746,23 @@ public class MakefileTokenMaker extends AbstractJFlexTokenMaker {
           }
         case 29: break;
         case 1:
-          { addToken(Token.IDENTIFIER);
+          { addToken(TokenTypes.IDENTIFIER);
           }
         case 30: break;
         case 5:
-          { addToken(Token.ERROR_CHAR); addNullToken(); return firstToken;
+          { addToken(TokenTypes.ERROR_CHAR); addNullToken(); return firstToken;
           }
         case 31: break;
         case 6:
-          { addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
+          { addToken(TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
           }
         case 32: break;
         case 10:
-          { int temp1 = zzStartRead; int temp2 = zzMarkedPos; addToken(start,zzStartRead-1, Token.VARIABLE); addToken(temp1, temp2-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+          { int temp1 = zzStartRead; int temp2 = zzMarkedPos; addToken(start,zzStartRead-1, TokenTypes.VARIABLE); addToken(temp1, temp2-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
           }
         case 33: break;
         case 17:
-          { addToken(Token.LITERAL_STRING_DOUBLE_QUOTE);
+          { addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
           }
         case 34: break;
         case 14:
@@ -773,13 +773,13 @@ public class MakefileTokenMaker extends AbstractJFlexTokenMaker {
           { if (!varDepths.empty() && Boolean.TRUE.equals(varDepths.peek())) {
 								varDepths.pop();
 								if (varDepths.empty()) {
-									addToken(start,zzStartRead, Token.VARIABLE); yybegin(YYINITIAL);
+									addToken(start,zzStartRead, TokenTypes.VARIABLE); yybegin(YYINITIAL);
 								}
 							}
           }
         case 36: break;
         case 7:
-          { addToken(Token.COMMENT_EOL); addNullToken(); return firstToken;
+          { addToken(TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
           }
         case 37: break;
         case 15:
@@ -787,18 +787,18 @@ public class MakefileTokenMaker extends AbstractJFlexTokenMaker {
           }
         case 38: break;
         case 2:
-          { addToken(Token.LITERAL_NUMBER_DECIMAL_INT);
+          { addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT);
           }
         case 39: break;
         case 8:
-          { addToken(Token.OPERATOR);
+          { addToken(TokenTypes.OPERATOR);
           }
         case 40: break;
         case 11:
           { if (!varDepths.empty() && Boolean.FALSE.equals(varDepths.peek())) {
 								varDepths.pop();
 								if (varDepths.empty()) {
-									addToken(start,zzStartRead, Token.VARIABLE); yybegin(YYINITIAL);
+									addToken(start,zzStartRead, TokenTypes.VARIABLE); yybegin(YYINITIAL);
 								}
 							}
           }
@@ -812,7 +812,7 @@ public class MakefileTokenMaker extends AbstractJFlexTokenMaker {
             zzAtEOF = true;
             switch (zzLexicalState) {
             case VAR: {
-              addToken(start,zzStartRead-1, Token.VARIABLE); addNullToken(); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.VARIABLE); addNullToken(); return firstToken;
             }
             case 128: break;
             case YYINITIAL: {

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/MarkdownTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/MarkdownTokenMaker.flex
@@ -446,12 +446,12 @@ EmailAddress            = ([^@]+@[^@]+\.[^@]+)
     {HeadingStart}.*            {
                                     // In almost all cases, '#' is the beginning of a heading
                                     if (getNoTokensIdentifiedYet()) {
-                                        addToken(Token.RESERVED_WORD);
+                                        addToken(TokenTypes.RESERVED_WORD);
                                     }
                                     // If for some reason it isn't, highlight it as an identifier and continue on
                                     else {
                                         int count = yylength();
-                                        addToken(zzStartRead, zzStartRead, Token.IDENTIFIER);
+                                        addToken(zzStartRead, zzStartRead, TokenTypes.IDENTIFIER);
                                         zzMarkedPos -= (count - 1);
                                     }
                                 }
@@ -508,12 +508,12 @@ EmailAddress            = ([^@]+@[^@]+\.[^@]+)
     ">".*                       {
                                     // In many cases, '>' is the beginning of a block quote
                                     if (TokenUtils.isBlankOrAllWhiteSpace(firstToken)) {
-                                        addToken(Token.COMMENT_EOL);
+                                        addToken(TokenTypes.COMMENT_EOL);
                                     }
                                     // But if not, highlight it as an identifier and continue on
                                     else {
                                         int count = yylength();
-                                        addToken(zzStartRead, zzStartRead, Token.IDENTIFIER);
+                                        addToken(zzStartRead, zzStartRead, TokenTypes.IDENTIFIER);
                                         zzMarkedPos -= (count - 1);
                                     }
                                 }
@@ -537,35 +537,35 @@ EmailAddress            = ([^@]+@[^@]+\.[^@]+)
                                         }
                                         else {
                                             // "hr" markup with following content is invalid
-                                            addToken(start, start + 2, Token.IDENTIFIER);
+                                            addToken(start, start + 2, TokenTypes.IDENTIFIER);
                                             zzMarkedPos = start + 3;
                                         }
                                     }
                                     else {
                                         // The "hr" markup is really just an identifier
-                                        addToken(start, start + 2, Token.IDENTIFIER);
+                                        addToken(start, start + 2, TokenTypes.IDENTIFIER);
                                         zzMarkedPos = start + 3;
                                     }
                                 }
 
 	"<"({Letter}|{Digit})+		{
 									int count = yylength();
-									addToken(zzStartRead,zzStartRead, Token.MARKUP_TAG_DELIMITER);
+									addToken(zzStartRead,zzStartRead, TokenTypes.MARKUP_TAG_DELIMITER);
 									zzMarkedPos -= (count-1); //yypushback(count-1);
 									yybegin(INTAG_CHECK_TAG_NAME);
 								}
 	"</"({Letter}|{Digit})+		{
 									int count = yylength();
-									addToken(zzStartRead,zzStartRead+1, Token.MARKUP_TAG_DELIMITER);
+									addToken(zzStartRead,zzStartRead+1, TokenTypes.MARKUP_TAG_DELIMITER);
 									zzMarkedPos -= (count-2); //yypushback(count-2);
 									yybegin(INTAG_CHECK_TAG_NAME);
 								}
-	"<"							{ addToken(Token.MARKUP_TAG_DELIMITER); yybegin(INTAG); }
-	"</"						{ addToken(Token.MARKUP_TAG_DELIMITER); yybegin(INTAG); }
+	"<"							{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(INTAG); }
+	"</"						{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(INTAG); }
 	{LineTerminator}			{ addNullToken(); return firstToken; }
-	{Identifier}				{ addToken(Token.IDENTIFIER); } // Catches everything.
-	{EntityReference}			{ addToken(Token.MARKUP_ENTITY_REFERENCE); }
-	{Whitespace}				{ addToken(Token.WHITESPACE); }
+	{Identifier}				{ addToken(TokenTypes.IDENTIFIER); } // Catches everything.
+	{EntityReference}			{ addToken(TokenTypes.MARKUP_ENTITY_REFERENCE); }
+	{Whitespace}				{ addToken(TokenTypes.WHITESPACE); }
 	<<EOF>>					{ addNullToken(); return firstToken; }
 }
 
@@ -693,19 +693,19 @@ EmailAddress            = ([^@]+@[^@]+\.[^@]+)
 	[uU] |
 	[uU][lL] |
 	[vV][aA][rR] |
-	[vV][iI][dD][eE][oO]    { addToken(Token.MARKUP_TAG_NAME); }
+	[vV][iI][dD][eE][oO]    { addToken(TokenTypes.MARKUP_TAG_NAME); }
 	{InTagIdentifier}		{ /* A non-recognized HTML tag name */ yypushback(yylength()); yybegin(INTAG); }
 	.						{ /* Shouldn't happen */ yypushback(1); yybegin(INTAG); }
 	<<EOF>>					{ addToken(zzMarkedPos,zzMarkedPos, INTERNAL_INTAG); return firstToken; }
 }
 
 <INTAG> {
-	"/"						{ addToken(Token.MARKUP_TAG_DELIMITER); }
-	{InTagIdentifier}			{ addToken(Token.MARKUP_TAG_ATTRIBUTE); }
-	{Whitespace}				{ addToken(Token.WHITESPACE); }
-	"="						{ addToken(Token.OPERATOR); }
-	"/>"						{ yybegin(YYINITIAL); addToken(Token.MARKUP_TAG_DELIMITER); }
-	">"						{ yybegin(YYINITIAL); addToken(Token.MARKUP_TAG_DELIMITER); }
+	"/"						{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); }
+	{InTagIdentifier}			{ addToken(TokenTypes.MARKUP_TAG_ATTRIBUTE); }
+	{Whitespace}				{ addToken(TokenTypes.WHITESPACE); }
+	"="						{ addToken(TokenTypes.OPERATOR); }
+	"/>"						{ yybegin(YYINITIAL); addToken(TokenTypes.MARKUP_TAG_DELIMITER); }
+	">"						{ yybegin(YYINITIAL); addToken(TokenTypes.MARKUP_TAG_DELIMITER); }
 	[\"]						{ start = zzMarkedPos-1; yybegin(INATTR_DOUBLE); }
 	[\']						{ start = zzMarkedPos-1; yybegin(INATTR_SINGLE); }
 	<<EOF>>					{ addToken(zzMarkedPos,zzMarkedPos, INTERNAL_INTAG); return firstToken; }
@@ -713,69 +713,69 @@ EmailAddress            = ([^@]+@[^@]+\.[^@]+)
 
 <INATTR_DOUBLE> {
 	[^\"]*						{}
-	[\"]						{ yybegin(INTAG); addToken(start,zzStartRead, Token.MARKUP_TAG_ATTRIBUTE_VALUE); }
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE); return firstToken; }
+	[\"]						{ yybegin(INTAG); addToken(start,zzStartRead, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE); return firstToken; }
 }
 
 <INATTR_SINGLE> {
 	[^\']*						{}
-	[\']						{ yybegin(INTAG); addToken(start,zzStartRead, Token.MARKUP_TAG_ATTRIBUTE_VALUE); }
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE); return firstToken; }
+	[\']						{ yybegin(INTAG); addToken(start,zzStartRead, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE); return firstToken; }
 }
 
 <BOLDITALIC1> {
     [^*]*                       {}
-    [*][*][*]                   { addToken(start,zzStartRead + 2, Token.FUNCTION); yybegin(YYINITIAL); }
+    [*][*][*]                   { addToken(start,zzStartRead + 2, TokenTypes.FUNCTION); yybegin(YYINITIAL); }
     [*]                         {}
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.FUNCTION); addEndToken(INTERNAL_IN_BOLDITALIC1); return firstToken; }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.FUNCTION); addEndToken(INTERNAL_IN_BOLDITALIC1); return firstToken; }
 }
 <BOLDITALIC2> {
     [^_]*                       {}
-    [_][_][_]                   { addToken(start,zzStartRead + 2, Token.FUNCTION); yybegin(YYINITIAL); }
+    [_][_][_]                   { addToken(start,zzStartRead + 2, TokenTypes.FUNCTION); yybegin(YYINITIAL); }
     [_]                         {}
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.FUNCTION); addEndToken(INTERNAL_IN_BOLDITALIC2); return firstToken; }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.FUNCTION); addEndToken(INTERNAL_IN_BOLDITALIC2); return firstToken; }
 }
 
 <BOLD1> {
     [^*]*                       {}
-    [*][*]                      { addToken(start,zzStartRead + 1, Token.RESERVED_WORD_2); yybegin(YYINITIAL); }
+    [*][*]                      { addToken(start,zzStartRead + 1, TokenTypes.RESERVED_WORD_2); yybegin(YYINITIAL); }
     [*]                         {}
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.RESERVED_WORD_2); addEndToken(INTERNAL_IN_BOLD1); return firstToken; }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.RESERVED_WORD_2); addEndToken(INTERNAL_IN_BOLD1); return firstToken; }
 }
 <BOLD2> {
     [^_]*                       {}
-    [_][_]                      { addToken(start,zzStartRead + 1, Token.RESERVED_WORD_2); yybegin(YYINITIAL); }
+    [_][_]                      { addToken(start,zzStartRead + 1, TokenTypes.RESERVED_WORD_2); yybegin(YYINITIAL); }
     [_]                         {}
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.RESERVED_WORD_2); addEndToken(INTERNAL_IN_BOLD2); return firstToken; }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.RESERVED_WORD_2); addEndToken(INTERNAL_IN_BOLD2); return firstToken; }
 }
 
 <ITALIC1> {
     [^*]*                       {}
-    [*]                         { addToken(start,zzStartRead, Token.DATA_TYPE); yybegin(YYINITIAL); }
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.DATA_TYPE); addEndToken(INTERNAL_IN_ITALIC1); return firstToken; }
+    [*]                         { addToken(start,zzStartRead, TokenTypes.DATA_TYPE); yybegin(YYINITIAL); }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.DATA_TYPE); addEndToken(INTERNAL_IN_ITALIC1); return firstToken; }
 }
 <ITALIC2> {
     [^_]*                       {}
-    [_]                         { addToken(start,zzStartRead, Token.DATA_TYPE); yybegin(YYINITIAL); }
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.DATA_TYPE); addEndToken(INTERNAL_IN_ITALIC2); return firstToken; }
+    [_]                         { addToken(start,zzStartRead, TokenTypes.DATA_TYPE); yybegin(YYINITIAL); }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.DATA_TYPE); addEndToken(INTERNAL_IN_ITALIC2); return firstToken; }
 }
 
 <STRIKETHROUGH> {
     [^~]*                       {}
-    [~][~]                      { addToken(start,zzStartRead + 1, Token.OPERATOR); yybegin(YYINITIAL); }
+    [~][~]                      { addToken(start,zzStartRead + 1, TokenTypes.OPERATOR); yybegin(YYINITIAL); }
     [~]                         {}
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.OPERATOR); addEndToken(INTERNAL_IN_STRIKETHROUGH); return firstToken; }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.OPERATOR); addEndToken(INTERNAL_IN_STRIKETHROUGH); return firstToken; }
 }
 
 <CODE> {
     [^`]*                       {}
-    [`]                         { addToken(start,zzStartRead, Token.PREPROCESSOR); yybegin(YYINITIAL); }
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.PREPROCESSOR); addEndToken(INTERNAL_IN_CODE); return firstToken; }
+    [`]                         { addToken(start,zzStartRead, TokenTypes.PREPROCESSOR); yybegin(YYINITIAL); }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.PREPROCESSOR); addEndToken(INTERNAL_IN_CODE); return firstToken; }
 }
 
 <SYNTAX_HIGHLIGHTING> {
     [^`]*                       {}
-    [`][`][`]                   { addToken(start,zzStartRead + 2, Token.PREPROCESSOR); yybegin(YYINITIAL); }
+    [`][`][`]                   { addToken(start,zzStartRead + 2, TokenTypes.PREPROCESSOR); yybegin(YYINITIAL); }
     [`]                         {}
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.PREPROCESSOR); addEndToken(INTERNAL_IN_SYNTAX_HIGHLIGHTING); return firstToken; }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.PREPROCESSOR); addEndToken(INTERNAL_IN_SYNTAX_HIGHLIGHTING); return firstToken; }
 }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/MarkdownTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/MarkdownTokenMaker.java
@@ -1455,7 +1455,7 @@ public class MarkdownTokenMaker extends AbstractMarkupTokenMaker {
 
       switch (zzAction < 0 ? zzAction : ZZ_ACTION[zzAction]) {
         case 2:
-          { addToken(Token.IDENTIFIER);
+          { addToken(TokenTypes.IDENTIFIER);
           }
         case 44: break;
         case 27:
@@ -1463,11 +1463,11 @@ public class MarkdownTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 45: break;
         case 38:
-          { addToken(start,zzStartRead + 2, Token.FUNCTION); yybegin(YYINITIAL);
+          { addToken(start,zzStartRead + 2, TokenTypes.FUNCTION); yybegin(YYINITIAL);
           }
         case 46: break;
         case 17:
-          { yybegin(YYINITIAL); addToken(Token.MARKUP_TAG_DELIMITER);
+          { yybegin(YYINITIAL); addToken(TokenTypes.MARKUP_TAG_DELIMITER);
           }
         case 47: break;
         case 11:
@@ -1477,18 +1477,18 @@ public class MarkdownTokenMaker extends AbstractMarkupTokenMaker {
         case 12:
           { // In many cases, '>' is the beginning of a block quote
                                     if (TokenUtils.isBlankOrAllWhiteSpace(firstToken)) {
-                                        addToken(Token.COMMENT_EOL);
+                                        addToken(TokenTypes.COMMENT_EOL);
                                     }
                                     // But if not, highlight it as an identifier and continue on
                                     else {
                                         int count = yylength();
-                                        addToken(zzStartRead, zzStartRead, Token.IDENTIFIER);
+                                        addToken(zzStartRead, zzStartRead, TokenTypes.IDENTIFIER);
                                         zzMarkedPos -= (count - 1);
                                     }
           }
         case 49: break;
         case 30:
-          { addToken(start,zzStartRead + 1, Token.RESERVED_WORD_2); yybegin(YYINITIAL);
+          { addToken(start,zzStartRead + 1, TokenTypes.RESERVED_WORD_2); yybegin(YYINITIAL);
           }
         case 50: break;
         case 28:
@@ -1515,7 +1515,7 @@ public class MarkdownTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 53: break;
         case 6:
-          { addToken(Token.MARKUP_TAG_DELIMITER); yybegin(INTAG);
+          { addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(INTAG);
           }
         case 54: break;
         case 4:
@@ -1527,12 +1527,12 @@ public class MarkdownTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 56: break;
         case 24:
-          { addToken(start,zzStartRead, Token.PREPROCESSOR); yybegin(YYINITIAL);
+          { addToken(start,zzStartRead, TokenTypes.PREPROCESSOR); yybegin(YYINITIAL);
           }
         case 57: break;
         case 26:
           { int count = yylength();
-									addToken(zzStartRead,zzStartRead, Token.MARKUP_TAG_DELIMITER);
+									addToken(zzStartRead,zzStartRead, TokenTypes.MARKUP_TAG_DELIMITER);
 									zzMarkedPos -= (count-1); //yypushback(count-1);
 									yybegin(INTAG_CHECK_TAG_NAME);
           }
@@ -1560,7 +1560,7 @@ public class MarkdownTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 60: break;
         case 22:
-          { yybegin(INTAG); addToken(start,zzStartRead, Token.MARKUP_TAG_ATTRIBUTE_VALUE);
+          { yybegin(INTAG); addToken(start,zzStartRead, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE);
           }
         case 61: break;
         case 14:
@@ -1570,12 +1570,12 @@ public class MarkdownTokenMaker extends AbstractMarkupTokenMaker {
         case 8:
           { // In almost all cases, '#' is the beginning of a heading
                                     if (getNoTokensIdentifiedYet()) {
-                                        addToken(Token.RESERVED_WORD);
+                                        addToken(TokenTypes.RESERVED_WORD);
                                     }
                                     // If for some reason it isn't, highlight it as an identifier and continue on
                                     else {
                                         int count = yylength();
-                                        addToken(zzStartRead, zzStartRead, Token.IDENTIFIER);
+                                        addToken(zzStartRead, zzStartRead, TokenTypes.IDENTIFIER);
                                         zzMarkedPos -= (count - 1);
                                     }
           }
@@ -1598,13 +1598,13 @@ public class MarkdownTokenMaker extends AbstractMarkupTokenMaker {
                                         }
                                         else {
                                             // "hr" markup with following content is invalid
-                                            addToken(start, start + 2, Token.IDENTIFIER);
+                                            addToken(start, start + 2, TokenTypes.IDENTIFIER);
                                             zzMarkedPos = start + 3;
                                         }
                                     }
                                     else {
                                         // The "hr" markup is really just an identifier
-                                        addToken(start, start + 2, Token.IDENTIFIER);
+                                        addToken(start, start + 2, TokenTypes.IDENTIFIER);
                                         zzMarkedPos = start + 3;
                                     }
           }
@@ -1614,11 +1614,11 @@ public class MarkdownTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 67: break;
         case 5:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 68: break;
         case 21:
-          { addToken(Token.MARKUP_TAG_NAME);
+          { addToken(TokenTypes.MARKUP_TAG_NAME);
           }
         case 69: break;
         case 35:
@@ -1626,7 +1626,7 @@ public class MarkdownTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 70: break;
         case 23:
-          { addToken(start,zzStartRead, Token.DATA_TYPE); yybegin(YYINITIAL);
+          { addToken(start,zzStartRead, TokenTypes.DATA_TYPE); yybegin(YYINITIAL);
           }
         case 71: break;
         case 16:
@@ -1634,11 +1634,11 @@ public class MarkdownTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 72: break;
         case 13:
-          { addToken(Token.MARKUP_TAG_ATTRIBUTE);
+          { addToken(TokenTypes.MARKUP_TAG_ATTRIBUTE);
           }
         case 73: break;
         case 7:
-          { addToken(Token.MARKUP_ENTITY_REFERENCE);
+          { addToken(TokenTypes.MARKUP_ENTITY_REFERENCE);
           }
         case 74: break;
         case 41:
@@ -1651,11 +1651,11 @@ public class MarkdownTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 75: break;
         case 39:
-          { addToken(start,zzStartRead + 2, Token.PREPROCESSOR); yybegin(YYINITIAL);
+          { addToken(start,zzStartRead + 2, TokenTypes.PREPROCESSOR); yybegin(YYINITIAL);
           }
         case 76: break;
         case 31:
-          { addToken(start,zzStartRead + 1, Token.OPERATOR); yybegin(YYINITIAL);
+          { addToken(start,zzStartRead + 1, TokenTypes.OPERATOR); yybegin(YYINITIAL);
           }
         case 77: break;
         case 40:
@@ -1670,7 +1670,7 @@ public class MarkdownTokenMaker extends AbstractMarkupTokenMaker {
         case 78: break;
         case 33:
           { int count = yylength();
-									addToken(zzStartRead,zzStartRead+1, Token.MARKUP_TAG_DELIMITER);
+									addToken(zzStartRead,zzStartRead+1, TokenTypes.MARKUP_TAG_DELIMITER);
 									zzMarkedPos -= (count-2); //yypushback(count-2);
 									yybegin(INTAG_CHECK_TAG_NAME);
           }
@@ -1688,7 +1688,7 @@ public class MarkdownTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 82: break;
         case 18:
-          { addToken(Token.OPERATOR);
+          { addToken(TokenTypes.OPERATOR);
           }
         case 83: break;
         case 25:
@@ -1696,7 +1696,7 @@ public class MarkdownTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 84: break;
         case 15:
-          { addToken(Token.MARKUP_TAG_DELIMITER);
+          { addToken(TokenTypes.MARKUP_TAG_DELIMITER);
           }
         case 85: break;
         case 1:
@@ -1708,7 +1708,7 @@ public class MarkdownTokenMaker extends AbstractMarkupTokenMaker {
             zzAtEOF = true;
             switch (zzLexicalState) {
             case CODE: {
-              addToken(start,zzStartRead-1, Token.PREPROCESSOR); addEndToken(INTERNAL_IN_CODE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.PREPROCESSOR); addEndToken(INTERNAL_IN_CODE); return firstToken;
             }
             case 343: break;
             case INTAG_CHECK_TAG_NAME: {
@@ -1716,43 +1716,43 @@ public class MarkdownTokenMaker extends AbstractMarkupTokenMaker {
             }
             case 344: break;
             case STRIKETHROUGH: {
-              addToken(start,zzStartRead-1, Token.OPERATOR); addEndToken(INTERNAL_IN_STRIKETHROUGH); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.OPERATOR); addEndToken(INTERNAL_IN_STRIKETHROUGH); return firstToken;
             }
             case 345: break;
             case BOLDITALIC2: {
-              addToken(start,zzStartRead-1, Token.FUNCTION); addEndToken(INTERNAL_IN_BOLDITALIC2); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.FUNCTION); addEndToken(INTERNAL_IN_BOLDITALIC2); return firstToken;
             }
             case 346: break;
             case BOLDITALIC1: {
-              addToken(start,zzStartRead-1, Token.FUNCTION); addEndToken(INTERNAL_IN_BOLDITALIC1); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.FUNCTION); addEndToken(INTERNAL_IN_BOLDITALIC1); return firstToken;
             }
             case 347: break;
             case ITALIC2: {
-              addToken(start,zzStartRead-1, Token.DATA_TYPE); addEndToken(INTERNAL_IN_ITALIC2); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.DATA_TYPE); addEndToken(INTERNAL_IN_ITALIC2); return firstToken;
             }
             case 348: break;
             case ITALIC1: {
-              addToken(start,zzStartRead-1, Token.DATA_TYPE); addEndToken(INTERNAL_IN_ITALIC1); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.DATA_TYPE); addEndToken(INTERNAL_IN_ITALIC1); return firstToken;
             }
             case 349: break;
             case BOLD2: {
-              addToken(start,zzStartRead-1, Token.RESERVED_WORD_2); addEndToken(INTERNAL_IN_BOLD2); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.RESERVED_WORD_2); addEndToken(INTERNAL_IN_BOLD2); return firstToken;
             }
             case 350: break;
             case BOLD1: {
-              addToken(start,zzStartRead-1, Token.RESERVED_WORD_2); addEndToken(INTERNAL_IN_BOLD1); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.RESERVED_WORD_2); addEndToken(INTERNAL_IN_BOLD1); return firstToken;
             }
             case 351: break;
             case SYNTAX_HIGHLIGHTING: {
-              addToken(start,zzStartRead-1, Token.PREPROCESSOR); addEndToken(INTERNAL_IN_SYNTAX_HIGHLIGHTING); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.PREPROCESSOR); addEndToken(INTERNAL_IN_SYNTAX_HIGHLIGHTING); return firstToken;
             }
             case 352: break;
             case INATTR_SINGLE: {
-              addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE); return firstToken;
             }
             case 353: break;
             case INATTR_DOUBLE: {
-              addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE); return firstToken;
             }
             case 354: break;
             case YYINITIAL: {

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/MxmlTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/MxmlTokenMaker.flex
@@ -258,13 +258,13 @@ import org.fife.ui.rsyntaxtextarea.*;
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = Token.NULL;
+		int state = TokenTypes.NULL;
 		switch (initialTokenType) {
-			case Token.MARKUP_COMMENT:
+			case TokenTypes.MARKUP_COMMENT:
 				state = COMMENT;
 				start = text.offset;
 				break;
-			case Token.MARKUP_DTD:
+			case TokenTypes.MARKUP_DTD:
 				state = DTD;
 				start = text.offset;
 				break;
@@ -276,7 +276,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 				state = INATTR_SINGLE;
 				start = text.offset;
 				break;
-			case Token.MARKUP_PROCESSING_INSTRUCTION:
+			case TokenTypes.MARKUP_PROCESSING_INSTRUCTION:
 				state = PI;
 				start = text.offset;
 				break;
@@ -304,12 +304,12 @@ import org.fife.ui.rsyntaxtextarea.*;
 				state = AS_MLC;
 				start = text.offset;
 				break;
-			case Token.MARKUP_CDATA:
+			case TokenTypes.MARKUP_CDATA:
 				state = CDATA;
 				start = text.offset;
 				break;
 			default:
-				state = Token.NULL;
+				state = TokenTypes.NULL;
 		}
 
 		s = text;
@@ -468,14 +468,14 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 
 <YYINITIAL> {
 	"<!--"						{ start = zzMarkedPos-4; yybegin(COMMENT); }
-	{CDataBegin}					{ addToken(Token.MARKUP_CDATA_DELIMITER); start = zzMarkedPos; yybegin(CDATA); }
+	{CDataBegin}					{ addToken(TokenTypes.MARKUP_CDATA_DELIMITER); start = zzMarkedPos; yybegin(CDATA); }
 	"<!"							{ start = zzMarkedPos-2; yybegin(DTD); }
 	"<?"							{ start = zzMarkedPos-2; yybegin(PI); }
 	"<"{TagName}				{
 									int count = yylength();
 									String tag = yytext(); // Get before addToken calls
-									addToken(zzStartRead,zzStartRead, Token.MARKUP_TAG_DELIMITER);
-									addToken(zzMarkedPos-(count-1), zzMarkedPos-1, Token.MARKUP_TAG_NAME);
+									addToken(zzStartRead,zzStartRead, TokenTypes.MARKUP_TAG_DELIMITER);
+									addToken(zzMarkedPos-(count-1), zzMarkedPos-1, TokenTypes.MARKUP_TAG_NAME);
 									if (tag.endsWith(":Script") || tag.equals("<Script")) {
 										yybegin(INTAG_SCRIPT);
 									}
@@ -485,51 +485,51 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 								}
 	"</"{TagName}				{
 									int count = yylength();
-									addToken(zzStartRead,zzStartRead+1, Token.MARKUP_TAG_DELIMITER);
-									addToken(zzMarkedPos-(count-2), zzMarkedPos-1, Token.MARKUP_TAG_NAME);
+									addToken(zzStartRead,zzStartRead+1, TokenTypes.MARKUP_TAG_DELIMITER);
+									addToken(zzMarkedPos-(count-2), zzMarkedPos-1, TokenTypes.MARKUP_TAG_NAME);
 									yybegin(INTAG);
 								}
-	"<"							{ addToken(Token.MARKUP_TAG_DELIMITER); yybegin(INTAG); }
-	"</"						{ addToken(Token.MARKUP_TAG_DELIMITER); yybegin(INTAG); }
+	"<"							{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(INTAG); }
+	"</"						{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(INTAG); }
 	{LineTerminator}				{ addNullToken(); return firstToken; }
-	{Identifier}					{ addToken(Token.IDENTIFIER); }
-	{EntityReference}					{ addToken(Token.MARKUP_ENTITY_REFERENCE); }
-	{Whitespace}+					{ addToken(Token.WHITESPACE); }
+	{Identifier}					{ addToken(TokenTypes.IDENTIFIER); }
+	{EntityReference}					{ addToken(TokenTypes.MARKUP_ENTITY_REFERENCE); }
+	{Whitespace}+					{ addToken(TokenTypes.WHITESPACE); }
 	<<EOF>>						{ addNullToken(); return firstToken; }
 }
 
 <COMMENT> {
 	[^hwf\n\-]+						{}
-	{URL}						{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.MARKUP_COMMENT); addHyperlinkToken(temp,zzMarkedPos-1, Token.MARKUP_COMMENT); start = zzMarkedPos; }
+	{URL}						{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.MARKUP_COMMENT); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.MARKUP_COMMENT); start = zzMarkedPos; }
 	[hwf]						{}
-	"-->"						{ yybegin(YYINITIAL); addToken(start,zzStartRead+2, Token.MARKUP_COMMENT); }
+	"-->"						{ yybegin(YYINITIAL); addToken(start,zzStartRead+2, TokenTypes.MARKUP_COMMENT); }
 	"-"							{}
 	{LineTerminator} |
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.MARKUP_COMMENT); return firstToken; }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_COMMENT); return firstToken; }
 }
 
 <PI> {
 	[^\n\?]+						{}
-	{LineTerminator}				{ addToken(start,zzStartRead-1, Token.MARKUP_PROCESSING_INSTRUCTION); return firstToken; }
-	"?>"							{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.MARKUP_PROCESSING_INSTRUCTION); }
+	{LineTerminator}				{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_PROCESSING_INSTRUCTION); return firstToken; }
+	"?>"							{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.MARKUP_PROCESSING_INSTRUCTION); }
 	"?"							{}
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.MARKUP_PROCESSING_INSTRUCTION); return firstToken; }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_PROCESSING_INSTRUCTION); return firstToken; }
 }
 
 <DTD> {
 	[^\n>]+					{}
-	{LineTerminator}			{ addToken(start,zzStartRead-1, Token.MARKUP_DTD); return firstToken; }
-	">"						{ yybegin(YYINITIAL); addToken(start,zzStartRead, Token.MARKUP_DTD); }
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.MARKUP_DTD); return firstToken; }
+	{LineTerminator}			{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_DTD); return firstToken; }
+	">"						{ yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.MARKUP_DTD); }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_DTD); return firstToken; }
 }
 
 <INTAG> {
-	{InTagIdentifier}				{ addToken(Token.MARKUP_TAG_ATTRIBUTE); }
-	{Whitespace}+					{ addToken(Token.WHITESPACE); }
-	"="							{ addToken(Token.OPERATOR); }
-	"/"							{ addToken(Token.MARKUP_TAG_DELIMITER); /* Not valid but we'll still accept it */ }
-	"/>"						{ yybegin(YYINITIAL); addToken(Token.MARKUP_TAG_DELIMITER); }
-	">"							{ yybegin(YYINITIAL); addToken(Token.MARKUP_TAG_DELIMITER); }
+	{InTagIdentifier}				{ addToken(TokenTypes.MARKUP_TAG_ATTRIBUTE); }
+	{Whitespace}+					{ addToken(TokenTypes.WHITESPACE); }
+	"="							{ addToken(TokenTypes.OPERATOR); }
+	"/"							{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); /* Not valid but we'll still accept it */ }
+	"/>"						{ yybegin(YYINITIAL); addToken(TokenTypes.MARKUP_TAG_DELIMITER); }
+	">"							{ yybegin(YYINITIAL); addToken(TokenTypes.MARKUP_TAG_DELIMITER); }
 	[\"]						{ start = zzMarkedPos-1; yybegin(INATTR_DOUBLE); }
 	[\']						{ start = zzMarkedPos-1; yybegin(INATTR_SINGLE); }
 	<<EOF>>						{ addToken(start,zzStartRead-1, INTERNAL_INTAG); return firstToken; }
@@ -537,23 +537,23 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 
 <INATTR_DOUBLE> {
 	[^\"]*						{}
-	[\"]						{ yybegin(INTAG); addToken(start,zzStartRead, Token.MARKUP_TAG_ATTRIBUTE_VALUE); }
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE); return firstToken; }
+	[\"]						{ yybegin(INTAG); addToken(start,zzStartRead, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE); return firstToken; }
 }
 
 <INATTR_SINGLE> {
 	[^\']*						{}
-	[\']						{ yybegin(INTAG); addToken(start,zzStartRead, Token.MARKUP_TAG_ATTRIBUTE_VALUE); }
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE); return firstToken; }
+	[\']						{ yybegin(INTAG); addToken(start,zzStartRead, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE); return firstToken; }
 }
 
 <INTAG_SCRIPT> {
-	{InTagIdentifier}				{ addToken(Token.MARKUP_TAG_ATTRIBUTE); }
-	{Whitespace}+					{ addToken(Token.WHITESPACE); }
-	"="							{ addToken(Token.OPERATOR); }
-	"/"							{ addToken(Token.MARKUP_TAG_DELIMITER); /* Not valid but we'll still accept it */ }
-	"/>"						{ yybegin(YYINITIAL); addToken(Token.MARKUP_TAG_DELIMITER); }
-	">"							{ yybegin(AS); addToken(Token.MARKUP_TAG_DELIMITER); }
+	{InTagIdentifier}				{ addToken(TokenTypes.MARKUP_TAG_ATTRIBUTE); }
+	{Whitespace}+					{ addToken(TokenTypes.WHITESPACE); }
+	"="							{ addToken(TokenTypes.OPERATOR); }
+	"/"							{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); /* Not valid but we'll still accept it */ }
+	"/>"						{ yybegin(YYINITIAL); addToken(TokenTypes.MARKUP_TAG_DELIMITER); }
+	">"							{ yybegin(AS); addToken(TokenTypes.MARKUP_TAG_DELIMITER); }
 	[\"]						{ start = zzMarkedPos-1; yybegin(INATTR_DOUBLE_SCRIPT); }
 	[\']						{ start = zzMarkedPos-1; yybegin(INATTR_SINGLE_SCRIPT); }
 	<<EOF>>						{ addToken(start,zzStartRead-1, INTERNAL_INTAG_SCRIPT); return firstToken; }
@@ -561,21 +561,21 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 
 <INATTR_DOUBLE_SCRIPT> {
 	[^\"]*						{}
-	[\"]						{ yybegin(INTAG_SCRIPT); addToken(start,zzStartRead, Token.MARKUP_TAG_ATTRIBUTE_VALUE); }
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE_QUOTE_SCRIPT); return firstToken; }
+	[\"]						{ yybegin(INTAG_SCRIPT); addToken(start,zzStartRead, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE_QUOTE_SCRIPT); return firstToken; }
 }
 
 <INATTR_SINGLE_SCRIPT> {
 	[^\']*						{}
-	[\']						{ yybegin(INTAG_SCRIPT); addToken(start,zzStartRead, Token.MARKUP_TAG_ATTRIBUTE_VALUE); }
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE_QUOTE_SCRIPT); return firstToken; }
+	[\']						{ yybegin(INTAG_SCRIPT); addToken(start,zzStartRead, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE_QUOTE_SCRIPT); return firstToken; }
 }
 
 <CDATA> {
 	[^\]]+						{}
-	{CDataEnd}					{ int temp=zzStartRead; yybegin(YYINITIAL); addToken(start,zzStartRead-1, Token.MARKUP_CDATA); addToken(temp,zzMarkedPos-1, Token.MARKUP_CDATA_DELIMITER); }
+	{CDataEnd}					{ int temp=zzStartRead; yybegin(YYINITIAL); addToken(start,zzStartRead-1, TokenTypes.MARKUP_CDATA); addToken(temp,zzMarkedPos-1, TokenTypes.MARKUP_CDATA_DELIMITER); }
 	"]"							{}
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.MARKUP_CDATA); return firstToken; }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_CDATA); return firstToken; }
 }
 
 <AS> {
@@ -589,17 +589,17 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 								  }
 								  int tagNameLen = tagNameEnd - 1;
 								  yybegin(YYINITIAL);
-								  addToken(zzStartRead,zzStartRead+1, Token.MARKUP_TAG_DELIMITER);
-								  addToken(origStart+2,origStart+2+tagNameLen-1, Token.MARKUP_TAG_NAME);
+								  addToken(zzStartRead,zzStartRead+1, TokenTypes.MARKUP_TAG_DELIMITER);
+								  addToken(origStart+2,origStart+2+tagNameLen-1, TokenTypes.MARKUP_TAG_NAME);
 								  if (tagNameEnd<text.length()-2) {
-								      addToken(origStart+tagNameEnd+1, zzMarkedPos-2, Token.WHITESPACE);
+								      addToken(origStart+tagNameEnd+1, zzMarkedPos-2, TokenTypes.WHITESPACE);
 								  }
-								  addToken(zzMarkedPos-1,zzMarkedPos-1, Token.MARKUP_TAG_DELIMITER);
+								  addToken(zzMarkedPos-1,zzMarkedPos-1, TokenTypes.MARKUP_TAG_DELIMITER);
 								}
 
 	/* ActionScript snippets are usually wrapped in CDATA. */
 	{CDataBegin} |
-	{CDataEnd}					{ addToken(Token.MARKUP_CDATA_DELIMITER); }
+	{CDataEnd}					{ addToken(TokenTypes.MARKUP_CDATA_DELIMITER); }
 	
 	/* Keywords */
 	"add" |
@@ -666,7 +666,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"with" |
 
 	"null" |
-	"undefined"				{ addToken(Token.RESERVED_WORD); }
+	"undefined"				{ addToken(TokenTypes.RESERVED_WORD); }
 
 	/* Built-in objects (good idea not to use these names!) */
 	"Array" |
@@ -689,7 +689,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"Vector" |
 	"XML" |
 	"XMLNode" |
-	"XMLSocket"			{ addToken(Token.DATA_TYPE); }
+	"XMLSocket"			{ addToken(TokenTypes.DATA_TYPE); }
 
 	/* Global functions */
 	"call" |
@@ -736,50 +736,50 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"unescape" |
 	"unloadMovie" |
 	"unloadMovieNum" |
-	"updateAfterEvent"			{ addToken(Token.FUNCTION); }
+	"updateAfterEvent"			{ addToken(TokenTypes.FUNCTION); }
 
 	/* Booleans. */
-	{AS_BooleanLiteral}			{ addToken(Token.LITERAL_BOOLEAN); }
+	{AS_BooleanLiteral}			{ addToken(TokenTypes.LITERAL_BOOLEAN); }
 
 	{LineTerminator}				{ addEndToken(INTERNAL_IN_AS); return firstToken; }
 
-	{AS_Identifier}					{ addToken(Token.IDENTIFIER); }
+	{AS_Identifier}					{ addToken(TokenTypes.IDENTIFIER); }
 
-	{Whitespace}+					{ addToken(Token.WHITESPACE); }
+	{Whitespace}+					{ addToken(TokenTypes.WHITESPACE); }
 
 	/* String/Character literals. */
-	{AS_CharLiteral}					{ addToken(Token.LITERAL_CHAR); }
-	{AS_UnclosedCharLiteral}			{ addToken(Token.ERROR_CHAR); addNullToken(); return firstToken; }
-	{AS_ErrorCharLiteral}				{ addToken(Token.ERROR_CHAR); }
-	{AS_StringLiteral}				{ addToken(Token.LITERAL_STRING_DOUBLE_QUOTE); }
-	{AS_UnclosedStringLiteral}			{ addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
-	{AS_ErrorStringLiteral}			{ addToken(Token.ERROR_STRING_DOUBLE); }
+	{AS_CharLiteral}					{ addToken(TokenTypes.LITERAL_CHAR); }
+	{AS_UnclosedCharLiteral}			{ addToken(TokenTypes.ERROR_CHAR); addNullToken(); return firstToken; }
+	{AS_ErrorCharLiteral}				{ addToken(TokenTypes.ERROR_CHAR); }
+	{AS_StringLiteral}				{ addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); }
+	{AS_UnclosedStringLiteral}			{ addToken(TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
+	{AS_ErrorStringLiteral}			{ addToken(TokenTypes.ERROR_STRING_DOUBLE); }
 
 	/* Comment literals. */
-	"/**/"						{ addToken(Token.COMMENT_MULTILINE); }
+	"/**/"						{ addToken(TokenTypes.COMMENT_MULTILINE); }
 	{AS_MLCBegin}					{ start = zzMarkedPos-2; yybegin(AS_MLC); }
 	{AS_LineCommentBegin}			{ start = zzMarkedPos-2; yybegin(AS_EOL_COMMENT); }
 
 	/* Separators. */
-	{AS_Separator}					{ addToken(Token.SEPARATOR); }
-	{AS_Separator2}					{ addToken(Token.IDENTIFIER); }
+	{AS_Separator}					{ addToken(TokenTypes.SEPARATOR); }
+	{AS_Separator2}					{ addToken(TokenTypes.IDENTIFIER); }
 
 	/* Operators. */
-	{AS_Operator}					{ addToken(Token.OPERATOR); }
+	{AS_Operator}					{ addToken(TokenTypes.OPERATOR); }
 
 	/* Numbers */
-	{AS_IntegerLiteral}				{ addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
-	{AS_HexLiteral}					{ addToken(Token.LITERAL_NUMBER_HEXADECIMAL); }
-	{AS_FloatLiteral}					{ addToken(Token.LITERAL_NUMBER_FLOAT); }
-	{AS_ErrorNumberFormat}				{ addToken(Token.ERROR_NUMBER_FORMAT); }
+	{AS_IntegerLiteral}				{ addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT); }
+	{AS_HexLiteral}					{ addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL); }
+	{AS_FloatLiteral}					{ addToken(TokenTypes.LITERAL_NUMBER_FLOAT); }
+	{AS_ErrorNumberFormat}				{ addToken(TokenTypes.ERROR_NUMBER_FORMAT); }
 
-	{AS_ErrorIdentifier}				{ addToken(Token.ERROR_IDENTIFIER); }
+	{AS_ErrorIdentifier}				{ addToken(TokenTypes.ERROR_IDENTIFIER); }
 
 	/* Ended with a line not in a string or comment. */
 	<<EOF>>						{ addEndToken(INTERNAL_IN_AS); return firstToken; }
 
 	/* Catch any other (unhandled) characters and flag them as bad. */
-	.							{ addToken(Token.ERROR_IDENTIFIER); }
+	.							{ addToken(TokenTypes.ERROR_IDENTIFIER); }
 
 }
 
@@ -787,22 +787,22 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 <AS_MLC> {
 
 	[^hwf\n\*]+				{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos; }
 	[hwf]					{}
 
-	\n						{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_AS_MLC); return firstToken; }
-	{AS_MLCEnd}				{ yybegin(AS); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE); }
+	\n						{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_AS_MLC); return firstToken; }
+	{AS_MLCEnd}				{ yybegin(AS); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE); }
 	\*						{}
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_AS_MLC); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_AS_MLC); return firstToken; }
 
 }
 
 
 <AS_EOL_COMMENT> {
 	[^hwf\n]+				{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos; }
 	[hwf]					{}
 	\n |
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_EOL); addEndToken(INTERNAL_IN_AS); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addEndToken(INTERNAL_IN_AS); return firstToken; }
 
 }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/MxmlTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/MxmlTokenMaker.java
@@ -2052,13 +2052,13 @@ public class MxmlTokenMaker extends AbstractMarkupTokenMaker {
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = Token.NULL;
+		int state = TokenTypes.NULL;
 		switch (initialTokenType) {
-			case Token.MARKUP_COMMENT:
+			case TokenTypes.MARKUP_COMMENT:
 				state = COMMENT;
 				start = text.offset;
 				break;
-			case Token.MARKUP_DTD:
+			case TokenTypes.MARKUP_DTD:
 				state = DTD;
 				start = text.offset;
 				break;
@@ -2070,7 +2070,7 @@ public class MxmlTokenMaker extends AbstractMarkupTokenMaker {
 				state = INATTR_SINGLE;
 				start = text.offset;
 				break;
-			case Token.MARKUP_PROCESSING_INSTRUCTION:
+			case TokenTypes.MARKUP_PROCESSING_INSTRUCTION:
 				state = PI;
 				start = text.offset;
 				break;
@@ -2098,12 +2098,12 @@ public class MxmlTokenMaker extends AbstractMarkupTokenMaker {
 				state = AS_MLC;
 				start = text.offset;
 				break;
-			case Token.MARKUP_CDATA:
+			case TokenTypes.MARKUP_CDATA:
 				state = CDATA;
 				start = text.offset;
 				break;
 			default:
-				state = Token.NULL;
+				state = TokenTypes.NULL;
 		}
 
 		s = text;
@@ -2395,27 +2395,27 @@ public class MxmlTokenMaker extends AbstractMarkupTokenMaker {
 
       switch (zzAction < 0 ? zzAction : ZZ_ACTION[zzAction]) {
         case 2:
-          { addToken(Token.IDENTIFIER);
+          { addToken(TokenTypes.IDENTIFIER);
           }
         case 59: break;
         case 53:
-          { addToken(Token.LITERAL_BOOLEAN);
+          { addToken(TokenTypes.LITERAL_BOOLEAN);
           }
         case 60: break;
         case 29:
-          { addToken(start,zzStartRead-1, Token.COMMENT_EOL); addEndToken(INTERNAL_IN_AS); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addEndToken(INTERNAL_IN_AS); return firstToken;
           }
         case 61: break;
         case 50:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.MARKUP_COMMENT); addHyperlinkToken(temp,zzMarkedPos-1, Token.MARKUP_COMMENT); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.MARKUP_COMMENT); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.MARKUP_COMMENT); start = zzMarkedPos;
           }
         case 62: break;
         case 51:
-          { addToken(Token.ERROR_CHAR);
+          { addToken(TokenTypes.ERROR_CHAR);
           }
         case 63: break;
         case 34:
-          { addToken(Token.ERROR_NUMBER_FORMAT);
+          { addToken(TokenTypes.ERROR_NUMBER_FORMAT);
           }
         case 64: break;
         case 24:
@@ -2427,25 +2427,25 @@ public class MxmlTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 66: break;
         case 13:
-          { yybegin(YYINITIAL); addToken(Token.MARKUP_TAG_DELIMITER);
+          { yybegin(YYINITIAL); addToken(TokenTypes.MARKUP_TAG_DELIMITER);
           }
         case 67: break;
         case 26:
-          { addToken(Token.ERROR_CHAR); addNullToken(); return firstToken;
+          { addToken(TokenTypes.ERROR_CHAR); addNullToken(); return firstToken;
           }
         case 68: break;
         case 38:
-          { addToken(Token.LITERAL_STRING_DOUBLE_QUOTE);
+          { addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
           }
         case 69: break;
         case 54:
-          { addToken(Token.FUNCTION);
+          { addToken(TokenTypes.FUNCTION);
           }
         case 70: break;
         case 43:
           { int count = yylength();
-									addToken(zzStartRead,zzStartRead+1, Token.MARKUP_TAG_DELIMITER);
-									addToken(zzMarkedPos-(count-2), zzMarkedPos-1, Token.MARKUP_TAG_NAME);
+									addToken(zzStartRead,zzStartRead+1, TokenTypes.MARKUP_TAG_DELIMITER);
+									addToken(zzMarkedPos-(count-2), zzMarkedPos-1, TokenTypes.MARKUP_TAG_NAME);
 									yybegin(INTAG);
           }
         case 71: break;
@@ -2454,43 +2454,43 @@ public class MxmlTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 72: break;
         case 27:
-          { addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
+          { addToken(TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
           }
         case 73: break;
         case 21:
-          { yybegin(INTAG_SCRIPT); addToken(start,zzStartRead, Token.MARKUP_TAG_ATTRIBUTE_VALUE);
+          { yybegin(INTAG_SCRIPT); addToken(start,zzStartRead, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE);
           }
         case 74: break;
         case 57:
-          { addToken(Token.MARKUP_CDATA_DELIMITER); start = zzMarkedPos; yybegin(CDATA);
+          { addToken(TokenTypes.MARKUP_CDATA_DELIMITER); start = zzMarkedPos; yybegin(CDATA);
           }
         case 75: break;
         case 22:
-          { addToken(Token.ERROR_IDENTIFIER);
+          { addToken(TokenTypes.ERROR_IDENTIFIER);
           }
         case 76: break;
         case 4:
-          { addToken(Token.MARKUP_TAG_DELIMITER); yybegin(INTAG);
+          { addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(INTAG);
           }
         case 77: break;
         case 28:
-          { addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_AS_MLC); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_AS_MLC); return firstToken;
           }
         case 78: break;
         case 46:
-          { addToken(Token.MARKUP_CDATA_DELIMITER);
+          { addToken(TokenTypes.MARKUP_CDATA_DELIMITER);
           }
         case 79: break;
         case 45:
-          { int temp=zzStartRead; yybegin(YYINITIAL); addToken(start,zzStartRead-1, Token.MARKUP_CDATA); addToken(temp,zzMarkedPos-1, Token.MARKUP_CDATA_DELIMITER);
+          { int temp=zzStartRead; yybegin(YYINITIAL); addToken(start,zzStartRead-1, TokenTypes.MARKUP_CDATA); addToken(temp,zzMarkedPos-1, TokenTypes.MARKUP_CDATA_DELIMITER);
           }
         case 80: break;
         case 17:
-          { yybegin(INTAG); addToken(start,zzStartRead, Token.MARKUP_TAG_ATTRIBUTE_VALUE);
+          { yybegin(INTAG); addToken(start,zzStartRead, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE);
           }
         case 81: break;
         case 37:
-          { addToken(Token.LITERAL_CHAR);
+          { addToken(TokenTypes.LITERAL_CHAR);
           }
         case 82: break;
         case 32:
@@ -2502,23 +2502,23 @@ public class MxmlTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 84: break;
         case 42:
-          { yybegin(AS); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE);
+          { yybegin(AS); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE);
           }
         case 85: break;
         case 7:
-          { addToken(start,zzStartRead-1, Token.MARKUP_COMMENT); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.MARKUP_COMMENT); return firstToken;
           }
         case 86: break;
         case 9:
-          { addToken(start,zzStartRead-1, Token.MARKUP_DTD); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.MARKUP_DTD); return firstToken;
           }
         case 87: break;
         case 36:
-          { addToken(Token.LITERAL_NUMBER_HEXADECIMAL);
+          { addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL);
           }
         case 88: break;
         case 8:
-          { addToken(start,zzStartRead-1, Token.MARKUP_PROCESSING_INSTRUCTION); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.MARKUP_PROCESSING_INSTRUCTION); return firstToken;
           }
         case 89: break;
         case 20:
@@ -2530,18 +2530,18 @@ public class MxmlTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 91: break;
         case 16:
-          { addToken(Token.MARKUP_TAG_DELIMITER); /* Not valid but we'll still accept it */
+          { addToken(TokenTypes.MARKUP_TAG_DELIMITER); /* Not valid but we'll still accept it */
           }
         case 92: break;
         case 5:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 93: break;
         case 30:
           { int count = yylength();
 									String tag = yytext(); // Get before addToken calls
-									addToken(zzStartRead,zzStartRead, Token.MARKUP_TAG_DELIMITER);
-									addToken(zzMarkedPos-(count-1), zzMarkedPos-1, Token.MARKUP_TAG_NAME);
+									addToken(zzStartRead,zzStartRead, TokenTypes.MARKUP_TAG_DELIMITER);
+									addToken(zzMarkedPos-(count-1), zzMarkedPos-1, TokenTypes.MARKUP_TAG_NAME);
 									if (tag.endsWith(":Script") || tag.equals("<Script")) {
 										yybegin(INTAG_SCRIPT);
 									}
@@ -2551,11 +2551,11 @@ public class MxmlTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 94: break;
         case 48:
-          { addToken(Token.DATA_TYPE);
+          { addToken(TokenTypes.DATA_TYPE);
           }
         case 95: break;
         case 23:
-          { addToken(Token.LITERAL_NUMBER_DECIMAL_INT);
+          { addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT);
           }
         case 96: break;
         case 14:
@@ -2563,19 +2563,19 @@ public class MxmlTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 97: break;
         case 11:
-          { addToken(Token.MARKUP_TAG_ATTRIBUTE);
+          { addToken(TokenTypes.MARKUP_TAG_ATTRIBUTE);
           }
         case 98: break;
         case 33:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.MARKUP_PROCESSING_INSTRUCTION);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.MARKUP_PROCESSING_INSTRUCTION);
           }
         case 99: break;
         case 6:
-          { addToken(Token.MARKUP_ENTITY_REFERENCE);
+          { addToken(TokenTypes.MARKUP_ENTITY_REFERENCE);
           }
         case 100: break;
         case 44:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead+2, Token.MARKUP_COMMENT);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead+2, TokenTypes.MARKUP_COMMENT);
           }
         case 101: break;
         case 40:
@@ -2587,15 +2587,15 @@ public class MxmlTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 103: break;
         case 39:
-          { addToken(Token.RESERVED_WORD);
+          { addToken(TokenTypes.RESERVED_WORD);
           }
         case 104: break;
         case 55:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos;
           }
         case 105: break;
         case 25:
-          { addToken(Token.SEPARATOR);
+          { addToken(TokenTypes.SEPARATOR);
           }
         case 106: break;
         case 3:
@@ -2603,27 +2603,27 @@ public class MxmlTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 107: break;
         case 10:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead, Token.MARKUP_DTD);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.MARKUP_DTD);
           }
         case 108: break;
         case 18:
-          { yybegin(AS); addToken(Token.MARKUP_TAG_DELIMITER);
+          { yybegin(AS); addToken(TokenTypes.MARKUP_TAG_DELIMITER);
           }
         case 109: break;
         case 12:
-          { addToken(Token.OPERATOR);
+          { addToken(TokenTypes.OPERATOR);
           }
         case 110: break;
         case 35:
-          { addToken(Token.LITERAL_NUMBER_FLOAT);
+          { addToken(TokenTypes.LITERAL_NUMBER_FLOAT);
           }
         case 111: break;
         case 56:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos;
           }
         case 112: break;
         case 52:
-          { addToken(Token.COMMENT_MULTILINE);
+          { addToken(TokenTypes.COMMENT_MULTILINE);
           }
         case 113: break;
         case 58:
@@ -2635,16 +2635,16 @@ public class MxmlTokenMaker extends AbstractMarkupTokenMaker {
 								  }
 								  int tagNameLen = tagNameEnd - 1;
 								  yybegin(YYINITIAL);
-								  addToken(zzStartRead,zzStartRead+1, Token.MARKUP_TAG_DELIMITER);
-								  addToken(origStart+2,origStart+2+tagNameLen-1, Token.MARKUP_TAG_NAME);
+								  addToken(zzStartRead,zzStartRead+1, TokenTypes.MARKUP_TAG_DELIMITER);
+								  addToken(origStart+2,origStart+2+tagNameLen-1, TokenTypes.MARKUP_TAG_NAME);
 								  if (tagNameEnd<text.length()-2) {
-								      addToken(origStart+tagNameEnd+1, zzMarkedPos-2, Token.WHITESPACE);
+								      addToken(origStart+tagNameEnd+1, zzMarkedPos-2, TokenTypes.WHITESPACE);
 								  }
-								  addToken(zzMarkedPos-1,zzMarkedPos-1, Token.MARKUP_TAG_DELIMITER);
+								  addToken(zzMarkedPos-1,zzMarkedPos-1, TokenTypes.MARKUP_TAG_DELIMITER);
           }
         case 114: break;
         case 47:
-          { addToken(Token.ERROR_STRING_DOUBLE);
+          { addToken(TokenTypes.ERROR_STRING_DOUBLE);
           }
         case 115: break;
         case 1:
@@ -2656,11 +2656,11 @@ public class MxmlTokenMaker extends AbstractMarkupTokenMaker {
             zzAtEOF = true;
             switch (zzLexicalState) {
             case AS_EOL_COMMENT: {
-              addToken(start,zzStartRead-1, Token.COMMENT_EOL); addEndToken(INTERNAL_IN_AS); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addEndToken(INTERNAL_IN_AS); return firstToken;
             }
             case 625: break;
             case AS_MLC: {
-              addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_AS_MLC); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_AS_MLC); return firstToken;
             }
             case 626: break;
             case INTAG_SCRIPT: {
@@ -2668,27 +2668,27 @@ public class MxmlTokenMaker extends AbstractMarkupTokenMaker {
             }
             case 627: break;
             case INATTR_DOUBLE_SCRIPT: {
-              addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE_QUOTE_SCRIPT); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE_QUOTE_SCRIPT); return firstToken;
             }
             case 628: break;
             case CDATA: {
-              addToken(start,zzStartRead-1, Token.MARKUP_CDATA); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_CDATA); return firstToken;
             }
             case 629: break;
             case INATTR_SINGLE_SCRIPT: {
-              addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE_QUOTE_SCRIPT); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE_QUOTE_SCRIPT); return firstToken;
             }
             case 630: break;
             case DTD: {
-              addToken(start,zzStartRead-1, Token.MARKUP_DTD); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_DTD); return firstToken;
             }
             case 631: break;
             case INATTR_SINGLE: {
-              addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE); return firstToken;
             }
             case 632: break;
             case INATTR_DOUBLE: {
-              addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE); return firstToken;
             }
             case 633: break;
             case YYINITIAL: {
@@ -2704,11 +2704,11 @@ public class MxmlTokenMaker extends AbstractMarkupTokenMaker {
             }
             case 636: break;
             case COMMENT: {
-              addToken(start,zzStartRead-1, Token.MARKUP_COMMENT); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_COMMENT); return firstToken;
             }
             case 637: break;
             case PI: {
-              addToken(start,zzStartRead-1, Token.MARKUP_PROCESSING_INSTRUCTION); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_PROCESSING_INSTRUCTION); return firstToken;
             }
             case 638: break;
             default:

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/NSISTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/NSISTokenMaker.flex
@@ -152,16 +152,16 @@ import org.fife.ui.rsyntaxtextarea.*;
 		// Start off in the proper state.
 		int state = YYINITIAL;
 		switch (initialTokenType) {
-			case Token.LITERAL_STRING_DOUBLE_QUOTE:
+			case TokenTypes.LITERAL_STRING_DOUBLE_QUOTE:
 				state = STRING;
 				break;
-			case Token.LITERAL_CHAR:
+			case TokenTypes.LITERAL_CHAR:
 				state = CHAR_LITERAL;
 				break;
-			case Token.LITERAL_BACKQUOTE:
+			case TokenTypes.LITERAL_BACKQUOTE:
 				state = BACKTICKS;
 				break;
-			case Token.COMMENT_MULTILINE:
+			case TokenTypes.COMMENT_MULTILINE:
 				state = MLC;
 				break;
 		}
@@ -282,7 +282,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"section" |
 	"sectionend" |
 	"subsection" |
-	"subsectionend"				{ addToken(Token.RESERVED_WORD); }
+	"subsectionend"				{ addToken(TokenTypes.RESERVED_WORD); }
 
 	/* Instructions */
 	"addbrandingimage" |
@@ -469,7 +469,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"quit" |
 	"seterrors" |
 	"strcmp" |
-	"strcmps"				{ addToken(Token.FUNCTION); }
+	"strcmps"				{ addToken(TokenTypes.FUNCTION); }
 
 	/* Compiler utility commands */
 	"!addincludedir" |
@@ -493,7 +493,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"!else" |
 	"!endif" |
 	"!macro" |
-	"!macroend"				{ addToken(Token.RESERVED_WORD); }
+	"!macroend"				{ addToken(TokenTypes.RESERVED_WORD); }
 
 	/* Global variables */
 	"$0" |
@@ -632,18 +632,18 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"OFFLINE" |
 	"READONLY" |
 	"SYSTEM" |
-	"TEMPORARY"						{ addToken(Token.VARIABLE); }
+	"TEMPORARY"						{ addToken(TokenTypes.VARIABLE); }
 
 	{LineTerminator}				{ addNullToken(); return firstToken; }
 
 	/* Operators. */
-	{Operator}					{ addToken(Token.OPERATOR); }
+	{Operator}					{ addToken(TokenTypes.OPERATOR); }
 
-	{BooleanLiteral}				{ addToken(Token.LITERAL_BOOLEAN); }
-	{Identifier}					{ addToken(Token.IDENTIFIER); }
-	{Variable}						{ addToken(Token.VARIABLE); }
+	{BooleanLiteral}				{ addToken(TokenTypes.LITERAL_BOOLEAN); }
+	{Identifier}					{ addToken(TokenTypes.IDENTIFIER); }
+	{Variable}						{ addToken(TokenTypes.VARIABLE); }
 
-	{WhiteSpace}+					{ addToken(Token.WHITESPACE); }
+	{WhiteSpace}+					{ addToken(TokenTypes.WHITESPACE); }
 
 	/* String/Character literals. */
 	\"							{ start = zzMarkedPos-1; yybegin(STRING); }
@@ -651,24 +651,24 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	\`							{ start = zzMarkedPos-1; yybegin(BACKTICKS); }
 
 	/* Comment literals. */
-	"/**/"						{ addToken(Token.COMMENT_MULTILINE); }
+	"/**/"						{ addToken(TokenTypes.COMMENT_MULTILINE); }
 	{MLCBegin}					{ start = zzMarkedPos-2; yybegin(MLC); }
 	{LineCommentBegin}			{ start = zzMarkedPos-1; yybegin(EOL_COMMENT); }
 
 	/* Separators. */
-	{Separator}					{ addToken(Token.SEPARATOR); }
-	{Separator2}					{ addToken(Token.IDENTIFIER); }
+	{Separator}					{ addToken(TokenTypes.SEPARATOR); }
+	{Separator2}					{ addToken(TokenTypes.IDENTIFIER); }
 
 	/* Numbers */
-	{IntegerLiteral}				{ addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
-	{HexLiteral}					{ addToken(Token.LITERAL_NUMBER_HEXADECIMAL); }
-	{ErrorNumberFormat}				{ addToken(Token.ERROR_NUMBER_FORMAT); }
+	{IntegerLiteral}				{ addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT); }
+	{HexLiteral}					{ addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL); }
+	{ErrorNumberFormat}				{ addToken(TokenTypes.ERROR_NUMBER_FORMAT); }
 
 	/* Ended with a line not in a string or comment. */
 	<<EOF>>						{ addNullToken(); return firstToken; }
 
 	/* Catch any other (unhandled) characters and flag them as identifiers. */
-	.							{ addToken(Token.IDENTIFIER); }
+	.							{ addToken(TokenTypes.IDENTIFIER); }
 
 }
 
@@ -677,14 +677,14 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	[^\n\\\$\"]+		{}
 	\\.					{ /* Skip all escaped chars. */ }
 	\\					{ /* Line ending in '\' => continue to next line. */
-							addToken(start,zzStartRead, Token.LITERAL_STRING_DOUBLE_QUOTE);
+							addToken(start,zzStartRead, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
 							return firstToken;
 						}
-	{Variable}			{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); addToken(temp,zzMarkedPos-1, Token.VARIABLE); start = zzMarkedPos; }
+	{Variable}			{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); addToken(temp,zzMarkedPos-1, TokenTypes.VARIABLE); start = zzMarkedPos; }
 	{VariableStart}		{}
-	\"					{ yybegin(YYINITIAL); addToken(start,zzStartRead, Token.LITERAL_STRING_DOUBLE_QUOTE); }
+	\"					{ yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); }
 	\n |
-	<<EOF>>				{ addToken(start,zzStartRead-1, Token.ERROR_STRING_DOUBLE); return firstToken; }
+	<<EOF>>				{ addToken(start,zzStartRead-1, TokenTypes.ERROR_STRING_DOUBLE); return firstToken; }
 }
 
 
@@ -692,14 +692,14 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	[^\n\\\$\']+		{}
 	\\.					{ /* Skip all escaped chars. */ }
 	\\					{ /* Line ending in '\' => continue to next line. */
-							addToken(start,zzStartRead, Token.LITERAL_CHAR);
+							addToken(start,zzStartRead, TokenTypes.LITERAL_CHAR);
 							return firstToken;
 						}
-	{Variable}			{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); addToken(temp,zzMarkedPos-1, Token.VARIABLE); start = zzMarkedPos; }
+	{Variable}			{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); addToken(temp,zzMarkedPos-1, TokenTypes.VARIABLE); start = zzMarkedPos; }
 	{VariableStart}		{}
-	\'					{ yybegin(YYINITIAL); addToken(start,zzStartRead, Token.LITERAL_CHAR); }
+	\'					{ yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.LITERAL_CHAR); }
 	\n |
-	<<EOF>>				{ addToken(start,zzStartRead-1, Token.ERROR_CHAR); return firstToken; }
+	<<EOF>>				{ addToken(start,zzStartRead-1, TokenTypes.ERROR_CHAR); return firstToken; }
 }
 
 
@@ -707,33 +707,33 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	[^\n\\\$\`]+		{}
 	\\.					{ /* Skip all escaped chars. */ }
 	\\					{ /* Line ending in '\' => continue to next line. */
-							addToken(start,zzStartRead, Token.LITERAL_BACKQUOTE);
+							addToken(start,zzStartRead, TokenTypes.LITERAL_BACKQUOTE);
 							return firstToken;
 						}
-	{Variable}			{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.LITERAL_BACKQUOTE); addToken(temp,zzMarkedPos-1, Token.VARIABLE); start = zzMarkedPos; }
+	{Variable}			{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.LITERAL_BACKQUOTE); addToken(temp,zzMarkedPos-1, TokenTypes.VARIABLE); start = zzMarkedPos; }
 	{VariableStart}		{}
-	\`					{ yybegin(YYINITIAL); addToken(start,zzStartRead, Token.LITERAL_BACKQUOTE); }
+	\`					{ yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.LITERAL_BACKQUOTE); }
 	\n |
-	<<EOF>>				{ addToken(start,zzStartRead-1, Token.LITERAL_BACKQUOTE); return firstToken; }
+	<<EOF>>				{ addToken(start,zzStartRead-1, TokenTypes.LITERAL_BACKQUOTE); return firstToken; }
 }
 
 
 <MLC> {
 	[^hwf\n\*]+				{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos; }
 	[hwf]					{}
 
-	\n						{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken; }
-	{MLCEnd}					{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE); }
+	\n						{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken; }
+	{MLCEnd}					{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE); }
 	\*						{}
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken; }
 }
 
 
 <EOL_COMMENT> {
 	[^hwf\n]+				{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos; }
 	[hwf]					{}
 	\n |
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken; }
 }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/NSISTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/NSISTokenMaker.java
@@ -2488,16 +2488,16 @@ public class NSISTokenMaker extends AbstractJFlexCTokenMaker {
 		// Start off in the proper state.
 		int state = YYINITIAL;
 		switch (initialTokenType) {
-			case Token.LITERAL_STRING_DOUBLE_QUOTE:
+			case TokenTypes.LITERAL_STRING_DOUBLE_QUOTE:
 				state = STRING;
 				break;
-			case Token.LITERAL_CHAR:
+			case TokenTypes.LITERAL_CHAR:
 				state = CHAR_LITERAL;
 				break;
-			case Token.LITERAL_BACKQUOTE:
+			case TokenTypes.LITERAL_BACKQUOTE:
 				state = BACKTICKS;
 				break;
-			case Token.COMMENT_MULTILINE:
+			case TokenTypes.COMMENT_MULTILINE:
 				state = MLC;
 				break;
 		}
@@ -2781,20 +2781,20 @@ public class NSISTokenMaker extends AbstractJFlexCTokenMaker {
 
       switch (zzAction < 0 ? zzAction : ZZ_ACTION[zzAction]) {
         case 1:
-          { addToken(Token.IDENTIFIER);
+          { addToken(TokenTypes.IDENTIFIER);
           }
         case 37: break;
         case 34:
-          { addToken(Token.LITERAL_BOOLEAN);
+          { addToken(TokenTypes.LITERAL_BOOLEAN);
           }
         case 38: break;
         case 29:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.LITERAL_BACKQUOTE); addToken(temp,zzMarkedPos-1, Token.VARIABLE); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.LITERAL_BACKQUOTE); addToken(temp,zzMarkedPos-1, TokenTypes.VARIABLE); start = zzMarkedPos;
           }
         case 39: break;
         case 19:
           { /* Line ending in '\' => continue to next line. */
-							addToken(start,zzStartRead, Token.LITERAL_BACKQUOTE);
+							addToken(start,zzStartRead, TokenTypes.LITERAL_BACKQUOTE);
 							return firstToken;
           }
         case 40: break;
@@ -2803,7 +2803,7 @@ public class NSISTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 41: break;
         case 24:
-          { addToken(Token.ERROR_NUMBER_FORMAT);
+          { addToken(TokenTypes.ERROR_NUMBER_FORMAT);
           }
         case 42: break;
         case 3:
@@ -2811,35 +2811,35 @@ public class NSISTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 43: break;
         case 32:
-          { addToken(Token.FUNCTION);
+          { addToken(TokenTypes.FUNCTION);
           }
         case 44: break;
         case 8:
-          { addToken(Token.VARIABLE);
+          { addToken(TokenTypes.VARIABLE);
           }
         case 45: break;
         case 16:
           { /* Line ending in '\' => continue to next line. */
-							addToken(start,zzStartRead, Token.LITERAL_CHAR);
+							addToken(start,zzStartRead, TokenTypes.LITERAL_CHAR);
 							return firstToken;
           }
         case 46: break;
         case 14:
           { /* Line ending in '\' => continue to next line. */
-							addToken(start,zzStartRead, Token.LITERAL_STRING_DOUBLE_QUOTE);
+							addToken(start,zzStartRead, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
 							return firstToken;
           }
         case 47: break;
         case 17:
-          { addToken(start,zzStartRead-1, Token.ERROR_CHAR); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.ERROR_CHAR); return firstToken;
           }
         case 48: break;
         case 18:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead, Token.LITERAL_CHAR);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.LITERAL_CHAR);
           }
         case 49: break;
         case 25:
-          { addToken(Token.LITERAL_NUMBER_HEXADECIMAL);
+          { addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL);
           }
         case 50: break;
         case 26:
@@ -2847,11 +2847,11 @@ public class NSISTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 51: break;
         case 7:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 52: break;
         case 30:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE);
           }
         case 53: break;
         case 10:
@@ -2859,11 +2859,11 @@ public class NSISTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 54: break;
         case 2:
-          { addToken(Token.LITERAL_NUMBER_DECIMAL_INT);
+          { addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT);
           }
         case 55: break;
         case 28:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); addToken(temp,zzMarkedPos-1, Token.VARIABLE); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); addToken(temp,zzMarkedPos-1, TokenTypes.VARIABLE); start = zzMarkedPos;
           }
         case 56: break;
         case 4:
@@ -2871,35 +2871,35 @@ public class NSISTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 57: break;
         case 21:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead, Token.LITERAL_BACKQUOTE);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.LITERAL_BACKQUOTE);
           }
         case 58: break;
         case 13:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead, Token.LITERAL_STRING_DOUBLE_QUOTE);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
           }
         case 59: break;
         case 15:
-          { addToken(start,zzStartRead-1, Token.ERROR_STRING_DOUBLE); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.ERROR_STRING_DOUBLE); return firstToken;
           }
         case 60: break;
         case 31:
-          { addToken(Token.RESERVED_WORD);
+          { addToken(TokenTypes.RESERVED_WORD);
           }
         case 61: break;
         case 35:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos;
           }
         case 62: break;
         case 20:
-          { addToken(start,zzStartRead-1, Token.LITERAL_BACKQUOTE); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.LITERAL_BACKQUOTE); return firstToken;
           }
         case 63: break;
         case 23:
-          { addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
           }
         case 64: break;
         case 9:
-          { addToken(Token.SEPARATOR);
+          { addToken(TokenTypes.SEPARATOR);
           }
         case 65: break;
         case 6:
@@ -2907,19 +2907,19 @@ public class NSISTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 66: break;
         case 22:
-          { addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken;
           }
         case 67: break;
         case 5:
-          { addToken(Token.OPERATOR);
+          { addToken(TokenTypes.OPERATOR);
           }
         case 68: break;
         case 36:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos;
           }
         case 69: break;
         case 33:
-          { addToken(Token.COMMENT_MULTILINE);
+          { addToken(TokenTypes.COMMENT_MULTILINE);
           }
         case 70: break;
         case 11:
@@ -2935,15 +2935,15 @@ public class NSISTokenMaker extends AbstractJFlexCTokenMaker {
             zzAtEOF = true;
             switch (zzLexicalState) {
             case EOL_COMMENT: {
-              addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
             }
             case 1322: break;
             case STRING: {
-              addToken(start,zzStartRead-1, Token.ERROR_STRING_DOUBLE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.ERROR_STRING_DOUBLE); return firstToken;
             }
             case 1323: break;
             case CHAR_LITERAL: {
-              addToken(start,zzStartRead-1, Token.ERROR_CHAR); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.ERROR_CHAR); return firstToken;
             }
             case 1324: break;
             case YYINITIAL: {
@@ -2951,11 +2951,11 @@ public class NSISTokenMaker extends AbstractJFlexCTokenMaker {
             }
             case 1325: break;
             case MLC: {
-              addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken;
             }
             case 1326: break;
             case BACKTICKS: {
-              addToken(start,zzStartRead-1, Token.LITERAL_BACKQUOTE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.LITERAL_BACKQUOTE); return firstToken;
             }
             case 1327: break;
             default:

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/PHPTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/PHPTokenMaker.flex
@@ -393,8 +393,8 @@ import org.fife.ui.rsyntaxtextarea.*;
 
 	@Override
 	public boolean getMarkOccurrencesOfTokenType(int type) {
-		return type==Token.FUNCTION || type==Token.VARIABLE ||
-				type==Token.MARKUP_TAG_NAME;
+		return type==TokenTypes.FUNCTION || type==TokenTypes.VARIABLE ||
+				type==TokenTypes.MARKUP_TAG_NAME;
 	}
 
 
@@ -439,7 +439,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 		// Start off in the proper state.
 		int state;
 		switch (initialTokenType) {
-			case Token.MARKUP_COMMENT:
+			case TokenTypes.MARKUP_COMMENT:
 				state = COMMENT;
 				break;
 			case INTERNAL_INTAG:
@@ -790,35 +790,35 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 <YYINITIAL> {
 	"<!--"						{ start = zzMarkedPos-4; yybegin(COMMENT); }
 	"<"[sS][cC][rR][iI][pP][tT]	{
-								  addToken(zzStartRead,zzStartRead, Token.MARKUP_TAG_DELIMITER);
-								  addToken(zzMarkedPos-6,zzMarkedPos-1, Token.MARKUP_TAG_NAME);
+								  addToken(zzStartRead,zzStartRead, TokenTypes.MARKUP_TAG_DELIMITER);
+								  addToken(zzMarkedPos-6,zzMarkedPos-1, TokenTypes.MARKUP_TAG_NAME);
 								  start = zzMarkedPos; yybegin(INTAG_SCRIPT);
 								}
 	"<"[sS][tT][yY][lL][eE]		{
-								  addToken(zzStartRead,zzStartRead, Token.MARKUP_TAG_DELIMITER);
-								  addToken(zzMarkedPos-5,zzMarkedPos-1, Token.MARKUP_TAG_NAME);
+								  addToken(zzStartRead,zzStartRead, TokenTypes.MARKUP_TAG_DELIMITER);
+								  addToken(zzMarkedPos-5,zzMarkedPos-1, TokenTypes.MARKUP_TAG_NAME);
 								  start = zzMarkedPos; cssPrevState = zzLexicalState; yybegin(INTAG_STYLE);
 								}
 	"<!"						{ start = zzMarkedPos-2; yybegin(DTD); }
-	{PHP_Start}					{ addToken(Token.MARKUP_TAG_DELIMITER); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP); }
+	{PHP_Start}					{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP); }
 	"<"({Letter}|{Digit})+		{
 									int count = yylength();
-									addToken(zzStartRead,zzStartRead, Token.MARKUP_TAG_DELIMITER);
+									addToken(zzStartRead,zzStartRead, TokenTypes.MARKUP_TAG_DELIMITER);
 									zzMarkedPos -= (count-1); //yypushback(count-1);
 									yybegin(INTAG_CHECK_TAG_NAME);
 								}
 	"</"({Letter}|{Digit})+		{
 									int count = yylength();
-									addToken(zzStartRead,zzStartRead+1, Token.MARKUP_TAG_DELIMITER);
+									addToken(zzStartRead,zzStartRead+1, TokenTypes.MARKUP_TAG_DELIMITER);
 									zzMarkedPos -= (count-2); //yypushback(count-2);
 									yybegin(INTAG_CHECK_TAG_NAME);
 								}
-	"<"							{ addToken(Token.MARKUP_TAG_DELIMITER); yybegin(INTAG); }
-	"</"						{ addToken(Token.MARKUP_TAG_DELIMITER); yybegin(INTAG); }
+	"<"							{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(INTAG); }
+	"</"						{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(INTAG); }
 	{LineTerminator}			{ addNullToken(); return firstToken; }
-	{Identifier}				{ addToken(Token.IDENTIFIER); } // Catches everything.
-	{EntityReference}				{ addToken(Token.MARKUP_ENTITY_REFERENCE); }
-	{Whitespace}				{ addToken(Token.WHITESPACE); }
+	{Identifier}				{ addToken(TokenTypes.IDENTIFIER); } // Catches everything.
+	{EntityReference}				{ addToken(TokenTypes.MARKUP_ENTITY_REFERENCE); }
+	{Whitespace}				{ addToken(TokenTypes.WHITESPACE); }
 	<<EOF>>					{ addNullToken(); return firstToken; }
 }
 
@@ -834,17 +834,17 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 
                             }
 	[hwf]					{}
-	"-->"					{ yybegin(YYINITIAL); addToken(start,zzStartRead+2, Token.MARKUP_COMMENT); }
+	"-->"					{ yybegin(YYINITIAL); addToken(start,zzStartRead+2, TokenTypes.MARKUP_COMMENT); }
 	"-"						{}
 	{LineTerminator} |
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.MARKUP_COMMENT); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_COMMENT); return firstToken; }
 }
 
 <DTD> {
 	[^\n>]+					{}
-	">"						{ yybegin(YYINITIAL); addToken(start,zzStartRead, Token.MARKUP_DTD); }
+	">"						{ yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.MARKUP_DTD); }
 	{LineTerminator} |
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.MARKUP_DTD); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_DTD); return firstToken; }
 }
 
 <INTAG_CHECK_TAG_NAME> {
@@ -973,106 +973,106 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	[uU] |
 	[uU][lL] |
 	[vV][aA][rR] |
-	[vV][iI][dD][eE][oO]    { addToken(Token.MARKUP_TAG_NAME); }
+	[vV][iI][dD][eE][oO]    { addToken(TokenTypes.MARKUP_TAG_NAME); }
 	{InTagIdentifier}		{ /* A non-recognized HTML tag name */ yypushback(yylength()); yybegin(INTAG); }
 	.						{ /* Shouldn't happen */ yypushback(1); yybegin(INTAG); }
 	<<EOF>>					{ addToken(zzMarkedPos,zzMarkedPos, INTERNAL_INTAG); return firstToken; }
 }
 
 <INTAG> {
-	{PHP_Start}				{ addToken(Token.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP); }
-	"/"						{ addToken(Token.MARKUP_TAG_DELIMITER); }
-	{InTagIdentifier}			{ addToken(Token.MARKUP_TAG_ATTRIBUTE); }
-	{Whitespace}				{ addToken(Token.WHITESPACE); }
-	"="						{ addToken(Token.OPERATOR); }
-	"/>"						{ yybegin(YYINITIAL); addToken(Token.MARKUP_TAG_DELIMITER); }
-	">"						{ yybegin(YYINITIAL); addToken(Token.MARKUP_TAG_DELIMITER); }
+	{PHP_Start}				{ addToken(TokenTypes.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP); }
+	"/"						{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); }
+	{InTagIdentifier}			{ addToken(TokenTypes.MARKUP_TAG_ATTRIBUTE); }
+	{Whitespace}				{ addToken(TokenTypes.WHITESPACE); }
+	"="						{ addToken(TokenTypes.OPERATOR); }
+	"/>"						{ yybegin(YYINITIAL); addToken(TokenTypes.MARKUP_TAG_DELIMITER); }
+	">"						{ yybegin(YYINITIAL); addToken(TokenTypes.MARKUP_TAG_DELIMITER); }
 	[\"]						{ start = zzMarkedPos-1; yybegin(INATTR_DOUBLE); }
 	[\']						{ start = zzMarkedPos-1; yybegin(INATTR_SINGLE); }
 	<<EOF>>					{ addToken(zzMarkedPos,zzMarkedPos, INTERNAL_INTAG); return firstToken; }
 }
 
 <INATTR_DOUBLE> {
-	{PHP_Start}					{ int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addToken(temp, zzMarkedPos-1, Token.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP); }
+	{PHP_Start}					{ int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addToken(temp, zzMarkedPos-1, TokenTypes.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP); }
 	[^\"<]*						{}
 	"<"							{ /* Allowing "<?" and "<?php" to start PHP */ }
-	[\"]						{ addToken(start,zzStartRead, Token.MARKUP_TAG_ATTRIBUTE_VALUE); yybegin(INTAG); }
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE); return firstToken; }
+	[\"]						{ addToken(start,zzStartRead, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); yybegin(INTAG); }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE); return firstToken; }
 }
 
 <INATTR_SINGLE> {
-	{PHP_Start}					{ int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addToken(temp, zzMarkedPos-1, Token.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP); }
+	{PHP_Start}					{ int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addToken(temp, zzMarkedPos-1, TokenTypes.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP); }
 	[^\'<]*						{}
 	"<"							{ /* Allowing "<?" and "<?php" to start PHP */ }
-	[\']						{ addToken(start,zzStartRead, Token.MARKUP_TAG_ATTRIBUTE_VALUE); yybegin(INTAG); }
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE); return firstToken; }
+	[\']						{ addToken(start,zzStartRead, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); yybegin(INTAG); }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE); return firstToken; }
 }
 
 <INTAG_SCRIPT> {
-	{PHP_Start}					{ addToken(Token.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP); }
-	{InTagIdentifier}			{ addToken(Token.MARKUP_TAG_ATTRIBUTE); }
-	"/>"					{	addToken(Token.MARKUP_TAG_DELIMITER); yybegin(YYINITIAL); }
-	"/"						{ addToken(Token.MARKUP_TAG_DELIMITER); } // Won't appear in valid HTML.
-	{Whitespace}				{ addToken(Token.WHITESPACE); }
-	"="						{ addToken(Token.OPERATOR); }
-	">"						{ addToken(Token.MARKUP_TAG_DELIMITER); yybegin(JAVASCRIPT, LANG_INDEX_JS); }
+	{PHP_Start}					{ addToken(TokenTypes.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP); }
+	{InTagIdentifier}			{ addToken(TokenTypes.MARKUP_TAG_ATTRIBUTE); }
+	"/>"					{	addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(YYINITIAL); }
+	"/"						{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); } // Won't appear in valid HTML.
+	{Whitespace}				{ addToken(TokenTypes.WHITESPACE); }
+	"="						{ addToken(TokenTypes.OPERATOR); }
+	">"						{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(JAVASCRIPT, LANG_INDEX_JS); }
 	[\"]						{ start = zzMarkedPos-1; yybegin(INATTR_DOUBLE_SCRIPT); }
 	[\']						{ start = zzMarkedPos-1; yybegin(INATTR_SINGLE_SCRIPT); }
 	<<EOF>>					{ addToken(zzMarkedPos,zzMarkedPos, INTERNAL_INTAG_SCRIPT); return firstToken; }
 }
 
 <INATTR_DOUBLE_SCRIPT> {
-	{PHP_Start}					{ int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addToken(temp, zzMarkedPos-1, Token.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP); }
+	{PHP_Start}					{ int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addToken(temp, zzMarkedPos-1, TokenTypes.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP); }
 	[^\"<]*						{}
 	"<"							{ /* Allowing "<?" and "<?php" to start PHP */ }
-	[\"]						{ addToken(start,zzStartRead, Token.MARKUP_TAG_ATTRIBUTE_VALUE); yybegin(INTAG_SCRIPT); }
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE_QUOTE_SCRIPT); return firstToken; }
+	[\"]						{ addToken(start,zzStartRead, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); yybegin(INTAG_SCRIPT); }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE_QUOTE_SCRIPT); return firstToken; }
 }
 
 <INATTR_SINGLE_SCRIPT> {
-	{PHP_Start}					{ int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addToken(temp, zzMarkedPos-1, Token.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP); }
+	{PHP_Start}					{ int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addToken(temp, zzMarkedPos-1, TokenTypes.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP); }
 	[^\'<]*						{}
 	"<"							{ /* Allowing "<?" and "<?php" to start PHP */ }
-	[\']						{ addToken(start,zzStartRead, Token.MARKUP_TAG_ATTRIBUTE_VALUE); yybegin(INTAG_SCRIPT); }
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE_QUOTE_SCRIPT); return firstToken; }
+	[\']						{ addToken(start,zzStartRead, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); yybegin(INTAG_SCRIPT); }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE_QUOTE_SCRIPT); return firstToken; }
 }
 
 <INTAG_STYLE> {
-	{PHP_Start}					{ addToken(Token.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP); }
-	{InTagIdentifier}			{ addToken(Token.MARKUP_TAG_ATTRIBUTE); }
-	"/>"					{	addToken(Token.MARKUP_TAG_DELIMITER); yybegin(YYINITIAL); }
-	"/"						{ addToken(Token.MARKUP_TAG_DELIMITER); } // Won't appear in valid HTML.
-	{Whitespace}				{ addToken(Token.WHITESPACE); }
-	"="						{ addToken(Token.OPERATOR); }
-	">"						{ addToken(Token.MARKUP_TAG_DELIMITER); yybegin(CSS, LANG_INDEX_CSS); }
+	{PHP_Start}					{ addToken(TokenTypes.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP); }
+	{InTagIdentifier}			{ addToken(TokenTypes.MARKUP_TAG_ATTRIBUTE); }
+	"/>"					{	addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(YYINITIAL); }
+	"/"						{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); } // Won't appear in valid HTML.
+	{Whitespace}				{ addToken(TokenTypes.WHITESPACE); }
+	"="						{ addToken(TokenTypes.OPERATOR); }
+	">"						{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(CSS, LANG_INDEX_CSS); }
 	[\"]						{ start = zzMarkedPos-1; yybegin(INATTR_DOUBLE_STYLE); }
 	[\']						{ start = zzMarkedPos-1; yybegin(INATTR_SINGLE_STYLE); }
 	<<EOF>>					{ addToken(zzMarkedPos,zzMarkedPos, INTERNAL_INTAG_STYLE); return firstToken; }
 }
 
 <INATTR_DOUBLE_STYLE> {
-	{PHP_Start}					{ int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addToken(temp, zzMarkedPos-1, Token.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP); }
+	{PHP_Start}					{ int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addToken(temp, zzMarkedPos-1, TokenTypes.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP); }
 	[^\"<]*						{}
 	"<"							{ /* Allowing "<?" and "<?php" to start PHP */ }
-	[\"]						{ yybegin(INTAG_STYLE); addToken(start,zzStartRead, Token.MARKUP_TAG_ATTRIBUTE_VALUE); }
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE_QUOTE_STYLE); return firstToken; }
+	[\"]						{ yybegin(INTAG_STYLE); addToken(start,zzStartRead, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE_QUOTE_STYLE); return firstToken; }
 }
 
 <INATTR_SINGLE_STYLE> {
-	{PHP_Start}					{ int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addToken(temp, zzMarkedPos-1, Token.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP); }
+	{PHP_Start}					{ int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addToken(temp, zzMarkedPos-1, TokenTypes.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP); }
 	[^\'<]*						{}
 	"<"							{ /* Allowing "<?" and "<?php" to start PHP */ }
-	[\']						{ yybegin(INTAG_STYLE); addToken(start,zzStartRead, Token.MARKUP_TAG_ATTRIBUTE_VALUE); }
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE_QUOTE_STYLE); return firstToken; }
+	[\']						{ yybegin(INTAG_STYLE); addToken(start,zzStartRead, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE_QUOTE_STYLE); return firstToken; }
 }
 
 <JAVASCRIPT> {
 
 	{EndScriptTag}					{
 								  yybegin(YYINITIAL, LANG_INDEX_DEFAULT);
-								  addToken(zzStartRead,zzStartRead+1, Token.MARKUP_TAG_DELIMITER);
-								  addToken(zzMarkedPos-7,zzMarkedPos-2, Token.MARKUP_TAG_NAME);
-								  addToken(zzMarkedPos-1,zzMarkedPos-1, Token.MARKUP_TAG_DELIMITER);
+								  addToken(zzStartRead,zzStartRead+1, TokenTypes.MARKUP_TAG_DELIMITER);
+								  addToken(zzMarkedPos-7,zzMarkedPos-2, TokenTypes.MARKUP_TAG_NAME);
+								  addToken(zzMarkedPos-1,zzMarkedPos-1, TokenTypes.MARKUP_TAG_DELIMITER);
 								}
 
 	// ECMA 3+ keywords.
@@ -1090,61 +1090,61 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"var" |
 	"void" |
 	"while" |
-	"with"						{ addToken(Token.RESERVED_WORD); }
-	"return"					{ addToken(Token.RESERVED_WORD_2); }
+	"with"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"return"					{ addToken(TokenTypes.RESERVED_WORD_2); }
 
 	//JavaScript 1.6
-	"each" 						{if(JavaScriptTokenMaker.isJavaScriptCompatible("1.6")){ addToken(Token.RESERVED_WORD);} else {addToken(Token.IDENTIFIER);} }
+	"each" 						{if(JavaScriptTokenMaker.isJavaScriptCompatible("1.6")){ addToken(TokenTypes.RESERVED_WORD);} else {addToken(TokenTypes.IDENTIFIER);} }
 	//JavaScript 1.7
-	"let" 						{if(JavaScriptTokenMaker.isJavaScriptCompatible("1.7")){ addToken(Token.RESERVED_WORD);} else {addToken(Token.IDENTIFIER);} }
+	"let" 						{if(JavaScriptTokenMaker.isJavaScriptCompatible("1.7")){ addToken(TokenTypes.RESERVED_WORD);} else {addToken(TokenTypes.IDENTIFIER);} }
 
 	// Reserved (but not yet used) ECMA keywords.
-	"abstract"					{ addToken(Token.RESERVED_WORD); }
-	"boolean"						{ addToken(Token.DATA_TYPE); }
-	"byte"						{ addToken(Token.DATA_TYPE); }
-	"case"						{ addToken(Token.RESERVED_WORD); }
-	"catch"						{ addToken(Token.RESERVED_WORD); }
-	"char"						{ addToken(Token.DATA_TYPE); }
-	"class"						{ addToken(Token.RESERVED_WORD); }
-	"const"						{ addToken(Token.RESERVED_WORD); }
-	"debugger"					{ addToken(Token.RESERVED_WORD); }
-	"default"						{ addToken(Token.RESERVED_WORD); }
-	"do"							{ addToken(Token.RESERVED_WORD); }
-	"double"						{ addToken(Token.DATA_TYPE); }
-	"enum"						{ addToken(Token.RESERVED_WORD); }
-	"export"						{ addToken(Token.RESERVED_WORD); }
-	"extends"						{ addToken(Token.RESERVED_WORD); }
-	"final"						{ addToken(Token.RESERVED_WORD); }
-	"finally"						{ addToken(Token.RESERVED_WORD); }
-	"float"						{ addToken(Token.DATA_TYPE); }
-	"goto"						{ addToken(Token.RESERVED_WORD); }
-	"implements"					{ addToken(Token.RESERVED_WORD); }
-	"import"						{ addToken(Token.RESERVED_WORD); }
-	"instanceof"					{ addToken(Token.RESERVED_WORD); }
-	"int"						{ addToken(Token.DATA_TYPE); }
-	"interface"					{ addToken(Token.RESERVED_WORD); }
-	"long"						{ addToken(Token.DATA_TYPE); }
-	"native"						{ addToken(Token.RESERVED_WORD); }
-	"package"						{ addToken(Token.RESERVED_WORD); }
-	"private"						{ addToken(Token.RESERVED_WORD); }
-	"protected"					{ addToken(Token.RESERVED_WORD); }
-	"public"						{ addToken(Token.RESERVED_WORD); }
-	"short"						{ addToken(Token.DATA_TYPE); }
-	"static"						{ addToken(Token.RESERVED_WORD); }
-	"super"						{ addToken(Token.RESERVED_WORD); }
-	"switch"						{ addToken(Token.RESERVED_WORD); }
-	"synchronized"					{ addToken(Token.RESERVED_WORD); }
-	"throw"						{ addToken(Token.RESERVED_WORD); }
-	"throws"						{ addToken(Token.RESERVED_WORD); }
-	"transient"					{ addToken(Token.RESERVED_WORD); }
-	"try"						{ addToken(Token.RESERVED_WORD); }
-	"volatile"					{ addToken(Token.RESERVED_WORD); }
-	"null"						{ addToken(Token.RESERVED_WORD); }
+	"abstract"					{ addToken(TokenTypes.RESERVED_WORD); }
+	"boolean"						{ addToken(TokenTypes.DATA_TYPE); }
+	"byte"						{ addToken(TokenTypes.DATA_TYPE); }
+	"case"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"catch"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"char"						{ addToken(TokenTypes.DATA_TYPE); }
+	"class"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"const"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"debugger"					{ addToken(TokenTypes.RESERVED_WORD); }
+	"default"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"do"							{ addToken(TokenTypes.RESERVED_WORD); }
+	"double"						{ addToken(TokenTypes.DATA_TYPE); }
+	"enum"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"export"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"extends"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"final"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"finally"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"float"						{ addToken(TokenTypes.DATA_TYPE); }
+	"goto"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"implements"					{ addToken(TokenTypes.RESERVED_WORD); }
+	"import"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"instanceof"					{ addToken(TokenTypes.RESERVED_WORD); }
+	"int"						{ addToken(TokenTypes.DATA_TYPE); }
+	"interface"					{ addToken(TokenTypes.RESERVED_WORD); }
+	"long"						{ addToken(TokenTypes.DATA_TYPE); }
+	"native"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"package"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"private"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"protected"					{ addToken(TokenTypes.RESERVED_WORD); }
+	"public"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"short"						{ addToken(TokenTypes.DATA_TYPE); }
+	"static"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"super"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"switch"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"synchronized"					{ addToken(TokenTypes.RESERVED_WORD); }
+	"throw"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"throws"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"transient"					{ addToken(TokenTypes.RESERVED_WORD); }
+	"try"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"volatile"					{ addToken(TokenTypes.RESERVED_WORD); }
+	"null"						{ addToken(TokenTypes.RESERVED_WORD); }
 
 	// Literals.
-	{JS_BooleanLiteral}			{ addToken(Token.LITERAL_BOOLEAN); }
-	"NaN"						{ addToken(Token.RESERVED_WORD); }
-	"Infinity"					{ addToken(Token.RESERVED_WORD); }
+	{JS_BooleanLiteral}			{ addToken(TokenTypes.LITERAL_BOOLEAN); }
+	"NaN"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"Infinity"					{ addToken(TokenTypes.RESERVED_WORD); }
 
 	// Functions.
 	"eval" |
@@ -1153,11 +1153,11 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"escape" |
 	"unescape" |
 	"isNaN" |
-	"isFinite"					{ addToken(Token.FUNCTION); }
+	"isFinite"					{ addToken(TokenTypes.FUNCTION); }
 
 	{LineTerminator}				{ addEndToken(INTERNAL_IN_JS); return firstToken; }
-	{JS_Identifier}				{ addToken(Token.IDENTIFIER); }
-	{Whitespace}					{ addToken(Token.WHITESPACE); }
+	{JS_Identifier}				{ addToken(TokenTypes.IDENTIFIER); }
+	{Whitespace}					{ addToken(TokenTypes.WHITESPACE); }
 
 	/* String/Character literals. */
 	[\']							{ start = zzMarkedPos-1; validJSString = true; yybegin(JS_CHAR); }
@@ -1165,7 +1165,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	[\`]							{ start = zzMarkedPos-1; validJSString = true; yybegin(JS_TEMPLATE_LITERAL); }
 
 	/* Comment literals. */
-	"/**/"						{ addToken(Token.COMMENT_MULTILINE); }
+	"/**/"						{ addToken(TokenTypes.COMMENT_MULTILINE); }
 	{JS_MLCBegin}					{ start = zzMarkedPos-2; yybegin(JS_MLC); }
 	{JS_DocCommentBegin}			{ start = zzMarkedPos-3; yybegin(JS_DOCCOMMENT); }
 	{JS_LineCommentBegin}			{ start = zzMarkedPos-2; yybegin(JS_EOL_COMMENT); }
@@ -1174,7 +1174,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	{JS_Regex}						{
 										boolean highlightedAsRegex = false;
 										if (firstToken==null) {
-											addToken(Token.REGEX);
+											addToken(TokenTypes.REGEX);
 											highlightedAsRegex = true;
 										}
 										else {
@@ -1182,7 +1182,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 											// the previous token, highlight it as such.
 											Token t = firstToken.getLastNonCommentNonWhitespaceToken();
 											if (RSyntaxUtilities.regexCanFollowInJavaScript(t)) {
-												addToken(Token.REGEX);
+												addToken(TokenTypes.REGEX);
 												highlightedAsRegex = true;
 											}
 										}
@@ -1190,42 +1190,42 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 										// individual tokens.
 										if (!highlightedAsRegex) {
 											int temp = zzStartRead + 1;
-											addToken(zzStartRead, zzStartRead, Token.OPERATOR);
+											addToken(zzStartRead, zzStartRead, TokenTypes.OPERATOR);
 											zzStartRead = zzCurrentPos = zzMarkedPos = temp;
 										}
 									}
 
 	/* Separators. */
-	{JS_Separator}					{ addToken(Token.SEPARATOR); }
-	{JS_Separator2}				{ addToken(Token.IDENTIFIER); }
+	{JS_Separator}					{ addToken(TokenTypes.SEPARATOR); }
+	{JS_Separator2}				{ addToken(TokenTypes.IDENTIFIER); }
 
-	{PHP_Start}					{ addToken(Token.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP); }
+	{PHP_Start}					{ addToken(TokenTypes.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP); }
 
 	/* Operators. */
-	{JS_Operator}					{ addToken(Token.OPERATOR); }
+	{JS_Operator}					{ addToken(TokenTypes.OPERATOR); }
 
 	/* Numbers */
-	{JS_IntegerLiteral}				{ addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
-	{JS_HexLiteral}				{ addToken(Token.LITERAL_NUMBER_HEXADECIMAL); }
-	{JS_FloatLiteral}				{ addToken(Token.LITERAL_NUMBER_FLOAT); }
-	{JS_ErrorNumberFormat}			{ addToken(Token.ERROR_NUMBER_FORMAT); }
+	{JS_IntegerLiteral}				{ addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT); }
+	{JS_HexLiteral}				{ addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL); }
+	{JS_FloatLiteral}				{ addToken(TokenTypes.LITERAL_NUMBER_FLOAT); }
+	{JS_ErrorNumberFormat}			{ addToken(TokenTypes.ERROR_NUMBER_FORMAT); }
 
-	{JS_ErrorIdentifier}			{ addToken(Token.ERROR_IDENTIFIER); }
+	{JS_ErrorIdentifier}			{ addToken(TokenTypes.ERROR_IDENTIFIER); }
 
 	/* Ended with a line not in a string or comment. */
 	<<EOF>>						{ addEndToken(INTERNAL_IN_JS); return firstToken; }
 
 	/* Catch any other (unhandled) characters and flag them as bad. */
-	.							{ addToken(Token.ERROR_IDENTIFIER); }
+	.							{ addToken(TokenTypes.ERROR_IDENTIFIER); }
 
 }
 
 
 <JS_STRING> {
-	{PHP_Start}				{ int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, validJSString ? Token.LITERAL_STRING_DOUBLE_QUOTE : Token.ERROR_STRING_DOUBLE); validJSString = true; addToken(temp, zzMarkedPos-1, Token.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP); }
+	{PHP_Start}				{ int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, validJSString ? TokenTypes.LITERAL_STRING_DOUBLE_QUOTE : TokenTypes.ERROR_STRING_DOUBLE); validJSString = true; addToken(temp, zzMarkedPos-1, TokenTypes.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP); }
 	[^\n\\\"<]+				{}
 	"<"							{ /* Allowing "<?" and "<?php" to start PHP */ }
-	\n						{ addToken(start,zzStartRead-1, Token.ERROR_STRING_DOUBLE); addEndToken(INTERNAL_IN_JS); return firstToken; }
+	\n						{ addToken(start,zzStartRead-1, TokenTypes.ERROR_STRING_DOUBLE); addEndToken(INTERNAL_IN_JS); return firstToken; }
 	\\x{HexDigit}{2}		{}
 	\\x						{ /* Invalid latin-1 character \xXX */ validJSString = false; }
 	\\u{HexDigit}{4}		{}
@@ -1233,21 +1233,21 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	\\.						{ /* Skip all escaped chars. */ }
 	\\						{ /* Line ending in '\' => continue to next line. */
 								if (validJSString) {
-									addToken(start,zzStartRead, Token.LITERAL_STRING_DOUBLE_QUOTE);
+									addToken(start,zzStartRead, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
 									addEndToken(INTERNAL_IN_JS_STRING_VALID);
 								}
 								else {
-									addToken(start,zzStartRead, Token.ERROR_STRING_DOUBLE);
+									addToken(start,zzStartRead, TokenTypes.ERROR_STRING_DOUBLE);
 									addEndToken(INTERNAL_IN_JS_STRING_INVALID);
 								}
 								return firstToken;
 							}
-	\"						{ int type = validJSString ? Token.LITERAL_STRING_DOUBLE_QUOTE : Token.ERROR_STRING_DOUBLE; addToken(start,zzStartRead, type); yybegin(JAVASCRIPT); }
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.ERROR_STRING_DOUBLE); addEndToken(INTERNAL_IN_JS); return firstToken; }
+	\"						{ int type = validJSString ? TokenTypes.LITERAL_STRING_DOUBLE_QUOTE : TokenTypes.ERROR_STRING_DOUBLE; addToken(start,zzStartRead, type); yybegin(JAVASCRIPT); }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.ERROR_STRING_DOUBLE); addEndToken(INTERNAL_IN_JS); return firstToken; }
 }
 
 <JS_CHAR> {
-	{PHP_Start}				{ int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, validJSString ? Token.LITERAL_CHAR : Token.ERROR_CHAR); validJSString = true; addToken(temp, zzMarkedPos-1, Token.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP); }
+	{PHP_Start}				{ int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, validJSString ? TokenTypes.LITERAL_CHAR : TokenTypes.ERROR_CHAR); validJSString = true; addToken(temp, zzMarkedPos-1, TokenTypes.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP); }
 	[^\n\\\'<]+				{}
 	"<"							{ /* Allowing "<?" and "<?php" to start PHP */ }
 	\\x{HexDigit}{2}		{}
@@ -1257,18 +1257,18 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	\\.						{ /* Skip all escaped chars. */ }
 	\\						{ /* Line ending in '\' => continue to next line. */
 								if (validJSString) {
-									addToken(start,zzStartRead, Token.LITERAL_CHAR);
+									addToken(start,zzStartRead, TokenTypes.LITERAL_CHAR);
 									addEndToken(INTERNAL_IN_JS_CHAR_VALID);
 								}
 								else {
-									addToken(start,zzStartRead, Token.ERROR_CHAR);
+									addToken(start,zzStartRead, TokenTypes.ERROR_CHAR);
 									addEndToken(INTERNAL_IN_JS_CHAR_INVALID);
 								}
 								return firstToken;
 							}
-	\'						{ int type = validJSString ? Token.LITERAL_CHAR : Token.ERROR_CHAR; addToken(start,zzStartRead, type); yybegin(JAVASCRIPT); }
+	\'						{ int type = validJSString ? TokenTypes.LITERAL_CHAR : TokenTypes.ERROR_CHAR; addToken(start,zzStartRead, type); yybegin(JAVASCRIPT); }
 	\n |
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.ERROR_CHAR); addEndToken(INTERNAL_IN_JS); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.ERROR_CHAR); addEndToken(INTERNAL_IN_JS); return firstToken; }
 }
 
 <JS_TEMPLATE_LITERAL> {
@@ -1280,7 +1280,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	\\.						{ /* Skip all escaped chars. */ }
 
 	{JS_TemplateLiteralExprStart}	{
-								addToken(start, zzStartRead - 1, Token.LITERAL_BACKQUOTE);
+								addToken(start, zzStartRead - 1, TokenTypes.LITERAL_BACKQUOTE);
 								start = zzMarkedPos-2;
 								if (varDepths==null) {
 									varDepths = new Stack<>();
@@ -1293,16 +1293,16 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 							}
 	"$"						{ /* Skip valid '$' that is not part of template literal expression start */ }
 	
-	\`						{ int type = validJSString ? Token.LITERAL_BACKQUOTE : Token.ERROR_STRING_DOUBLE; addToken(start,zzStartRead, type); yybegin(JAVASCRIPT); }
+	\`						{ int type = validJSString ? TokenTypes.LITERAL_BACKQUOTE : TokenTypes.ERROR_STRING_DOUBLE; addToken(start,zzStartRead, type); yybegin(JAVASCRIPT); }
 
 	/* Line ending in '\' => continue to next line, though not necessary in template strings. */
 	\\						{
 								if (validJSString) {
-									addToken(start,zzStartRead, Token.LITERAL_BACKQUOTE);
+									addToken(start,zzStartRead, TokenTypes.LITERAL_BACKQUOTE);
 									addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_VALID);
 								}
 								else {
-									addToken(start,zzStartRead, Token.ERROR_STRING_DOUBLE);
+									addToken(start,zzStartRead, TokenTypes.ERROR_STRING_DOUBLE);
 									addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_INVALID);
 								}
 								return firstToken;
@@ -1310,11 +1310,11 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	\n |
 	<<EOF>>					{
 								if (validJSString) {
-									addToken(start, zzStartRead - 1, Token.LITERAL_BACKQUOTE);
+									addToken(start, zzStartRead - 1, TokenTypes.LITERAL_BACKQUOTE);
 									addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_VALID);
 								}
 								else {
-									addToken(start,zzStartRead - 1, Token.ERROR_STRING_DOUBLE);
+									addToken(start,zzStartRead - 1, TokenTypes.ERROR_STRING_DOUBLE);
 									addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_INVALID);
 								}
 								return firstToken;
@@ -1327,7 +1327,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 							if (!varDepths.empty()) {
 								varDepths.pop();
 								if (varDepths.empty()) {
-									addToken(start,zzStartRead, Token.VARIABLE);
+									addToken(start,zzStartRead, TokenTypes.VARIABLE);
 									start = zzMarkedPos;
 									yybegin(JS_TEMPLATE_LITERAL);
 								}
@@ -1338,183 +1338,183 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	\n |
 	<<EOF>>				{
 							// TODO: This isn't right.  The expression and its depth should continue to the next line.
-							addToken(start,zzStartRead-1, Token.VARIABLE); addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_INVALID); return firstToken;
+							addToken(start,zzStartRead-1, TokenTypes.VARIABLE); addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_INVALID); return firstToken;
 						}
 }
 
 <JS_MLC> {
 	// JavaScript MLC's.  This state is essentially Java's MLC state.
 	[^hwf<\n\*]+			{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos; }
 	[hwf]					{}
 	{EndScriptTag}			{
 							  yybegin(YYINITIAL);
 							  int temp = zzStartRead;
-							  addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE);
-							  addToken(temp,temp+1, Token.MARKUP_TAG_DELIMITER);
-							  addToken(zzMarkedPos-7,zzMarkedPos-2, Token.MARKUP_TAG_NAME);
-							  addToken(zzMarkedPos-1,zzMarkedPos-1, Token.MARKUP_TAG_DELIMITER);
+							  addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE);
+							  addToken(temp,temp+1, TokenTypes.MARKUP_TAG_DELIMITER);
+							  addToken(zzMarkedPos-7,zzMarkedPos-2, TokenTypes.MARKUP_TAG_NAME);
+							  addToken(zzMarkedPos-1,zzMarkedPos-1, TokenTypes.MARKUP_TAG_DELIMITER);
 							}
 	"<"						{}
-	{JS_MLCEnd}					{ yybegin(JAVASCRIPT); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE); }
+	{JS_MLCEnd}					{ yybegin(JAVASCRIPT); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE); }
 	\*							{}
 	\n |
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_JS_MLC); return firstToken; }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_JS_MLC); return firstToken; }
 }
 
 
 
 <JS_DOCCOMMENT> {
 	[^hwf\@\{\n\<\*]+			{}
-	{URL}						{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_DOCUMENTATION); start = zzMarkedPos; }
+	{URL}						{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_DOCUMENTATION); start = zzMarkedPos; }
 	[hwf]						{}
 
-	"@"{JS_BlockTag}			{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, Token.COMMENT_KEYWORD); start = zzMarkedPos; }
+	"@"{JS_BlockTag}			{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_KEYWORD); start = zzMarkedPos; }
 	"@"							{}
-	"{@"{JS_InlineTag}[^\}]*"}"	{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, Token.COMMENT_KEYWORD); start = zzMarkedPos; }
+	"{@"{JS_InlineTag}[^\}]*"}"	{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_KEYWORD); start = zzMarkedPos; }
 	"{"							{}
-	\n							{ addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addEndToken(INTERNAL_IN_JS_COMMENT_DOCUMENTATION); return firstToken; }
-	"<"[/]?({Letter}[^\>]*)?">"	{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, Token.COMMENT_MARKUP); start = zzMarkedPos; }
+	\n							{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addEndToken(INTERNAL_IN_JS_COMMENT_DOCUMENTATION); return firstToken; }
+	"<"[/]?({Letter}[^\>]*)?">"	{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MARKUP); start = zzMarkedPos; }
 	\<							{}
-	{JS_MLCEnd}					{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_DOCUMENTATION); }
+	{JS_MLCEnd}					{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_DOCUMENTATION); }
 	\*							{}
-	<<EOF>>						{ yybegin(YYINITIAL); addToken(start,zzEndRead, Token.COMMENT_DOCUMENTATION); addEndToken(INTERNAL_IN_JS_COMMENT_DOCUMENTATION); return firstToken; }
+	<<EOF>>						{ yybegin(YYINITIAL); addToken(start,zzEndRead, TokenTypes.COMMENT_DOCUMENTATION); addEndToken(INTERNAL_IN_JS_COMMENT_DOCUMENTATION); return firstToken; }
 }
 
 
 <JS_EOL_COMMENT> {
 	[^hwf<\n]+				{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos; }
 	[hwf]					{}
 	{EndScriptTag}			{
 							  int temp = zzStartRead;
-							  addToken(start,zzStartRead-1, Token.COMMENT_EOL);
+							  addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL);
 							  yybegin(YYINITIAL, LANG_INDEX_DEFAULT);
-							  addToken(temp,temp+1, Token.MARKUP_TAG_DELIMITER);
-							  addToken(zzMarkedPos-7,zzMarkedPos-2, Token.MARKUP_TAG_NAME);
-							  addToken(zzMarkedPos-1,zzMarkedPos-1, Token.MARKUP_TAG_DELIMITER);
+							  addToken(temp,temp+1, TokenTypes.MARKUP_TAG_DELIMITER);
+							  addToken(zzMarkedPos-7,zzMarkedPos-2, TokenTypes.MARKUP_TAG_NAME);
+							  addToken(zzMarkedPos-1,zzMarkedPos-1, TokenTypes.MARKUP_TAG_DELIMITER);
 							}
 	"<"						{}
 	\n |
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_EOL); addEndToken(INTERNAL_IN_JS); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addEndToken(INTERNAL_IN_JS); return firstToken; }
 
 }
 
 
 <CSS> {
-	{PHP_Start}			{ addToken(Token.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP); }
+	{PHP_Start}			{ addToken(TokenTypes.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP); }
 	{EndStyleTag}		{
 						  yybegin(YYINITIAL, LANG_INDEX_DEFAULT);
-						  addToken(zzStartRead,zzStartRead+1, Token.MARKUP_TAG_DELIMITER);
-						  addToken(zzMarkedPos-6,zzMarkedPos-2, Token.MARKUP_TAG_NAME);
-						  addToken(zzMarkedPos-1,zzMarkedPos-1, Token.MARKUP_TAG_DELIMITER);
+						  addToken(zzStartRead,zzStartRead+1, TokenTypes.MARKUP_TAG_DELIMITER);
+						  addToken(zzMarkedPos-6,zzMarkedPos-2, TokenTypes.MARKUP_TAG_NAME);
+						  addToken(zzMarkedPos-1,zzMarkedPos-1, TokenTypes.MARKUP_TAG_DELIMITER);
 						}
-	{CSS_SelectorPiece}	{ addToken(Token.DATA_TYPE); }
-	{CSS_PseudoClass}	{ addToken(Token.RESERVED_WORD); }
-	":"					{ /* Unknown pseudo class */ addToken(Token.DATA_TYPE); }
-	{CSS_AtKeyword}		{ addToken(Token.REGEX); }
-	{CSS_Id}			{ addToken(Token.VARIABLE); }
-	"{"					{ addToken(Token.SEPARATOR); yybegin(CSS_PROPERTY); }
-	[,]					{ addToken(Token.IDENTIFIER); }
+	{CSS_SelectorPiece}	{ addToken(TokenTypes.DATA_TYPE); }
+	{CSS_PseudoClass}	{ addToken(TokenTypes.RESERVED_WORD); }
+	":"					{ /* Unknown pseudo class */ addToken(TokenTypes.DATA_TYPE); }
+	{CSS_AtKeyword}		{ addToken(TokenTypes.REGEX); }
+	{CSS_Id}			{ addToken(TokenTypes.VARIABLE); }
+	"{"					{ addToken(TokenTypes.SEPARATOR); yybegin(CSS_PROPERTY); }
+	[,]					{ addToken(TokenTypes.IDENTIFIER); }
 	\"					{ start = zzMarkedPos-1; cssPrevState = zzLexicalState; yybegin(CSS_STRING); }
 	\'					{ start = zzMarkedPos-1; cssPrevState = zzLexicalState; yybegin(CSS_CHAR_LITERAL); }
-	[+>~\^$\|=]			{ addToken(Token.OPERATOR); }
-	{CSS_Separator}		{ addToken(Token.SEPARATOR); }
-	{Whitespace}		{ addToken(Token.WHITESPACE); }
+	[+>~\^$\|=]			{ addToken(TokenTypes.OPERATOR); }
+	{CSS_Separator}		{ addToken(TokenTypes.SEPARATOR); }
+	{Whitespace}		{ addToken(TokenTypes.WHITESPACE); }
 	{CSS_MlcStart}		{ start = zzMarkedPos-2; cssPrevState = zzLexicalState; yybegin(CSS_C_STYLE_COMMENT); }
-	.					{ /*System.out.println("CSS: " + yytext());*/ addToken(Token.IDENTIFIER); }
+	.					{ /*System.out.println("CSS: " + yytext());*/ addToken(TokenTypes.IDENTIFIER); }
 	"\n" |
 	<<EOF>>				{ addEndToken(INTERNAL_CSS); return firstToken; }
 }
 
 <CSS_PROPERTY> {
-	{PHP_Start}			{ addToken(Token.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP); }
+	{PHP_Start}			{ addToken(TokenTypes.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP); }
 	{EndStyleTag}		{
 						  yybegin(YYINITIAL, LANG_INDEX_DEFAULT);
-						  addToken(zzStartRead,zzStartRead+1, Token.MARKUP_TAG_DELIMITER);
-						  addToken(zzMarkedPos-6,zzMarkedPos-2, Token.MARKUP_TAG_NAME);
-						  addToken(zzMarkedPos-1,zzMarkedPos-1, Token.MARKUP_TAG_DELIMITER);
+						  addToken(zzStartRead,zzStartRead+1, TokenTypes.MARKUP_TAG_DELIMITER);
+						  addToken(zzMarkedPos-6,zzMarkedPos-2, TokenTypes.MARKUP_TAG_NAME);
+						  addToken(zzMarkedPos-1,zzMarkedPos-1, TokenTypes.MARKUP_TAG_DELIMITER);
 						}
-	{CSS_Property}		{ addToken(Token.RESERVED_WORD); }
-	"}"					{ addToken(Token.SEPARATOR); yybegin(CSS); }
-	":"					{ addToken(Token.OPERATOR); yybegin(CSS_VALUE); }
-	{Whitespace}		{ addToken(Token.WHITESPACE); }
+	{CSS_Property}		{ addToken(TokenTypes.RESERVED_WORD); }
+	"}"					{ addToken(TokenTypes.SEPARATOR); yybegin(CSS); }
+	":"					{ addToken(TokenTypes.OPERATOR); yybegin(CSS_VALUE); }
+	{Whitespace}		{ addToken(TokenTypes.WHITESPACE); }
 	{CSS_MlcStart}		{ start = zzMarkedPos-2; cssPrevState = zzLexicalState; yybegin(CSS_C_STYLE_COMMENT); }
-	.					{ /*System.out.println("css_property: " + yytext());*/ addToken(Token.IDENTIFIER); }
+	.					{ /*System.out.println("css_property: " + yytext());*/ addToken(TokenTypes.IDENTIFIER); }
 	"\n" |
 	<<EOF>>				{ addEndToken(INTERNAL_CSS_PROPERTY); return firstToken; }
 }
 
 <CSS_VALUE> {
-	{PHP_Start}			{ addToken(Token.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP); }
+	{PHP_Start}			{ addToken(TokenTypes.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP); }
 	{EndStyleTag}		{
 						  yybegin(YYINITIAL, LANG_INDEX_DEFAULT);
-						  addToken(zzStartRead,zzStartRead+1, Token.MARKUP_TAG_DELIMITER);
-						  addToken(zzMarkedPos-6,zzMarkedPos-2, Token.MARKUP_TAG_NAME);
-						  addToken(zzMarkedPos-1,zzMarkedPos-1, Token.MARKUP_TAG_DELIMITER);
+						  addToken(zzStartRead,zzStartRead+1, TokenTypes.MARKUP_TAG_DELIMITER);
+						  addToken(zzMarkedPos-6,zzMarkedPos-2, TokenTypes.MARKUP_TAG_NAME);
+						  addToken(zzMarkedPos-1,zzMarkedPos-1, TokenTypes.MARKUP_TAG_DELIMITER);
 						}
-	{CSS_Value}			{ addToken(Token.IDENTIFIER); }
-	"!important"		{ addToken(Token.ANNOTATION); }
+	{CSS_Value}			{ addToken(TokenTypes.IDENTIFIER); }
+	"!important"		{ addToken(TokenTypes.ANNOTATION); }
 	{CSS_Function}		{ int temp = zzMarkedPos - 2;
-						  addToken(zzStartRead, temp, Token.FUNCTION);
-						  addToken(zzMarkedPos-1, zzMarkedPos-1, Token.SEPARATOR);
+						  addToken(zzStartRead, temp, TokenTypes.FUNCTION);
+						  addToken(zzMarkedPos-1, zzMarkedPos-1, TokenTypes.SEPARATOR);
 						  zzStartRead = zzCurrentPos = zzMarkedPos;
 						}
-	{CSS_Number}		{ addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
+	{CSS_Number}		{ addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT); }
 	\"					{ start = zzMarkedPos-1; cssPrevState = zzLexicalState; yybegin(CSS_STRING); }
 	\'					{ start = zzMarkedPos-1; cssPrevState = zzLexicalState; yybegin(CSS_CHAR_LITERAL); }
-	")"					{ /* End of a function */ addToken(Token.SEPARATOR); }
-	[;]					{ addToken(Token.OPERATOR); yybegin(CSS_PROPERTY); }
-	[,\.]				{ addToken(Token.IDENTIFIER); }
-	"}"					{ addToken(Token.SEPARATOR); yybegin(CSS); }
-	{Whitespace}		{ addToken(Token.WHITESPACE); }
+	")"					{ /* End of a function */ addToken(TokenTypes.SEPARATOR); }
+	[;]					{ addToken(TokenTypes.OPERATOR); yybegin(CSS_PROPERTY); }
+	[,\.]				{ addToken(TokenTypes.IDENTIFIER); }
+	"}"					{ addToken(TokenTypes.SEPARATOR); yybegin(CSS); }
+	{Whitespace}		{ addToken(TokenTypes.WHITESPACE); }
 	{CSS_MlcStart}		{ start = zzMarkedPos-2; cssPrevState = zzLexicalState; yybegin(CSS_C_STYLE_COMMENT); }
-	.					{ /*System.out.println("css_value: " + yytext());*/ addToken(Token.IDENTIFIER); }
+	.					{ /*System.out.println("css_value: " + yytext());*/ addToken(TokenTypes.IDENTIFIER); }
 	"\n" |
 	<<EOF>>				{ addEndToken(INTERNAL_CSS_VALUE); return firstToken; }
 }
 
 <CSS_STRING> {
-	{PHP_Start}				{ int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, validJSString ? Token.LITERAL_CHAR : Token.ERROR_CHAR); validJSString = true; addToken(temp, zzMarkedPos-1, Token.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP); }
+	{PHP_Start}				{ int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, validJSString ? TokenTypes.LITERAL_CHAR : TokenTypes.ERROR_CHAR); validJSString = true; addToken(temp, zzMarkedPos-1, TokenTypes.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP); }
 	[^\n\\\"<]+			{}
 	"<"					{ /* Allowing "<?" and "<?php" to start PHP */ }
 	\\.?				{ /* Skip escaped chars. */ }
-	\"					{ addToken(start,zzStartRead, Token.LITERAL_STRING_DOUBLE_QUOTE); yybegin(cssPrevState); }
+	\"					{ addToken(start,zzStartRead, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); yybegin(cssPrevState); }
 	\n |
-	<<EOF>>				{ addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); addEndToken(INTERNAL_CSS_STRING - cssPrevState); return firstToken; }
+	<<EOF>>				{ addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); addEndToken(INTERNAL_CSS_STRING - cssPrevState); return firstToken; }
 }
 
 <CSS_CHAR_LITERAL> {
-	{PHP_Start}				{ int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, validJSString ? Token.LITERAL_CHAR : Token.ERROR_CHAR); validJSString = true; addToken(temp, zzMarkedPos-1, Token.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP); }
+	{PHP_Start}				{ int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, validJSString ? TokenTypes.LITERAL_CHAR : TokenTypes.ERROR_CHAR); validJSString = true; addToken(temp, zzMarkedPos-1, TokenTypes.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP); }
 	[^\n\\\'<]+			{}
 	"<"					{ /* Allowing "<?" and "<?php" to start PHP */ }
 	\\.?				{ /* Skip escaped chars. */ }
-	\'					{ addToken(start,zzStartRead, Token.LITERAL_CHAR); yybegin(cssPrevState); }
+	\'					{ addToken(start,zzStartRead, TokenTypes.LITERAL_CHAR); yybegin(cssPrevState); }
 	\n |
-	<<EOF>>				{ addToken(start,zzStartRead-1, Token.LITERAL_CHAR); addEndToken(INTERNAL_CSS_CHAR - cssPrevState); return firstToken; }
+	<<EOF>>				{ addToken(start,zzStartRead-1, TokenTypes.LITERAL_CHAR); addEndToken(INTERNAL_CSS_CHAR - cssPrevState); return firstToken; }
 }
 
 <CSS_C_STYLE_COMMENT> {
-	{PHP_Start}				{ int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, validJSString ? Token.LITERAL_CHAR : Token.ERROR_CHAR); validJSString = true; addToken(temp, zzMarkedPos-1, Token.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP); }
+	{PHP_Start}				{ int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, validJSString ? TokenTypes.LITERAL_CHAR : TokenTypes.ERROR_CHAR); validJSString = true; addToken(temp, zzMarkedPos-1, TokenTypes.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP); }
 	[^hwf\n\*<]+			{}
 	"<"					{ /* Allowing "<?" and "<?php" to start PHP */ }
-	{URL}				{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos; }
+	{URL}				{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos; }
 	[hwf]				{}
-	{CSS_MlcEnd}		{ addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE); yybegin(cssPrevState); }
+	{CSS_MlcEnd}		{ addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE); yybegin(cssPrevState); }
 	\*					{}
 	\n |
-	<<EOF>>				{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addEndToken(INTERNAL_CSS_MLC - cssPrevState); return firstToken; }
+	<<EOF>>				{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addEndToken(INTERNAL_CSS_MLC - cssPrevState); return firstToken; }
 }
 
 
 <PHP> {
 
-	"?>"						{ yybegin(phpInState, phpInLangIndex); addToken(Token.MARKUP_TAG_DELIMITER); start = zzMarkedPos; }
+	"?>"						{ yybegin(phpInState, phpInLangIndex); addToken(TokenTypes.MARKUP_TAG_DELIMITER); start = zzMarkedPos; }
 
 	/* Error control operator */
 	("@"{JS_Identifier})		{
 									int count = yylength();
-									addToken(zzStartRead,zzStartRead, Token.FUNCTION);
+									addToken(zzStartRead,zzStartRead, TokenTypes.FUNCTION);
 									zzMarkedPos -= (count-1); //yypushback(count-1);
 								}
 
@@ -1589,10 +1589,10 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 
 	"parent" |
 	"self" |
-	"stdClass"					{ addToken(Token.RESERVED_WORD); }
+	"stdClass"					{ addToken(TokenTypes.RESERVED_WORD); }
 
 	"exit" |
-	"return"					{ addToken(Token.RESERVED_WORD_2); }
+	"return"					{ addToken(TokenTypes.RESERVED_WORD_2); }
 
 	/* Functions */
 	"__call" |
@@ -2495,45 +2495,45 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"use_result" |
 	"user_error" |
 	("velocis_"("autocommit"|"close"|"commit"|"connect"|"exec"|"fetch"|"fieldname"|"fieldnum"|"freeresult"|"off_autocommit"|"result"|"rollback")) |
-	"virtual"							{ addToken(Token.FUNCTION); }
+	"virtual"							{ addToken(TokenTypes.FUNCTION); }
 
-	{PHP_BooleanLiteral}		{ addToken(Token.LITERAL_BOOLEAN); }
-	{PHP_Null}					{ addToken(Token.RESERVED_WORD); }
-	{PHP_Variable}				{ addToken(Token.VARIABLE); }
+	{PHP_BooleanLiteral}		{ addToken(TokenTypes.LITERAL_BOOLEAN); }
+	{PHP_Null}					{ addToken(TokenTypes.RESERVED_WORD); }
+	{PHP_Variable}				{ addToken(TokenTypes.VARIABLE); }
 
 	{LineTerminator}				{ addPhpEndToken(INTERNAL_IN_PHP); return firstToken; }
-	{JS_Identifier}				{ addToken(Token.IDENTIFIER); }
-	{Whitespace}					{ addToken(Token.WHITESPACE); }
+	{JS_Identifier}				{ addToken(TokenTypes.IDENTIFIER); }
+	{Whitespace}					{ addToken(TokenTypes.WHITESPACE); }
 
 	/* String/Character literals. */
 	[\"]							{ start = zzMarkedPos-1; yybegin(PHP_STRING); }
 	[\']							{ start = zzMarkedPos-1; yybegin(PHP_CHAR); }
 
 	/* Comment literals. */
-	"/**/"						{ addToken(Token.COMMENT_MULTILINE); }
+	"/**/"						{ addToken(TokenTypes.COMMENT_MULTILINE); }
 	{JS_MLCBegin}					{ start = zzMarkedPos-2; yybegin(PHP_MLC); }
-	{PHP_LineCommentBegin}.*			{ addToken(Token.COMMENT_EOL); addPhpEndToken(INTERNAL_IN_PHP); return firstToken; }
+	{PHP_LineCommentBegin}.*			{ addToken(TokenTypes.COMMENT_EOL); addPhpEndToken(INTERNAL_IN_PHP); return firstToken; }
 
 	/* Separators. */
-	{JS_Separator}					{ addToken(Token.SEPARATOR); }
-	{JS_Separator2}				{ addToken(Token.IDENTIFIER); }
+	{JS_Separator}					{ addToken(TokenTypes.SEPARATOR); }
+	{JS_Separator2}				{ addToken(TokenTypes.IDENTIFIER); }
 
 	/* Operators. */
-	{JS_Operator}					{ addToken(Token.OPERATOR); }
+	{JS_Operator}					{ addToken(TokenTypes.OPERATOR); }
 
 	/* Numbers */
-	{JS_IntegerLiteral}				{ addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
-	{JS_HexLiteral}				{ addToken(Token.LITERAL_NUMBER_HEXADECIMAL); }
-	{JS_FloatLiteral}				{ addToken(Token.LITERAL_NUMBER_FLOAT); }
-	{JS_ErrorNumberFormat}			{ addToken(Token.ERROR_NUMBER_FORMAT); }
+	{JS_IntegerLiteral}				{ addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT); }
+	{JS_HexLiteral}				{ addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL); }
+	{JS_FloatLiteral}				{ addToken(TokenTypes.LITERAL_NUMBER_FLOAT); }
+	{JS_ErrorNumberFormat}			{ addToken(TokenTypes.ERROR_NUMBER_FORMAT); }
 
-	{JS_ErrorIdentifier}			{ addToken(Token.ERROR_IDENTIFIER); }
+	{JS_ErrorIdentifier}			{ addToken(TokenTypes.ERROR_IDENTIFIER); }
 
 	/* Ended with a line not in a string or comment. */
 	<<EOF>>						{ addPhpEndToken(INTERNAL_IN_PHP); return firstToken; }
 
 	/* Catch any other (unhandled) characters and assume they are okay. */
-	.							{ addToken(Token.IDENTIFIER); }
+	.							{ addToken(TokenTypes.IDENTIFIER); }
 
 }
 
@@ -2541,12 +2541,12 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 <PHP_MLC> {
 	// PHP MLC's.  This state is essentially Java's MLC state.
 	[^hwf\n\*]+					{}
-	{URL}						{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos; }
+	{URL}						{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos; }
 	[hwf]						{}
-	{JS_MLCEnd}					{ yybegin(PHP); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE); }
+	{JS_MLCEnd}					{ yybegin(PHP); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE); }
 	\*							{}
 	\n |
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addPhpEndToken(INTERNAL_IN_PHP_MLC); return firstToken; }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addPhpEndToken(INTERNAL_IN_PHP_MLC); return firstToken; }
 }
 
 
@@ -2556,22 +2556,22 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	{PHP_Variable}		{
                             int temp=zzStartRead;
                             if (start <= zzStartRead - 1) {
-                                addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE);
+                                addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
                             }
-                            addToken(temp,zzMarkedPos-1, Token.VARIABLE);
+                            addToken(temp,zzMarkedPos-1, TokenTypes.VARIABLE);
                             start = zzMarkedPos;
                         }
 	"$"					{}
-	\"					{ yybegin(PHP); addToken(start,zzStartRead, Token.LITERAL_STRING_DOUBLE_QUOTE); }
+	\"					{ yybegin(PHP); addToken(start,zzStartRead, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); }
 	\n |
-	<<EOF>>				{ addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); addPhpEndToken(INTERNAL_IN_PHP_STRING); return firstToken; }
+	<<EOF>>				{ addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); addPhpEndToken(INTERNAL_IN_PHP_STRING); return firstToken; }
 }
 
 
 <PHP_CHAR> {
 	[^\n\\\']+			{}
 	\\.?				{ /* Skip escaped single quotes only, but this should still work. */ }
-	\'					{ yybegin(PHP); addToken(start,zzStartRead, Token.LITERAL_CHAR); }
+	\'					{ yybegin(PHP); addToken(start,zzStartRead, TokenTypes.LITERAL_CHAR); }
 	\n |
-	<<EOF>>				{ addToken(start,zzStartRead-1, Token.LITERAL_CHAR); addPhpEndToken(INTERNAL_IN_PHP_CHAR); return firstToken; }
+	<<EOF>>				{ addToken(start,zzStartRead-1, TokenTypes.LITERAL_CHAR); addPhpEndToken(INTERNAL_IN_PHP_CHAR); return firstToken; }
 }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/PHPTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/PHPTokenMaker.java
@@ -24663,8 +24663,8 @@ public class PHPTokenMaker extends AbstractMarkupTokenMaker {
 	 */
 	@Override
 	public boolean getMarkOccurrencesOfTokenType(int type) {
-		return type==Token.FUNCTION || type==Token.VARIABLE ||
-				type==Token.MARKUP_TAG_NAME;
+		return type==TokenTypes.FUNCTION || type==TokenTypes.VARIABLE ||
+				type==TokenTypes.MARKUP_TAG_NAME;
 	}
 
 
@@ -24709,7 +24709,7 @@ public class PHPTokenMaker extends AbstractMarkupTokenMaker {
 		// Start off in the proper state.
 		int state;
 		switch (initialTokenType) {
-			case Token.MARKUP_COMMENT:
+			case TokenTypes.MARKUP_COMMENT:
 				state = COMMENT;
 				break;
 			case INTERNAL_INTAG:
@@ -25152,22 +25152,22 @@ public class PHPTokenMaker extends AbstractMarkupTokenMaker {
           {
 			  int temp=zzStartRead;
 			  if (start <= zzStartRead - 1) {
-				  addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE);
+				  addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
 			  }
-			  addToken(temp,zzMarkedPos-1, Token.VARIABLE);
+			  addToken(temp,zzMarkedPos-1, TokenTypes.VARIABLE);
 			  start = zzMarkedPos;
           }
         case 137: break;
         case 67:
-          { addToken(Token.OPERATOR); yybegin(CSS_VALUE);
+          { addToken(TokenTypes.OPERATOR); yybegin(CSS_VALUE);
           }
         case 138: break;
         case 92:
-          { addToken(Token.ERROR_NUMBER_FORMAT);
+          { addToken(TokenTypes.ERROR_NUMBER_FORMAT);
           }
         case 139: break;
         case 75:
-          { addToken(start,zzStartRead-1, Token.LITERAL_CHAR); addEndToken(INTERNAL_CSS_CHAR - cssPrevState); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.LITERAL_CHAR); addEndToken(INTERNAL_CSS_CHAR - cssPrevState); return firstToken;
           }
         case 140: break;
         case 23:
@@ -25175,23 +25175,23 @@ public class PHPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 141: break;
         case 9:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead, Token.MARKUP_DTD);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.MARKUP_DTD);
           }
         case 142: break;
         case 61:
-          { addToken(Token.SEPARATOR); yybegin(CSS_PROPERTY);
+          { addToken(TokenTypes.SEPARATOR); yybegin(CSS_PROPERTY);
           }
         case 143: break;
         case 4:
-          { addToken(Token.MARKUP_TAG_DELIMITER); yybegin(INTAG);
+          { addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(INTAG);
           }
         case 144: break;
         case 129:
-          { addToken(Token.RESERVED_WORD_2);
+          { addToken(TokenTypes.RESERVED_WORD_2);
           }
         case 145: break;
         case 112:
-          { addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE); yybegin(cssPrevState);
+          { addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE); yybegin(cssPrevState);
           }
         case 146: break;
         case 110:
@@ -25199,41 +25199,41 @@ public class PHPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 147: break;
         case 5:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 148: break;
         case 115:
           { int count = yylength();
-									addToken(zzStartRead,zzStartRead+1, Token.MARKUP_TAG_DELIMITER);
+									addToken(zzStartRead,zzStartRead+1, TokenTypes.MARKUP_TAG_DELIMITER);
 									zzMarkedPos -= (count-2); //yypushback(count-2);
 									yybegin(INTAG_CHECK_TAG_NAME);
           }
         case 149: break;
         case 111:
-          { addToken(Token.REGEX);
+          { addToken(TokenTypes.REGEX);
           }
         case 150: break;
         case 42:
-          { addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_JS_MLC); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_JS_MLC); return firstToken;
           }
         case 151: break;
         case 132:
           { yybegin(YYINITIAL, LANG_INDEX_DEFAULT);
-						  addToken(zzStartRead,zzStartRead+1, Token.MARKUP_TAG_DELIMITER);
-						  addToken(zzMarkedPos-6,zzMarkedPos-2, Token.MARKUP_TAG_NAME);
-						  addToken(zzMarkedPos-1,zzMarkedPos-1, Token.MARKUP_TAG_DELIMITER);
+						  addToken(zzStartRead,zzStartRead+1, TokenTypes.MARKUP_TAG_DELIMITER);
+						  addToken(zzMarkedPos-6,zzMarkedPos-2, TokenTypes.MARKUP_TAG_NAME);
+						  addToken(zzMarkedPos-1,zzMarkedPos-1, TokenTypes.MARKUP_TAG_DELIMITER);
           }
         case 152: break;
         case 106:
-          { addToken(Token.FUNCTION);
+          { addToken(TokenTypes.FUNCTION);
           }
         case 153: break;
         case 101:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, Token.COMMENT_MARKUP); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MARKUP); start = zzMarkedPos;
           }
         case 154: break;
         case 39:
-          { addToken(start,zzStartRead-1, Token.ERROR_STRING_DOUBLE); addEndToken(INTERNAL_IN_JS); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.ERROR_STRING_DOUBLE); addEndToken(INTERNAL_IN_JS); return firstToken;
           }
         case 155: break;
         case 58:
@@ -25244,7 +25244,7 @@ public class PHPTokenMaker extends AbstractMarkupTokenMaker {
           { if (!varDepths.empty()) {
 								varDepths.pop();
 								if (varDepths.empty()) {
-									addToken(start,zzStartRead, Token.VARIABLE);
+									addToken(start,zzStartRead, TokenTypes.VARIABLE);
 									start = zzMarkedPos;
 									yybegin(JS_TEMPLATE_LITERAL);
 								}
@@ -25265,7 +25265,7 @@ public class PHPTokenMaker extends AbstractMarkupTokenMaker {
         case 160: break;
         case 84:
           { int count = yylength();
-									addToken(zzStartRead,zzStartRead, Token.MARKUP_TAG_DELIMITER);
+									addToken(zzStartRead,zzStartRead, TokenTypes.MARKUP_TAG_DELIMITER);
 									zzMarkedPos -= (count-1); //yypushback(count-1);
 									yybegin(INTAG_CHECK_TAG_NAME);
           }
@@ -25275,19 +25275,19 @@ public class PHPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 162: break;
         case 89:
-          { addToken(Token.MARKUP_TAG_DELIMITER); yybegin(YYINITIAL);
+          { addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(YYINITIAL);
           }
         case 163: break;
         case 28:
-          { yybegin(INTAG_STYLE); addToken(start,zzStartRead, Token.MARKUP_TAG_ATTRIBUTE_VALUE);
+          { yybegin(INTAG_STYLE); addToken(start,zzStartRead, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE);
           }
         case 164: break;
         case 124:
-          { if(JavaScriptTokenMaker.isJavaScriptCompatible("1.6")){ addToken(Token.RESERVED_WORD);} else {addToken(Token.IDENTIFIER);}
+          { if(JavaScriptTokenMaker.isJavaScriptCompatible("1.6")){ addToken(TokenTypes.RESERVED_WORD);} else {addToken(TokenTypes.IDENTIFIER);}
           }
         case 165: break;
         case 119:
-          { if(JavaScriptTokenMaker.isJavaScriptCompatible("1.7")){ addToken(Token.RESERVED_WORD);} else {addToken(Token.IDENTIFIER);}
+          { if(JavaScriptTokenMaker.isJavaScriptCompatible("1.7")){ addToken(TokenTypes.RESERVED_WORD);} else {addToken(TokenTypes.IDENTIFIER);}
           }
         case 166: break;
         case 46:
@@ -25295,11 +25295,11 @@ public class PHPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 167: break;
         case 68:
-          { /*System.out.println("css_value: " + yytext());*/ addToken(Token.IDENTIFIER);
+          { /*System.out.println("css_value: " + yytext());*/ addToken(TokenTypes.IDENTIFIER);
           }
         case 168: break;
         case 99:
-          { int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, validJSString ? Token.LITERAL_STRING_DOUBLE_QUOTE : Token.ERROR_STRING_DOUBLE); validJSString = true; addToken(temp, zzMarkedPos-1, Token.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP);
+          { int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, validJSString ? TokenTypes.LITERAL_STRING_DOUBLE_QUOTE : TokenTypes.ERROR_STRING_DOUBLE); validJSString = true; addToken(temp, zzMarkedPos-1, TokenTypes.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP);
           }
         case 169: break;
         case 16:
@@ -25307,11 +25307,11 @@ public class PHPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 170: break;
         case 26:
-          { addToken(Token.MARKUP_TAG_DELIMITER); yybegin(CSS, LANG_INDEX_CSS);
+          { addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(CSS, LANG_INDEX_CSS);
           }
         case 171: break;
         case 113:
-          { addToken(start, zzStartRead - 1, Token.LITERAL_BACKQUOTE);
+          { addToken(start, zzStartRead - 1, TokenTypes.LITERAL_BACKQUOTE);
 								start = zzMarkedPos-2;
 								if (varDepths==null) {
 									varDepths = new Stack<>();
@@ -25324,15 +25324,15 @@ public class PHPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 172: break;
         case 76:
-          { addToken(start,zzStartRead, Token.LITERAL_CHAR); yybegin(cssPrevState);
+          { addToken(start,zzStartRead, TokenTypes.LITERAL_CHAR); yybegin(cssPrevState);
           }
         case 173: break;
         case 95:
-          { int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, validJSString ? Token.LITERAL_CHAR : Token.ERROR_CHAR); validJSString = true; addToken(temp, zzMarkedPos-1, Token.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP);
+          { int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, validJSString ? TokenTypes.LITERAL_CHAR : TokenTypes.ERROR_CHAR); validJSString = true; addToken(temp, zzMarkedPos-1, TokenTypes.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP);
           }
         case 174: break;
         case 87:
-          { addToken(Token.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP);
+          { addToken(TokenTypes.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP);
           }
         case 175: break;
         case 114:
@@ -25346,10 +25346,10 @@ public class PHPTokenMaker extends AbstractMarkupTokenMaker {
         case 134:
           { yybegin(YYINITIAL);
 							  int temp = zzStartRead;
-							  addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE);
-							  addToken(temp,temp+1, Token.MARKUP_TAG_DELIMITER);
-							  addToken(zzMarkedPos-7,zzMarkedPos-2, Token.MARKUP_TAG_NAME);
-							  addToken(zzMarkedPos-1,zzMarkedPos-1, Token.MARKUP_TAG_DELIMITER);
+							  addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE);
+							  addToken(temp,temp+1, TokenTypes.MARKUP_TAG_DELIMITER);
+							  addToken(zzMarkedPos-7,zzMarkedPos-2, TokenTypes.MARKUP_TAG_NAME);
+							  addToken(zzMarkedPos-1,zzMarkedPos-1, TokenTypes.MARKUP_TAG_DELIMITER);
           }
         case 178: break;
         case 19:
@@ -25357,7 +25357,7 @@ public class PHPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 179: break;
         case 7:
-          { addToken(start,zzStartRead-1, Token.MARKUP_COMMENT); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.MARKUP_COMMENT); return firstToken;
           }
         case 180: break;
         case 98:
@@ -25365,53 +25365,53 @@ public class PHPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 181: break;
         case 40:
-          { int type = validJSString ? Token.LITERAL_STRING_DOUBLE_QUOTE : Token.ERROR_STRING_DOUBLE; addToken(start,zzStartRead, type); yybegin(JAVASCRIPT);
+          { int type = validJSString ? TokenTypes.LITERAL_STRING_DOUBLE_QUOTE : TokenTypes.ERROR_STRING_DOUBLE; addToken(start,zzStartRead, type); yybegin(JAVASCRIPT);
           }
         case 182: break;
         case 122:
-          { addToken(Token.COMMENT_MULTILINE);
+          { addToken(TokenTypes.COMMENT_MULTILINE);
           }
         case 183: break;
         case 107:
           { int count = yylength();
-									addToken(zzStartRead,zzStartRead, Token.FUNCTION);
+									addToken(zzStartRead,zzStartRead, TokenTypes.FUNCTION);
 									zzMarkedPos -= (count-1); //yypushback(count-1);
           }
         case 184: break;
         case 130:
-          { addToken(zzStartRead,zzStartRead, Token.MARKUP_TAG_DELIMITER);
-								  addToken(zzMarkedPos-5,zzMarkedPos-1, Token.MARKUP_TAG_NAME);
+          { addToken(zzStartRead,zzStartRead, TokenTypes.MARKUP_TAG_DELIMITER);
+								  addToken(zzMarkedPos-5,zzMarkedPos-1, TokenTypes.MARKUP_TAG_NAME);
 								  start = zzMarkedPos; cssPrevState = zzLexicalState; yybegin(INTAG_STYLE);
           }
         case 185: break;
         case 135:
           { int temp = zzStartRead;
-							  addToken(start,zzStartRead-1, Token.COMMENT_EOL);
+							  addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL);
 							  yybegin(YYINITIAL, LANG_INDEX_DEFAULT);
-							  addToken(temp,temp+1, Token.MARKUP_TAG_DELIMITER);
-							  addToken(zzMarkedPos-7,zzMarkedPos-2, Token.MARKUP_TAG_NAME);
-							  addToken(zzMarkedPos-1,zzMarkedPos-1, Token.MARKUP_TAG_DELIMITER);
+							  addToken(temp,temp+1, TokenTypes.MARKUP_TAG_DELIMITER);
+							  addToken(zzMarkedPos-7,zzMarkedPos-2, TokenTypes.MARKUP_TAG_NAME);
+							  addToken(zzMarkedPos-1,zzMarkedPos-1, TokenTypes.MARKUP_TAG_DELIMITER);
           }
         case 186: break;
         case 72:
           { int temp = zzMarkedPos - 2;
-						  addToken(zzStartRead, temp, Token.FUNCTION);
-						  addToken(zzMarkedPos-1, zzMarkedPos-1, Token.SEPARATOR);
+						  addToken(zzStartRead, temp, TokenTypes.FUNCTION);
+						  addToken(zzMarkedPos-1, zzMarkedPos-1, TokenTypes.SEPARATOR);
 						  zzStartRead = zzCurrentPos = zzMarkedPos;
           }
         case 187: break;
         case 63:
-          { /*System.out.println("css_property: " + yytext());*/ addToken(Token.IDENTIFIER);
+          { /*System.out.println("css_property: " + yytext());*/ addToken(TokenTypes.IDENTIFIER);
           }
         case 188: break;
         case 8:
-          { addToken(start,zzStartRead-1, Token.MARKUP_DTD); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.MARKUP_DTD); return firstToken;
           }
         case 189: break;
         case 117:
           { boolean highlightedAsRegex = false;
 										if (firstToken==null) {
-											addToken(Token.REGEX);
+											addToken(TokenTypes.REGEX);
 											highlightedAsRegex = true;
 										}
 										else {
@@ -25419,7 +25419,7 @@ public class PHPTokenMaker extends AbstractMarkupTokenMaker {
 											// the previous token, highlight it as such.
 											Token t = firstToken.getLastNonCommentNonWhitespaceToken();
 											if (RSyntaxUtilities.regexCanFollowInJavaScript(t)) {
-												addToken(Token.REGEX);
+												addToken(TokenTypes.REGEX);
 												highlightedAsRegex = true;
 											}
 										}
@@ -25427,7 +25427,7 @@ public class PHPTokenMaker extends AbstractMarkupTokenMaker {
 										// individual tokens.
 										if (!highlightedAsRegex) {
 											int temp = zzStartRead + 1;
-											addToken(zzStartRead, zzStartRead, Token.OPERATOR);
+											addToken(zzStartRead, zzStartRead, TokenTypes.OPERATOR);
 											zzStartRead = zzCurrentPos = zzMarkedPos = temp;
 										}
           }
@@ -25442,18 +25442,18 @@ public class PHPTokenMaker extends AbstractMarkupTokenMaker {
         case 192: break;
         case 82:
           { // TODO: This isn't right.  The expression and its depth should continue to the next line.
-							addToken(start,zzStartRead-1, Token.VARIABLE); addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_INVALID); return firstToken;
+							addToken(start,zzStartRead-1, TokenTypes.VARIABLE); addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_INVALID); return firstToken;
           }
         case 193: break;
         case 133:
           { yybegin(YYINITIAL, LANG_INDEX_DEFAULT);
-								  addToken(zzStartRead,zzStartRead+1, Token.MARKUP_TAG_DELIMITER);
-								  addToken(zzMarkedPos-7,zzMarkedPos-2, Token.MARKUP_TAG_NAME);
-								  addToken(zzMarkedPos-1,zzMarkedPos-1, Token.MARKUP_TAG_DELIMITER);
+								  addToken(zzStartRead,zzStartRead+1, TokenTypes.MARKUP_TAG_DELIMITER);
+								  addToken(zzMarkedPos-7,zzMarkedPos-2, TokenTypes.MARKUP_TAG_NAME);
+								  addToken(zzMarkedPos-1,zzMarkedPos-1, TokenTypes.MARKUP_TAG_DELIMITER);
           }
         case 194: break;
         case 100:
-          { yybegin(JAVASCRIPT); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE);
+          { yybegin(JAVASCRIPT); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE);
           }
         case 195: break;
         case 30:
@@ -25470,15 +25470,15 @@ public class PHPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 197: break;
         case 36:
-          { addToken(start,zzStartRead-1, Token.ERROR_CHAR); addEndToken(INTERNAL_IN_JS); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.ERROR_CHAR); addEndToken(INTERNAL_IN_JS); return firstToken;
           }
         case 198: break;
         case 14:
-          { addToken(Token.OPERATOR);
+          { addToken(TokenTypes.OPERATOR);
           }
         case 199: break;
         case 70:
-          { addToken(Token.OPERATOR); yybegin(CSS_PROPERTY);
+          { addToken(TokenTypes.OPERATOR); yybegin(CSS_PROPERTY);
           }
         case 200: break;
         case 120:
@@ -25486,47 +25486,47 @@ public class PHPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 201: break;
         case 116:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead+2, Token.MARKUP_COMMENT);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead+2, TokenTypes.MARKUP_COMMENT);
           }
         case 202: break;
         case 102:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_DOCUMENTATION);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_DOCUMENTATION);
           }
         case 203: break;
         case 104:
-          { addToken(Token.VARIABLE);
+          { addToken(TokenTypes.VARIABLE);
           }
         case 204: break;
         case 56:
-          { /*System.out.println("CSS: " + yytext());*/ addToken(Token.IDENTIFIER);
+          { /*System.out.println("CSS: " + yytext());*/ addToken(TokenTypes.IDENTIFIER);
           }
         case 205: break;
         case 43:
-          { addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addEndToken(INTERNAL_IN_JS_COMMENT_DOCUMENTATION); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addEndToken(INTERNAL_IN_JS_COMMENT_DOCUMENTATION); return firstToken;
           }
         case 206: break;
         case 81:
-          { int type = validJSString ? Token.LITERAL_BACKQUOTE : Token.ERROR_STRING_DOUBLE; addToken(start,zzStartRead, type); yybegin(JAVASCRIPT);
+          { int type = validJSString ? TokenTypes.LITERAL_BACKQUOTE : TokenTypes.ERROR_STRING_DOUBLE; addToken(start,zzStartRead, type); yybegin(JAVASCRIPT);
           }
         case 207: break;
         case 2:
-          { addToken(Token.IDENTIFIER);
+          { addToken(TokenTypes.IDENTIFIER);
           }
         case 208: break;
         case 125:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos;
           }
         case 209: break;
         case 22:
-          { addToken(Token.MARKUP_TAG_DELIMITER); yybegin(JAVASCRIPT, LANG_INDEX_JS);
+          { addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(JAVASCRIPT, LANG_INDEX_JS);
           }
         case 210: break;
         case 88:
-          { int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addToken(temp, zzMarkedPos-1, Token.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP);
+          { int temp=zzStartRead; if (zzStartRead>start) addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addToken(temp, zzMarkedPos-1, TokenTypes.SEPARATOR); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP);
           }
         case 211: break;
         case 128:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos;
           }
         case 212: break;
         case 103:
@@ -25538,7 +25538,7 @@ public class PHPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 214: break;
         case 66:
-          { addToken(Token.SEPARATOR); yybegin(CSS);
+          { addToken(TokenTypes.SEPARATOR); yybegin(CSS);
           }
         case 215: break;
         case 118:
@@ -25550,7 +25550,7 @@ public class PHPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 217: break;
         case 74:
-          { addToken(start,zzStartRead, Token.LITERAL_STRING_DOUBLE_QUOTE); yybegin(cssPrevState);
+          { addToken(start,zzStartRead, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); yybegin(cssPrevState);
           }
         case 218: break;
         case 64:
@@ -25562,7 +25562,7 @@ public class PHPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 220: break;
         case 38:
-          { int type = validJSString ? Token.LITERAL_CHAR : Token.ERROR_CHAR; addToken(start,zzStartRead, type); yybegin(JAVASCRIPT);
+          { int type = validJSString ? TokenTypes.LITERAL_CHAR : TokenTypes.ERROR_CHAR; addToken(start,zzStartRead, type); yybegin(JAVASCRIPT);
           }
         case 221: break;
         case 34:
@@ -25570,11 +25570,11 @@ public class PHPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 222: break;
         case 24:
-          { addToken(start,zzStartRead, Token.MARKUP_TAG_ATTRIBUTE_VALUE); yybegin(INTAG_SCRIPT);
+          { addToken(start,zzStartRead, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); yybegin(INTAG_SCRIPT);
           }
         case 223: break;
         case 126:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_DOCUMENTATION); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_DOCUMENTATION); start = zzMarkedPos;
           }
         case 224: break;
         case 91:
@@ -25582,27 +25582,27 @@ public class PHPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 225: break;
         case 94:
-          { addToken(Token.LITERAL_NUMBER_HEXADECIMAL);
+          { addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL);
           }
         case 226: break;
         case 50:
-          { addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); addPhpEndToken(INTERNAL_IN_PHP_STRING); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); addPhpEndToken(INTERNAL_IN_PHP_STRING); return firstToken;
           }
         case 227: break;
         case 136:
-          { addToken(Token.ANNOTATION);
+          { addToken(TokenTypes.ANNOTATION);
           }
         case 228: break;
         case 108:
-          { yybegin(PHP); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE);
+          { yybegin(PHP); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE);
           }
         case 229: break;
         case 51:
-          { yybegin(PHP); addToken(start,zzStartRead, Token.LITERAL_STRING_DOUBLE_QUOTE);
+          { yybegin(PHP); addToken(start,zzStartRead, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
           }
         case 230: break;
         case 29:
-          { addToken(Token.ERROR_IDENTIFIER);
+          { addToken(TokenTypes.ERROR_IDENTIFIER);
           }
         case 231: break;
         case 69:
@@ -25610,11 +25610,11 @@ public class PHPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 232: break;
         case 6:
-          { addToken(Token.MARKUP_ENTITY_REFERENCE);
+          { addToken(TokenTypes.MARKUP_ENTITY_REFERENCE);
           }
         case 233: break;
         case 123:
-          { addToken(Token.LITERAL_BOOLEAN);
+          { addToken(TokenTypes.LITERAL_BOOLEAN);
           }
         case 234: break;
         case 17:
@@ -25634,21 +25634,21 @@ public class PHPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 238: break;
         case 86:
-          { addToken(Token.MARKUP_TAG_DELIMITER); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP);
+          { addToken(TokenTypes.MARKUP_TAG_DELIMITER); phpInState = zzLexicalState; yybegin(PHP, LANG_INDEX_PHP);
           }
         case 239: break;
         case 65:
-          { addToken(Token.RESERVED_WORD);
+          { addToken(TokenTypes.RESERVED_WORD);
           }
         case 240: break;
         case 41:
           { /* Line ending in '\' => continue to next line. */
 								if (validJSString) {
-									addToken(start,zzStartRead, Token.LITERAL_STRING_DOUBLE_QUOTE);
+									addToken(start,zzStartRead, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
 									addEndToken(INTERNAL_IN_JS_STRING_VALID);
 								}
 								else {
-									addToken(start,zzStartRead, Token.ERROR_STRING_DOUBLE);
+									addToken(start,zzStartRead, TokenTypes.ERROR_STRING_DOUBLE);
 									addEndToken(INTERNAL_IN_JS_STRING_INVALID);
 								}
 								return firstToken;
@@ -25659,72 +25659,72 @@ public class PHPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 242: break;
         case 47:
-          { addToken(Token.COMMENT_EOL); addPhpEndToken(INTERNAL_IN_PHP); return firstToken;
+          { addToken(TokenTypes.COMMENT_EOL); addPhpEndToken(INTERNAL_IN_PHP); return firstToken;
           }
         case 243: break;
         case 13:
-          { yybegin(YYINITIAL); addToken(Token.MARKUP_TAG_DELIMITER);
+          { yybegin(YYINITIAL); addToken(TokenTypes.MARKUP_TAG_DELIMITER);
           }
         case 244: break;
         case 59:
-          { addToken(Token.DATA_TYPE);
+          { addToken(TokenTypes.DATA_TYPE);
           }
         case 245: break;
         case 53:
-          { addToken(start,zzStartRead-1, Token.LITERAL_CHAR); addPhpEndToken(INTERNAL_IN_PHP_CHAR); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.LITERAL_CHAR); addPhpEndToken(INTERNAL_IN_PHP_CHAR); return firstToken;
           }
         case 246: break;
         case 55:
-          { yybegin(PHP); addToken(start,zzStartRead, Token.LITERAL_CHAR);
+          { yybegin(PHP); addToken(start,zzStartRead, TokenTypes.LITERAL_CHAR);
           }
         case 247: break;
         case 33:
-          { addToken(Token.SEPARATOR);
+          { addToken(TokenTypes.SEPARATOR);
           }
         case 248: break;
         case 79:
           { if (validJSString) {
-									addToken(start,zzStartRead, Token.LITERAL_BACKQUOTE);
+									addToken(start,zzStartRead, TokenTypes.LITERAL_BACKQUOTE);
 									addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_VALID);
 								}
 								else {
-									addToken(start,zzStartRead, Token.ERROR_STRING_DOUBLE);
+									addToken(start,zzStartRead, TokenTypes.ERROR_STRING_DOUBLE);
 									addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_INVALID);
 								}
 								return firstToken;
           }
         case 249: break;
         case 73:
-          { addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); addEndToken(INTERNAL_CSS_STRING - cssPrevState); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); addEndToken(INTERNAL_CSS_STRING - cssPrevState); return firstToken;
           }
         case 250: break;
         case 71:
-          { /* End of a function */ addToken(Token.SEPARATOR);
+          { /* End of a function */ addToken(TokenTypes.SEPARATOR);
           }
         case 251: break;
         case 18:
-          { addToken(Token.MARKUP_TAG_NAME);
+          { addToken(TokenTypes.MARKUP_TAG_NAME);
           }
         case 252: break;
         case 10:
-          { addToken(Token.MARKUP_TAG_ATTRIBUTE);
+          { addToken(TokenTypes.MARKUP_TAG_ATTRIBUTE);
           }
         case 253: break;
         case 37:
           { /* Line ending in '\' => continue to next line. */
 								if (validJSString) {
-									addToken(start,zzStartRead, Token.LITERAL_CHAR);
+									addToken(start,zzStartRead, TokenTypes.LITERAL_CHAR);
 									addEndToken(INTERNAL_IN_JS_CHAR_VALID);
 								}
 								else {
-									addToken(start,zzStartRead, Token.ERROR_CHAR);
+									addToken(start,zzStartRead, TokenTypes.ERROR_CHAR);
 									addEndToken(INTERNAL_IN_JS_CHAR_INVALID);
 								}
 								return firstToken;
           }
         case 254: break;
         case 127:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, Token.COMMENT_KEYWORD); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_KEYWORD); start = zzMarkedPos;
           }
         case 255: break;
         case 48:
@@ -25732,7 +25732,7 @@ public class PHPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 256: break;
         case 105:
-          { yybegin(phpInState, phpInLangIndex); addToken(Token.MARKUP_TAG_DELIMITER); start = zzMarkedPos;
+          { yybegin(phpInState, phpInLangIndex); addToken(TokenTypes.MARKUP_TAG_DELIMITER); start = zzMarkedPos;
           }
         case 257: break;
         case 90:
@@ -25740,7 +25740,7 @@ public class PHPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 258: break;
         case 93:
-          { addToken(Token.LITERAL_NUMBER_FLOAT);
+          { addToken(TokenTypes.LITERAL_NUMBER_FLOAT);
           }
         case 259: break;
         case 15:
@@ -25748,15 +25748,15 @@ public class PHPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 260: break;
         case 77:
-          { addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addEndToken(INTERNAL_CSS_MLC - cssPrevState); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addEndToken(INTERNAL_CSS_MLC - cssPrevState); return firstToken;
           }
         case 261: break;
         case 12:
-          { addToken(Token.MARKUP_TAG_DELIMITER);
+          { addToken(TokenTypes.MARKUP_TAG_DELIMITER);
           }
         case 262: break;
         case 32:
-          { addToken(Token.LITERAL_NUMBER_DECIMAL_INT);
+          { addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT);
           }
         case 263: break;
         case 85:
@@ -25765,22 +25765,22 @@ public class PHPTokenMaker extends AbstractMarkupTokenMaker {
         case 264: break;
         case 78:
           { if (validJSString) {
-									addToken(start, zzStartRead - 1, Token.LITERAL_BACKQUOTE);
+									addToken(start, zzStartRead - 1, TokenTypes.LITERAL_BACKQUOTE);
 									addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_VALID);
 								}
 								else {
-									addToken(start,zzStartRead - 1, Token.ERROR_STRING_DOUBLE);
+									addToken(start,zzStartRead - 1, TokenTypes.ERROR_STRING_DOUBLE);
 									addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_INVALID);
 								}
 								return firstToken;
           }
         case 265: break;
         case 20:
-          { addToken(start,zzStartRead, Token.MARKUP_TAG_ATTRIBUTE_VALUE); yybegin(INTAG);
+          { addToken(start,zzStartRead, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); yybegin(INTAG);
           }
         case 266: break;
         case 49:
-          { addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addPhpEndToken(INTERNAL_IN_PHP_MLC); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addPhpEndToken(INTERNAL_IN_PHP_MLC); return firstToken;
           }
         case 267: break;
         case 21:
@@ -25788,16 +25788,16 @@ public class PHPTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 268: break;
         case 44:
-          { addToken(start,zzStartRead-1, Token.COMMENT_EOL); addEndToken(INTERNAL_IN_JS); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addEndToken(INTERNAL_IN_JS); return firstToken;
           }
         case 269: break;
         case 60:
-          { /* Unknown pseudo class */ addToken(Token.DATA_TYPE);
+          { /* Unknown pseudo class */ addToken(TokenTypes.DATA_TYPE);
           }
         case 270: break;
         case 131:
-          { addToken(zzStartRead,zzStartRead, Token.MARKUP_TAG_DELIMITER);
-								  addToken(zzMarkedPos-6,zzMarkedPos-1, Token.MARKUP_TAG_NAME);
+          { addToken(zzStartRead,zzStartRead, TokenTypes.MARKUP_TAG_DELIMITER);
+								  addToken(zzMarkedPos-6,zzMarkedPos-1, TokenTypes.MARKUP_TAG_NAME);
 								  start = zzMarkedPos; yybegin(INTAG_SCRIPT);
           }
         case 271: break;
@@ -25814,27 +25814,27 @@ public class PHPTokenMaker extends AbstractMarkupTokenMaker {
             }
             case 8199: break;
             case INATTR_SINGLE_SCRIPT: {
-              addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE_QUOTE_SCRIPT); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE_QUOTE_SCRIPT); return firstToken;
             }
             case 8200: break;
             case JS_CHAR: {
-              addToken(start,zzStartRead-1, Token.ERROR_CHAR); addEndToken(INTERNAL_IN_JS); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.ERROR_CHAR); addEndToken(INTERNAL_IN_JS); return firstToken;
             }
             case 8201: break;
             case CSS_STRING: {
-              addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); addEndToken(INTERNAL_CSS_STRING - cssPrevState); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); addEndToken(INTERNAL_CSS_STRING - cssPrevState); return firstToken;
             }
             case 8202: break;
             case JS_DOCCOMMENT: {
-              yybegin(YYINITIAL); addToken(start,zzEndRead, Token.COMMENT_DOCUMENTATION); addEndToken(INTERNAL_IN_JS_COMMENT_DOCUMENTATION); return firstToken;
+              yybegin(YYINITIAL); addToken(start,zzEndRead, TokenTypes.COMMENT_DOCUMENTATION); addEndToken(INTERNAL_IN_JS_COMMENT_DOCUMENTATION); return firstToken;
             }
             case 8203: break;
             case JS_MLC: {
-              addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_JS_MLC); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_JS_MLC); return firstToken;
             }
             case 8204: break;
             case CSS_CHAR_LITERAL: {
-              addToken(start,zzStartRead-1, Token.LITERAL_CHAR); addEndToken(INTERNAL_CSS_CHAR - cssPrevState); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.LITERAL_CHAR); addEndToken(INTERNAL_CSS_CHAR - cssPrevState); return firstToken;
             }
             case 8205: break;
             case INTAG_SCRIPT: {
@@ -25843,7 +25843,7 @@ public class PHPTokenMaker extends AbstractMarkupTokenMaker {
             case 8206: break;
             case JS_TEMPLATE_LITERAL_EXPR: {
               // TODO: This isn't right.  The expression and its depth should continue to the next line.
-							addToken(start,zzStartRead-1, Token.VARIABLE); addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_INVALID); return firstToken;
+							addToken(start,zzStartRead-1, TokenTypes.VARIABLE); addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_INVALID); return firstToken;
             }
             case 8207: break;
             case CSS_PROPERTY: {
@@ -25851,11 +25851,11 @@ public class PHPTokenMaker extends AbstractMarkupTokenMaker {
             }
             case 8208: break;
             case CSS_C_STYLE_COMMENT: {
-              addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addEndToken(INTERNAL_CSS_MLC - cssPrevState); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addEndToken(INTERNAL_CSS_MLC - cssPrevState); return firstToken;
             }
             case 8209: break;
             case PHP_MLC: {
-              addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addPhpEndToken(INTERNAL_IN_PHP_MLC); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addPhpEndToken(INTERNAL_IN_PHP_MLC); return firstToken;
             }
             case 8210: break;
             case CSS: {
@@ -25867,15 +25867,15 @@ public class PHPTokenMaker extends AbstractMarkupTokenMaker {
             }
             case 8212: break;
             case COMMENT: {
-              addToken(start,zzStartRead-1, Token.MARKUP_COMMENT); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_COMMENT); return firstToken;
             }
             case 8213: break;
             case INATTR_DOUBLE_SCRIPT: {
-              addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE_QUOTE_SCRIPT); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE_QUOTE_SCRIPT); return firstToken;
             }
             case 8214: break;
             case PHP_STRING: {
-              addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); addPhpEndToken(INTERNAL_IN_PHP_STRING); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); addPhpEndToken(INTERNAL_IN_PHP_STRING); return firstToken;
             }
             case 8215: break;
             case JAVASCRIPT: {
@@ -25891,36 +25891,36 @@ public class PHPTokenMaker extends AbstractMarkupTokenMaker {
             }
             case 8218: break;
             case INATTR_SINGLE_STYLE: {
-              addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE_QUOTE_STYLE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE_QUOTE_STYLE); return firstToken;
             }
             case 8219: break;
             case DTD: {
-              addToken(start,zzStartRead-1, Token.MARKUP_DTD); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_DTD); return firstToken;
             }
             case 8220: break;
             case PHP_CHAR: {
-              addToken(start,zzStartRead-1, Token.LITERAL_CHAR); addPhpEndToken(INTERNAL_IN_PHP_CHAR); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.LITERAL_CHAR); addPhpEndToken(INTERNAL_IN_PHP_CHAR); return firstToken;
             }
             case 8221: break;
             case JS_EOL_COMMENT: {
-              addToken(start,zzStartRead-1, Token.COMMENT_EOL); addEndToken(INTERNAL_IN_JS); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addEndToken(INTERNAL_IN_JS); return firstToken;
             }
             case 8222: break;
             case INATTR_DOUBLE_STYLE: {
-              addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE_QUOTE_STYLE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE_QUOTE_STYLE); return firstToken;
             }
             case 8223: break;
             case INATTR_SINGLE: {
-              addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE); return firstToken;
             }
             case 8224: break;
             case JS_TEMPLATE_LITERAL: {
               if (validJSString) {
-									addToken(start, zzStartRead - 1, Token.LITERAL_BACKQUOTE);
+									addToken(start, zzStartRead - 1, TokenTypes.LITERAL_BACKQUOTE);
 									addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_VALID);
 								}
 								else {
-									addToken(start,zzStartRead - 1, Token.ERROR_STRING_DOUBLE);
+									addToken(start,zzStartRead - 1, TokenTypes.ERROR_STRING_DOUBLE);
 									addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_INVALID);
 								}
 								return firstToken;
@@ -25931,11 +25931,11 @@ public class PHPTokenMaker extends AbstractMarkupTokenMaker {
             }
             case 8226: break;
             case INATTR_DOUBLE: {
-              addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE); return firstToken;
             }
             case 8227: break;
             case JS_STRING: {
-              addToken(start,zzStartRead-1, Token.ERROR_STRING_DOUBLE); addEndToken(INTERNAL_IN_JS); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.ERROR_STRING_DOUBLE); addEndToken(INTERNAL_IN_JS); return firstToken;
             }
             case 8228: break;
             case INTAG_STYLE: {

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/PerlTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/PerlTokenMaker.flex
@@ -157,7 +157,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 
 
 	public boolean getMarkOccurrencesOfTokenType(int type) {
-		return super.getMarkOccurrencesOfTokenType(type) || type==Token.VARIABLE;
+		return super.getMarkOccurrencesOfTokenType(type) || type==TokenTypes.VARIABLE;
 	}
 
 
@@ -181,15 +181,15 @@ import org.fife.ui.rsyntaxtextarea.*;
 		// Start off in the proper state.
 		int state;
 		switch (initialTokenType) {
-			case Token.LITERAL_STRING_DOUBLE_QUOTE:
+			case TokenTypes.LITERAL_STRING_DOUBLE_QUOTE:
 				state = STRING;
 				start = text.offset;
 				break;
-			case Token.LITERAL_CHAR:
+			case TokenTypes.LITERAL_CHAR:
 				state = CHAR_LITERAL;
 				start = text.offset;
 				break;
-			case Token.LITERAL_BACKQUOTE:
+			case TokenTypes.LITERAL_BACKQUOTE:
 				state = BACKTICKS;
 				start = text.offset;
 				break;
@@ -253,7 +253,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 					ch=='&'
 				)) ||
 				/* Operators "==", "===", "!=", "!==", etc. */
-				(t.getType()==Token.OPERATOR &&
+				(t.getType()==TokenTypes.OPERATOR &&
 					((ch=t.charAt(t.length()-1))=='=' || ch=='~'));
 	}
 
@@ -389,7 +389,7 @@ ErrorIdentifier			= ({NonSeparator}+)
 	"unless" |
 	"until" |
 	"while" |
-	"xor"				{ addToken(Token.RESERVED_WORD); }
+	"xor"				{ addToken(TokenTypes.RESERVED_WORD); }
 
 	/* Standard Functions */
 	"abs" |
@@ -591,16 +591,16 @@ ErrorIdentifier			= ({NonSeparator}+)
 	"waitpid" |
 	"wantarray" |
 	"warn" |
-	"write"			{ addToken(Token.FUNCTION); }
+	"write"			{ addToken(TokenTypes.FUNCTION); }
 
 }
 
 <YYINITIAL> {
 
 	{LineTerminator}				{ addNullToken(); return firstToken; }
-	{Identifier}					{ addToken(Token.IDENTIFIER); }
-	{WhiteSpace}+					{ addToken(Token.WHITESPACE); }
-	{Variable}					{ addToken(Token.VARIABLE); }
+	{Identifier}					{ addToken(TokenTypes.IDENTIFIER); }
+	{WhiteSpace}+					{ addToken(TokenTypes.WHITESPACE); }
+	{Variable}					{ addToken(TokenTypes.VARIABLE); }
 
 	/* String/Character literals. */
 	\"							{ start = zzMarkedPos-1; yybegin(STRING); }
@@ -608,14 +608,14 @@ ErrorIdentifier			= ({NonSeparator}+)
 	\`							{ start = zzMarkedPos-1; yybegin(BACKTICKS); }
 
 	/* Comment literals. */
-	{LineCommentBegin}"!".*			{ addToken(Token.PREPROCESSOR); addNullToken(); return firstToken; }
-	{LineCommentBegin}.*			{ addToken(Token.COMMENT_EOL); addNullToken(); return firstToken; }
+	{LineCommentBegin}"!".*			{ addToken(TokenTypes.PREPROCESSOR); addNullToken(); return firstToken; }
+	{LineCommentBegin}.*			{ addToken(TokenTypes.COMMENT_EOL); addNullToken(); return firstToken; }
 
 	/* Easily identifiable regexes of the form "/.../". This is not foolproof. */
 	{Regex}		{
 					boolean highlightedAsRegex = false;
 					if (firstToken==null) {
-						addToken(Token.REGEX);
+						addToken(TokenTypes.REGEX);
 						highlightedAsRegex = true;
 					}
 					else {
@@ -623,7 +623,7 @@ ErrorIdentifier			= ({NonSeparator}+)
 						// the previous token, highlight it as such.
 						Token t = firstToken.getLastNonCommentNonWhitespaceToken();
 						if (regexCanFollow(t)) {
-							addToken(Token.REGEX);
+							addToken(TokenTypes.REGEX);
 							highlightedAsRegex = true;
 						}
 					}
@@ -631,28 +631,28 @@ ErrorIdentifier			= ({NonSeparator}+)
 					// individual tokens.
 					if (!highlightedAsRegex) {
 						int temp = zzStartRead + 1;
-						addToken(zzStartRead, zzStartRead, Token.OPERATOR);
+						addToken(zzStartRead, zzStartRead, TokenTypes.OPERATOR);
 						zzStartRead = zzCurrentPos = zzMarkedPos = temp;
 					}
 				}
 
 	/* More regexes (m/.../, s!...!!, etc.).  This is nowhere near */
 	/* exhaustive, but is rather just the common ones.             */
-	m"/"[^/]*"/"[msixpodualgc]*				{ addToken(Token.REGEX); }
-	m"!"[^!]*"!"[msixpodualgc]*				{ addToken(Token.REGEX); }
-	m"|"[^\|]*"|"[msixpodualgc]*			{ addToken(Token.REGEX); }
-	m\\[^\\]*\\[msixpodualgc]*				{ addToken(Token.REGEX); }
-	s"/"[^/]*"/"[^/]*"/"[msixpodualgcer]*	{ addToken(Token.REGEX); }
-	s"!"[^!]*"!"[^!]*"!"[msixpodualgcer]*	{ addToken(Token.REGEX); }
-	s"|"[^\|]*"|"[^\|]*"|"[msixpodualgcer]*	{ addToken(Token.REGEX); }
-	(tr|y)"/"[^/]*"/"[^/]*"/"[cdsr]*		{ addToken(Token.REGEX); }
-	(tr|y)"!"[^!]*"!"[^!]*"!"[cdsr]*		{ addToken(Token.REGEX); }
-	(tr|y)"|"[^\|]*"|"[^\|]*"|"[cdsr]*		{ addToken(Token.REGEX); }
-	(tr|y)\\[^\\]*\\[^\\]*\\[cdsr]*		{ addToken(Token.REGEX); }
-	qr"/"[^/]*"/"[msixpodual]*			{ addToken(Token.REGEX); }
-	qr"!"[^/]*"!"[msixpodual]*			{ addToken(Token.REGEX); }
-	qr"|"[^/]*"|"[msixpodual]*			{ addToken(Token.REGEX); }
-	qr\\[^/]*\\[msixpodual]*			{ addToken(Token.REGEX); }
+	m"/"[^/]*"/"[msixpodualgc]*				{ addToken(TokenTypes.REGEX); }
+	m"!"[^!]*"!"[msixpodualgc]*				{ addToken(TokenTypes.REGEX); }
+	m"|"[^\|]*"|"[msixpodualgc]*			{ addToken(TokenTypes.REGEX); }
+	m\\[^\\]*\\[msixpodualgc]*				{ addToken(TokenTypes.REGEX); }
+	s"/"[^/]*"/"[^/]*"/"[msixpodualgcer]*	{ addToken(TokenTypes.REGEX); }
+	s"!"[^!]*"!"[^!]*"!"[msixpodualgcer]*	{ addToken(TokenTypes.REGEX); }
+	s"|"[^\|]*"|"[^\|]*"|"[msixpodualgcer]*	{ addToken(TokenTypes.REGEX); }
+	(tr|y)"/"[^/]*"/"[^/]*"/"[cdsr]*		{ addToken(TokenTypes.REGEX); }
+	(tr|y)"!"[^!]*"!"[^!]*"!"[cdsr]*		{ addToken(TokenTypes.REGEX); }
+	(tr|y)"|"[^\|]*"|"[^\|]*"|"[cdsr]*		{ addToken(TokenTypes.REGEX); }
+	(tr|y)\\[^\\]*\\[^\\]*\\[cdsr]*		{ addToken(TokenTypes.REGEX); }
+	qr"/"[^/]*"/"[msixpodual]*			{ addToken(TokenTypes.REGEX); }
+	qr"!"[^/]*"!"[msixpodual]*			{ addToken(TokenTypes.REGEX); }
+	qr"|"[^/]*"|"[msixpodual]*			{ addToken(TokenTypes.REGEX); }
+	qr\\[^/]*\\[msixpodual]*			{ addToken(TokenTypes.REGEX); }
 
 	/* "Here-document" syntax.  This is only implemented for the common */
 	/* cases.                                                           */
@@ -666,26 +666,26 @@ ErrorIdentifier			= ({NonSeparator}+)
 	"<<" {WhiteSpace}* \`"EOT"\`		{ start = zzStartRead; yybegin(HEREDOC_EOT_UNQUOTED); }
 
 	/* POD commands. */
-	{PodCommandsExceptCut}			{ addToken(Token.COMMENT_EOL); start = zzMarkedPos; yybegin(POD); }
+	{PodCommandsExceptCut}			{ addToken(TokenTypes.COMMENT_EOL); start = zzMarkedPos; yybegin(POD); }
 
 	/* Separators and operators. */
-	{Separator}					{ addToken(Token.SEPARATOR); }
-	{Separator2}					{ addToken(Token.IDENTIFIER); }
-	{Operator}					{ addToken(Token.OPERATOR); }
+	{Separator}					{ addToken(TokenTypes.SEPARATOR); }
+	{Separator2}					{ addToken(TokenTypes.IDENTIFIER); }
+	{Operator}					{ addToken(TokenTypes.OPERATOR); }
 
 	/* Numbers */
-	{IntegerLiteral}				{ addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
-	{HexLiteral}					{ addToken(Token.LITERAL_NUMBER_HEXADECIMAL); }
-	{FloatLiteral}					{ addToken(Token.LITERAL_NUMBER_FLOAT); }
-	{ErrorNumberFormat}				{ addToken(Token.ERROR_NUMBER_FORMAT); }
+	{IntegerLiteral}				{ addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT); }
+	{HexLiteral}					{ addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL); }
+	{FloatLiteral}					{ addToken(TokenTypes.LITERAL_NUMBER_FLOAT); }
+	{ErrorNumberFormat}				{ addToken(TokenTypes.ERROR_NUMBER_FORMAT); }
 
-	{ErrorIdentifier}				{ addToken(Token.ERROR_IDENTIFIER); }
+	{ErrorIdentifier}				{ addToken(TokenTypes.ERROR_IDENTIFIER); }
 
 	/* Ended with a line not in a string or comment. */
 	<<EOF>>						{ addNullToken(); return firstToken; }
 
 	/* Catch any other (unhandled) characters and flag them as bad. */
-	.							{ addToken(Token.ERROR_IDENTIFIER); }
+	.							{ addToken(TokenTypes.ERROR_IDENTIFIER); }
 
 }
 
@@ -693,31 +693,31 @@ ErrorIdentifier			= ({NonSeparator}+)
 <STRING> {
 	[^\n\\\$\@\%\"]+		{}
 	\\.?					{ /* Skip escaped chars. */ }
-	{Variable}			{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); addToken(temp,zzMarkedPos-1, Token.VARIABLE); start = zzMarkedPos; }
+	{Variable}			{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); addToken(temp,zzMarkedPos-1, TokenTypes.VARIABLE); start = zzMarkedPos; }
 	{VariableStart}		{}
-	\"					{ yybegin(YYINITIAL); addToken(start,zzStartRead, Token.LITERAL_STRING_DOUBLE_QUOTE); }
+	\"					{ yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); }
 	\n |
-	<<EOF>>				{ addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken; }
+	<<EOF>>				{ addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken; }
 }
 
 
 <CHAR_LITERAL> {
 	[^\n\\\']+			{}
 	\\.?					{ /* Skip escaped single quotes only, but this should still work. */ }
-	\'					{ yybegin(YYINITIAL); addToken(start,zzStartRead, Token.LITERAL_CHAR); }
+	\'					{ yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.LITERAL_CHAR); }
 	\n |
-	<<EOF>>				{ addToken(start,zzStartRead-1, Token.LITERAL_CHAR); return firstToken; }
+	<<EOF>>				{ addToken(start,zzStartRead-1, TokenTypes.LITERAL_CHAR); return firstToken; }
 }
 
 
 <BACKTICKS> {
 	[^\n\\\$\@\%\`]+		{}
 	\\.?					{ /* Skip escaped chars. */ }
-	{Variable}			{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.LITERAL_BACKQUOTE); addToken(temp,zzMarkedPos-1, Token.VARIABLE); start = zzMarkedPos; }
+	{Variable}			{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.LITERAL_BACKQUOTE); addToken(temp,zzMarkedPos-1, TokenTypes.VARIABLE); start = zzMarkedPos; }
 	{VariableStart}		{}
-	\`					{ yybegin(YYINITIAL); addToken(start,zzStartRead, Token.LITERAL_BACKQUOTE); }
+	\`					{ yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.LITERAL_BACKQUOTE); }
 	\n |
-	<<EOF>>				{ addToken(start,zzStartRead-1, Token.LITERAL_BACKQUOTE); return firstToken; }
+	<<EOF>>				{ addToken(start,zzStartRead-1, TokenTypes.LITERAL_BACKQUOTE); return firstToken; }
 }
 
 
@@ -731,13 +731,13 @@ ErrorIdentifier			= ({NonSeparator}+)
 	/* NOTE2: This case is used for unquoted <<EOF, double quoted       */
 	/* <<"EOF" and backticks <<`EOF`, since they all follow the same    */
 	/* syntactic rules.                                                 */
-	"EOF"				{ if (start==zzStartRead) { addToken(Token.PREPROCESSOR); addNullToken(); return firstToken; } }
+	"EOF"				{ if (start==zzStartRead) { addToken(TokenTypes.PREPROCESSOR); addNullToken(); return firstToken; } }
 	[^\n\\\$\@\%]+			{}
 	\\.?					{ /* Skip escaped chars. */ }
-	{Variable}			{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.PREPROCESSOR); addToken(temp,zzMarkedPos-1, Token.VARIABLE); start = zzMarkedPos; }
+	{Variable}			{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.PREPROCESSOR); addToken(temp,zzMarkedPos-1, TokenTypes.VARIABLE); start = zzMarkedPos; }
 	{VariableStart}		{}
 	\n |
-	<<EOF>>				{ addToken(start,zzStartRead-1, Token.PREPROCESSOR); addEndToken(INTERNAL_HEREDOC_EOF_UNQUOTED); return firstToken; }
+	<<EOF>>				{ addToken(start,zzStartRead-1, TokenTypes.PREPROCESSOR); addEndToken(INTERNAL_HEREDOC_EOF_UNQUOTED); return firstToken; }
 }
 
 
@@ -748,11 +748,11 @@ ErrorIdentifier			= ({NonSeparator}+)
 	/* work.  Fortunately we don't need the start- and end-line anchors */
 	/* since the production after "EOF" will match any line containing  */
 	/* EOF and any other chars.                                         */
-	"EOF"				{ if (start==zzStartRead) { addToken(Token.PREPROCESSOR); addNullToken(); return firstToken; } }
+	"EOF"				{ if (start==zzStartRead) { addToken(TokenTypes.PREPROCESSOR); addNullToken(); return firstToken; } }
 	[^\n\\]+				{}
 	\\.?					{ /* Skip escaped chars. */ }
 	\n |
-	<<EOF>>				{ addToken(start,zzStartRead-1, Token.PREPROCESSOR); addEndToken(INTERNAL_HEREDOC_EOF_SINGLE_QUOTED); return firstToken; }
+	<<EOF>>				{ addToken(start,zzStartRead-1, TokenTypes.PREPROCESSOR); addEndToken(INTERNAL_HEREDOC_EOF_SINGLE_QUOTED); return firstToken; }
 }
 
 
@@ -766,13 +766,13 @@ ErrorIdentifier			= ({NonSeparator}+)
 	/* NOTE2: This case is used for unquoted <<EOT, double quoted       */
 	/* <<"EOT" and backticks <<`EOT`, since they all follow the same    */
 	/* syntactic rules.                                                 */
-	"EOT"				{ if (start==zzStartRead) { addToken(Token.PREPROCESSOR); addNullToken(); return firstToken; } }
+	"EOT"				{ if (start==zzStartRead) { addToken(TokenTypes.PREPROCESSOR); addNullToken(); return firstToken; } }
 	[^\n\\\$\@\%]+			{}
 	\\.?					{ /* Skip escaped chars. */ }
-	{Variable}			{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.PREPROCESSOR); addToken(temp,zzMarkedPos-1, Token.VARIABLE); start = zzMarkedPos; }
+	{Variable}			{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.PREPROCESSOR); addToken(temp,zzMarkedPos-1, TokenTypes.VARIABLE); start = zzMarkedPos; }
 	{VariableStart}		{}
 	\n |
-	<<EOF>>				{ addToken(start,zzStartRead-1, Token.PREPROCESSOR); addEndToken(INTERNAL_HEREDOC_EOT_UNQUOTED); return firstToken; }
+	<<EOF>>				{ addToken(start,zzStartRead-1, TokenTypes.PREPROCESSOR); addEndToken(INTERNAL_HEREDOC_EOT_UNQUOTED); return firstToken; }
 }
 
 
@@ -783,20 +783,20 @@ ErrorIdentifier			= ({NonSeparator}+)
 	/* work.  Fortunately we don't need the start- and end-line anchors */
 	/* since the production after "EOT" will match any line containing  */
 	/* EOT and any other chars.                                         */
-	"EOT"				{ if (start==zzStartRead) { addToken(Token.PREPROCESSOR); addNullToken(); return firstToken; } }
+	"EOT"				{ if (start==zzStartRead) { addToken(TokenTypes.PREPROCESSOR); addNullToken(); return firstToken; } }
 	[^\n\\]+				{}
-	\n					{ addToken(start,zzStartRead-1, Token.PREPROCESSOR); addEndToken(INTERNAL_HEREDOC_EOT_SINGLE_QUOTED); return firstToken; }
+	\n					{ addToken(start,zzStartRead-1, TokenTypes.PREPROCESSOR); addEndToken(INTERNAL_HEREDOC_EOT_SINGLE_QUOTED); return firstToken; }
 	\\.?					{ /* Skip escaped chars. */ }
-	<<EOF>>				{ addToken(start,zzStartRead-1, Token.PREPROCESSOR); addEndToken(INTERNAL_HEREDOC_EOT_SINGLE_QUOTED); return firstToken; }
+	<<EOF>>				{ addToken(start,zzStartRead-1, TokenTypes.PREPROCESSOR); addEndToken(INTERNAL_HEREDOC_EOT_SINGLE_QUOTED); return firstToken; }
 }
 
 
 <POD> {
 	[^\n\=]+				{}
-	"=cut"				{ if (start==zzStartRead) { addToken(Token.COMMENT_DOCUMENTATION); yybegin(YYINITIAL); } }
-	{PodCommandsExceptCut}	{ if (start==zzStartRead) { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos; } }
+	"=cut"				{ if (start==zzStartRead) { addToken(TokenTypes.COMMENT_DOCUMENTATION); yybegin(YYINITIAL); } }
+	{PodCommandsExceptCut}	{ if (start==zzStartRead) { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos; } }
 	=					{}
 	\n |
-	<<EOF>>				{ addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addEndToken(INTERNAL_POD); return firstToken; }
+	<<EOF>>				{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addEndToken(INTERNAL_POD); return firstToken; }
 }
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/PerlTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/PerlTokenMaker.java
@@ -1480,7 +1480,7 @@ public class PerlTokenMaker extends AbstractJFlexCTokenMaker {
 
 	@Override
 	public boolean getMarkOccurrencesOfTokenType(int type) {
-		return super.getMarkOccurrencesOfTokenType(type) || type==Token.VARIABLE;
+		return super.getMarkOccurrencesOfTokenType(type) || type==TokenTypes.VARIABLE;
 	}
 
 
@@ -1505,15 +1505,15 @@ public class PerlTokenMaker extends AbstractJFlexCTokenMaker {
 		// Start off in the proper state.
 		int state;
 		switch (initialTokenType) {
-			case Token.LITERAL_STRING_DOUBLE_QUOTE:
+			case TokenTypes.LITERAL_STRING_DOUBLE_QUOTE:
 				state = STRING;
 				start = text.offset;
 				break;
-			case Token.LITERAL_CHAR:
+			case TokenTypes.LITERAL_CHAR:
 				state = CHAR_LITERAL;
 				start = text.offset;
 				break;
-			case Token.LITERAL_BACKQUOTE:
+			case TokenTypes.LITERAL_BACKQUOTE:
 				state = BACKTICKS;
 				start = text.offset;
 				break;
@@ -1577,7 +1577,7 @@ public class PerlTokenMaker extends AbstractJFlexCTokenMaker {
 					ch=='&'
 				)) ||
 				/* Operators "==", "===", "!=", "!==", etc. */
-				(t.getType()==Token.OPERATOR &&
+				(t.getType()==TokenTypes.OPERATOR &&
 					((ch=t.charAt(t.length()-1))=='=' || ch=='~'));
 	}
 
@@ -1847,19 +1847,19 @@ public final void yybegin(int newState) {
 
       switch (zzAction < 0 ? zzAction : ZZ_ACTION[zzAction]) {
         case 2:
-          { addToken(Token.IDENTIFIER);
+          { addToken(TokenTypes.IDENTIFIER);
           }
         case 46: break;
         case 34:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.LITERAL_BACKQUOTE); addToken(temp,zzMarkedPos-1, Token.VARIABLE); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.LITERAL_BACKQUOTE); addToken(temp,zzMarkedPos-1, TokenTypes.VARIABLE); start = zzMarkedPos;
           }
         case 47: break;
         case 40:
-          { if (start==zzStartRead) { addToken(Token.COMMENT_DOCUMENTATION); yybegin(YYINITIAL); }
+          { if (start==zzStartRead) { addToken(TokenTypes.COMMENT_DOCUMENTATION); yybegin(YYINITIAL); }
           }
         case 48: break;
         case 26:
-          { addToken(Token.ERROR_NUMBER_FORMAT);
+          { addToken(TokenTypes.ERROR_NUMBER_FORMAT);
           }
         case 49: break;
         case 11:
@@ -1867,35 +1867,35 @@ public final void yybegin(int newState) {
           }
         case 50: break;
         case 38:
-          { if (start==zzStartRead) { addToken(Token.PREPROCESSOR); addNullToken(); return firstToken; }
+          { if (start==zzStartRead) { addToken(TokenTypes.PREPROCESSOR); addNullToken(); return firstToken; }
           }
         case 51: break;
         case 31:
-          { addToken(Token.FUNCTION);
+          { addToken(TokenTypes.FUNCTION);
           }
         case 52: break;
         case 30:
-          { addToken(Token.VARIABLE);
+          { addToken(TokenTypes.VARIABLE);
           }
         case 53: break;
         case 1:
-          { addToken(Token.ERROR_IDENTIFIER);
+          { addToken(TokenTypes.ERROR_IDENTIFIER);
           }
         case 54: break;
         case 24:
-          { addToken(start,zzStartRead-1, Token.PREPROCESSOR); addEndToken(INTERNAL_HEREDOC_EOT_SINGLE_QUOTED); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.PREPROCESSOR); addEndToken(INTERNAL_HEREDOC_EOT_SINGLE_QUOTED); return firstToken;
           }
         case 55: break;
         case 4:
-          { addToken(Token.COMMENT_EOL); addNullToken(); return firstToken;
+          { addToken(TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
           }
         case 56: break;
         case 29:
-          { addToken(Token.PREPROCESSOR); addNullToken(); return firstToken;
+          { addToken(TokenTypes.PREPROCESSOR); addNullToken(); return firstToken;
           }
         case 57: break;
         case 41:
-          { if (start==zzStartRead) { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos; }
+          { if (start==zzStartRead) { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos; }
           }
         case 58: break;
         case 44:
@@ -1915,23 +1915,23 @@ public final void yybegin(int newState) {
           }
         case 62: break;
         case 37:
-          { addToken(Token.REGEX);
+          { addToken(TokenTypes.REGEX);
           }
         case 63: break;
         case 18:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead, Token.LITERAL_CHAR);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.LITERAL_CHAR);
           }
         case 64: break;
         case 28:
-          { addToken(Token.LITERAL_NUMBER_HEXADECIMAL);
+          { addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL);
           }
         case 65: break;
         case 21:
-          { addToken(start,zzStartRead-1, Token.PREPROCESSOR); addEndToken(INTERNAL_HEREDOC_EOF_UNQUOTED); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.PREPROCESSOR); addEndToken(INTERNAL_HEREDOC_EOF_UNQUOTED); return firstToken;
           }
         case 66: break;
         case 6:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 67: break;
         case 10:
@@ -1939,19 +1939,19 @@ public final void yybegin(int newState) {
           }
         case 68: break;
         case 3:
-          { addToken(Token.LITERAL_NUMBER_DECIMAL_INT);
+          { addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT);
           }
         case 69: break;
         case 33:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); addToken(temp,zzMarkedPos-1, Token.VARIABLE); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); addToken(temp,zzMarkedPos-1, TokenTypes.VARIABLE); start = zzMarkedPos;
           }
         case 70: break;
         case 20:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead, Token.LITERAL_BACKQUOTE);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.LITERAL_BACKQUOTE);
           }
         case 71: break;
         case 15:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead, Token.LITERAL_STRING_DOUBLE_QUOTE);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
           }
         case 72: break;
         case 16:
@@ -1959,13 +1959,13 @@ public final void yybegin(int newState) {
           }
         case 73: break;
         case 23:
-          { addToken(start,zzStartRead-1, Token.PREPROCESSOR); addEndToken(INTERNAL_HEREDOC_EOT_UNQUOTED); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.PREPROCESSOR); addEndToken(INTERNAL_HEREDOC_EOT_UNQUOTED); return firstToken;
           }
         case 74: break;
         case 36:
           { boolean highlightedAsRegex = false;
 					if (firstToken==null) {
-						addToken(Token.REGEX);
+						addToken(TokenTypes.REGEX);
 						highlightedAsRegex = true;
 					}
 					else {
@@ -1973,7 +1973,7 @@ public final void yybegin(int newState) {
 						// the previous token, highlight it as such.
 						Token t = firstToken.getLastNonCommentNonWhitespaceToken();
 						if (regexCanFollow(t)) {
-							addToken(Token.REGEX);
+							addToken(TokenTypes.REGEX);
 							highlightedAsRegex = true;
 						}
 					}
@@ -1981,29 +1981,29 @@ public final void yybegin(int newState) {
 					// individual tokens.
 					if (!highlightedAsRegex) {
 						int temp = zzStartRead + 1;
-						addToken(zzStartRead, zzStartRead, Token.OPERATOR);
+						addToken(zzStartRead, zzStartRead, TokenTypes.OPERATOR);
 						zzStartRead = zzCurrentPos = zzMarkedPos = temp;
 					}
           }
         case 75: break;
         case 35:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.PREPROCESSOR); addToken(temp,zzMarkedPos-1, Token.VARIABLE); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.PREPROCESSOR); addToken(temp,zzMarkedPos-1, TokenTypes.VARIABLE); start = zzMarkedPos;
           }
         case 76: break;
         case 39:
-          { addToken(Token.COMMENT_EOL); start = zzMarkedPos; yybegin(POD);
+          { addToken(TokenTypes.COMMENT_EOL); start = zzMarkedPos; yybegin(POD);
           }
         case 77: break;
         case 32:
-          { addToken(Token.RESERVED_WORD);
+          { addToken(TokenTypes.RESERVED_WORD);
           }
         case 78: break;
         case 19:
-          { addToken(start,zzStartRead-1, Token.LITERAL_BACKQUOTE); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.LITERAL_BACKQUOTE); return firstToken;
           }
         case 79: break;
         case 8:
-          { addToken(Token.SEPARATOR);
+          { addToken(TokenTypes.SEPARATOR);
           }
         case 80: break;
         case 5:
@@ -2011,19 +2011,19 @@ public final void yybegin(int newState) {
           }
         case 81: break;
         case 7:
-          { addToken(Token.OPERATOR);
+          { addToken(TokenTypes.OPERATOR);
           }
         case 82: break;
         case 17:
-          { addToken(start,zzStartRead-1, Token.LITERAL_CHAR); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.LITERAL_CHAR); return firstToken;
           }
         case 83: break;
         case 25:
-          { addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addEndToken(INTERNAL_POD); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addEndToken(INTERNAL_POD); return firstToken;
           }
         case 84: break;
         case 27:
-          { addToken(Token.LITERAL_NUMBER_FLOAT);
+          { addToken(TokenTypes.LITERAL_NUMBER_FLOAT);
           }
         case 85: break;
         case 43:
@@ -2039,11 +2039,11 @@ public final void yybegin(int newState) {
           }
         case 88: break;
         case 14:
-          { addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
           }
         case 89: break;
         case 22:
-          { addToken(start,zzStartRead-1, Token.PREPROCESSOR); addEndToken(INTERNAL_HEREDOC_EOF_SINGLE_QUOTED); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.PREPROCESSOR); addEndToken(INTERNAL_HEREDOC_EOF_SINGLE_QUOTED); return firstToken;
           }
         case 90: break;
         default:
@@ -2051,23 +2051,23 @@ public final void yybegin(int newState) {
             zzAtEOF = true;
             switch (zzLexicalState) {
             case HEREDOC_EOF_SINGLE_QUOTED: {
-              addToken(start,zzStartRead-1, Token.PREPROCESSOR); addEndToken(INTERNAL_HEREDOC_EOF_SINGLE_QUOTED); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.PREPROCESSOR); addEndToken(INTERNAL_HEREDOC_EOF_SINGLE_QUOTED); return firstToken;
             }
             case 602: break;
             case HEREDOC_EOT_SINGLE_QUOTED: {
-              addToken(start,zzStartRead-1, Token.PREPROCESSOR); addEndToken(INTERNAL_HEREDOC_EOT_SINGLE_QUOTED); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.PREPROCESSOR); addEndToken(INTERNAL_HEREDOC_EOT_SINGLE_QUOTED); return firstToken;
             }
             case 603: break;
             case HEREDOC_EOT_UNQUOTED: {
-              addToken(start,zzStartRead-1, Token.PREPROCESSOR); addEndToken(INTERNAL_HEREDOC_EOT_UNQUOTED); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.PREPROCESSOR); addEndToken(INTERNAL_HEREDOC_EOT_UNQUOTED); return firstToken;
             }
             case 604: break;
             case STRING: {
-              addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
             }
             case 605: break;
             case BACKTICKS: {
-              addToken(start,zzStartRead-1, Token.LITERAL_BACKQUOTE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.LITERAL_BACKQUOTE); return firstToken;
             }
             case 606: break;
             case YYINITIAL: {
@@ -2075,15 +2075,15 @@ public final void yybegin(int newState) {
             }
             case 607: break;
             case HEREDOC_EOF_UNQUOTED: {
-              addToken(start,zzStartRead-1, Token.PREPROCESSOR); addEndToken(INTERNAL_HEREDOC_EOF_UNQUOTED); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.PREPROCESSOR); addEndToken(INTERNAL_HEREDOC_EOF_UNQUOTED); return firstToken;
             }
             case 608: break;
             case CHAR_LITERAL: {
-              addToken(start,zzStartRead-1, Token.LITERAL_CHAR); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.LITERAL_CHAR); return firstToken;
             }
             case 609: break;
             case POD: {
-              addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addEndToken(INTERNAL_POD); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addEndToken(INTERNAL_POD); return firstToken;
             }
             case 610: break;
             default:

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/PropertiesFileTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/PropertiesFileTokenMaker.flex
@@ -135,14 +135,14 @@ import org.fife.ui.rsyntaxtextarea.*;
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = Token.NULL;
+		int state = TokenTypes.NULL;
 		switch (initialTokenType) {
-			case Token.LITERAL_STRING_DOUBLE_QUOTE:
+			case TokenTypes.LITERAL_STRING_DOUBLE_QUOTE:
 				state = VALUE;
 				start = text.offset;
 				break;
 			default:
-				state = Token.NULL;
+				state = TokenTypes.NULL;
 		}
 
 		s = text;
@@ -212,18 +212,18 @@ SingleQuote			= (')
 %%
 
 <YYINITIAL> {
-	{Name}			{ addToken(Token.RESERVED_WORD); }
-	{Equals}			{ start = zzMarkedPos; addToken(Token.OPERATOR); yybegin(VALUE); }
-	{Whitespace}		{ addToken(Token.WHITESPACE); }
-	{Comment}			{ addToken(Token.COMMENT_EOL); }
+	{Name}			{ addToken(TokenTypes.RESERVED_WORD); }
+	{Equals}			{ start = zzMarkedPos; addToken(TokenTypes.OPERATOR); yybegin(VALUE); }
+	{Whitespace}		{ addToken(TokenTypes.WHITESPACE); }
+	{Comment}			{ addToken(TokenTypes.COMMENT_EOL); }
 	<<EOF>>			{ addNullToken(); return firstToken; }
 }
 
 <VALUE> {
-	{SingleQuote}[^']*{SingleQuote}?	{ addToken(start, zzMarkedPos-1, Token.LITERAL_STRING_DOUBLE_QUOTE); start = zzMarkedPos; }
+	{SingleQuote}[^']*{SingleQuote}?	{ addToken(start, zzMarkedPos-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); start = zzMarkedPos; }
 	[^'\{\\]+						{}
-	"{"[^\}]*"}"?					{ int temp=zzStartRead; addToken(start, zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); addToken(temp, zzMarkedPos-1, Token.VARIABLE); start = zzMarkedPos; }
+	"{"[^\}]*"}"?					{ int temp=zzStartRead; addToken(start, zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); addToken(temp, zzMarkedPos-1, TokenTypes.VARIABLE); start = zzMarkedPos; }
 	[\\].							{}
-	[\\]							{ addToken(start, zzEndRead, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken; }
-	<<EOF>>							{ addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); addNullToken(); return firstToken; }
+	[\\]							{ addToken(start, zzEndRead, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken; }
+	<<EOF>>							{ addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); addNullToken(); return firstToken; }
 }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/PropertiesFileTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/PropertiesFileTokenMaker.java
@@ -311,14 +311,14 @@ public class PropertiesFileTokenMaker extends AbstractJFlexTokenMaker {
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = Token.NULL;
+		int state = TokenTypes.NULL;
 		switch (initialTokenType) {
-			case Token.LITERAL_STRING_DOUBLE_QUOTE:
+			case TokenTypes.LITERAL_STRING_DOUBLE_QUOTE:
 				state = VALUE;
 				start = text.offset;
 				break;
 			default:
-				state = Token.NULL;
+				state = TokenTypes.NULL;
 		}
 
 		s = text;
@@ -599,27 +599,27 @@ public final void yybegin(int newState) {
 
       switch (zzAction < 0 ? zzAction : ZZ_ACTION[zzAction]) {
         case 7:
-          { addToken(start, zzEndRead, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
+          { addToken(start, zzEndRead, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
           }
         case 9: break;
         case 2:
-          { start = zzMarkedPos; addToken(Token.OPERATOR); yybegin(VALUE);
+          { start = zzMarkedPos; addToken(TokenTypes.OPERATOR); yybegin(VALUE);
           }
         case 10: break;
         case 8:
-          { int temp=zzStartRead; addToken(start, zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); addToken(temp, zzMarkedPos-1, Token.VARIABLE); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start, zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); addToken(temp, zzMarkedPos-1, TokenTypes.VARIABLE); start = zzMarkedPos;
           }
         case 11: break;
         case 3:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 12: break;
         case 6:
-          { addToken(start, zzMarkedPos-1, Token.LITERAL_STRING_DOUBLE_QUOTE); start = zzMarkedPos;
+          { addToken(start, zzMarkedPos-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); start = zzMarkedPos;
           }
         case 13: break;
         case 1:
-          { addToken(Token.RESERVED_WORD);
+          { addToken(TokenTypes.RESERVED_WORD);
           }
         case 14: break;
         case 5:
@@ -627,7 +627,7 @@ public final void yybegin(int newState) {
           }
         case 15: break;
         case 4:
-          { addToken(Token.COMMENT_EOL);
+          { addToken(TokenTypes.COMMENT_EOL);
           }
         case 16: break;
         default:
@@ -639,7 +639,7 @@ public final void yybegin(int newState) {
             }
             case 14: break;
             case VALUE: {
-              addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); addNullToken(); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); addNullToken(); return firstToken;
             }
             case 15: break;
             default:

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/PythonTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/PythonTokenMaker.flex
@@ -14,6 +14,7 @@ import javax.swing.text.Segment;
 import org.fife.ui.rsyntaxtextarea.AbstractJFlexTokenMaker;
 import org.fife.ui.rsyntaxtextarea.Token;
 import org.fife.ui.rsyntaxtextarea.TokenImpl;
+import org.fife.ui.rsyntaxtextarea.TokenTypes;
 
 
 /**
@@ -116,16 +117,16 @@ import org.fife.ui.rsyntaxtextarea.TokenImpl;
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = Token.NULL;
+		int state = TokenTypes.NULL;
 		switch (initialTokenType) {
-			case Token.LITERAL_STRING_DOUBLE_QUOTE:
+			case TokenTypes.LITERAL_STRING_DOUBLE_QUOTE:
 				state = LONG_STRING_2;
 				break;
-			case Token.LITERAL_CHAR:
+			case TokenTypes.LITERAL_CHAR:
 				state = LONG_STRING_1;
 				break;
 			default:
-				state = Token.NULL;
+				state = TokenTypes.NULL;
 		}
 
 		s = text;
@@ -267,7 +268,7 @@ LineComment		= ("#".*)
     "return" |
     "try" |
     "while" |
-    "yield"					{ addToken(Token.RESERVED_WORD); }
+    "yield"					{ addToken(TokenTypes.RESERVED_WORD); }
 
     /* Data types. */
     "char" |
@@ -278,7 +279,7 @@ LineComment		= ("#".*)
     "short" |
     "signed" |
     "unsigned" |
-    "void"					{ addToken(Token.DATA_TYPE); }
+    "void"					{ addToken(TokenTypes.DATA_TYPE); }
 
     /* Standard functions */
 	"abs" |
@@ -345,25 +346,25 @@ LineComment		= ("#".*)
 	"unicode" |
 	"vars" |
 	"xrange" |
-	"zip"					{ addToken(Token.FUNCTION); }
+	"zip"					{ addToken(TokenTypes.FUNCTION); }
 
     "True" |
     "False" |
-    "None"                          { addToken(Token.LITERAL_BOOLEAN); }
+    "None"                          { addToken(TokenTypes.LITERAL_BOOLEAN); }
 
 	{LineTerminator}				{ addNullToken(); return firstToken; }
 
-	{identifier}					{ addToken(Token.IDENTIFIER); }
+	{identifier}					{ addToken(TokenTypes.IDENTIFIER); }
 
-	{WhiteSpace}+					{ addToken(Token.WHITESPACE); }
+	{WhiteSpace}+					{ addToken(TokenTypes.WHITESPACE); }
 
 	/* String/Character Literals. */
-	{stringliteral}				{ addToken(Token.LITERAL_STRING_DOUBLE_QUOTE); }
-	{LongStringStart1}				{ yybegin(LONG_STRING_1); addToken(Token.LITERAL_CHAR); }
-	{LongStringStart2}				{ yybegin(LONG_STRING_2); addToken(Token.LITERAL_STRING_DOUBLE_QUOTE); }
+	{stringliteral}				{ addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); }
+	{LongStringStart1}				{ yybegin(LONG_STRING_1); addToken(TokenTypes.LITERAL_CHAR); }
+	{LongStringStart2}				{ yybegin(LONG_STRING_2); addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); }
 
 	/* Comment Literals. */
-	{LineComment}					{ addToken(Token.COMMENT_EOL); }
+	{LineComment}					{ addToken(TokenTypes.COMMENT_EOL); }
 
 	/* Separators. */
 	"(" |
@@ -371,7 +372,7 @@ LineComment		= ("#".*)
 	"[" |
 	"]" |
 	"{" |
-	"}"							{ addToken(Token.SEPARATOR); }
+	"}"							{ addToken(TokenTypes.SEPARATOR); }
 
 	/* Operators. */
 	"=" |
@@ -406,44 +407,44 @@ LineComment		= ("#".*)
 	"++" |
 	"--" |
 	"." |
-	","							{ addToken(Token.OPERATOR); }
+	","							{ addToken(TokenTypes.OPERATOR); }
 
 	/* Numbers */
-	{longinteger}|{integer}			{ addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
-	{floatnumber}|{imagnumber}		{ addToken(Token.LITERAL_NUMBER_FLOAT); }
-	{ErrorNumberFormat}				{ addToken(Token.ERROR_NUMBER_FORMAT); }
+	{longinteger}|{integer}			{ addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT); }
+	{floatnumber}|{imagnumber}		{ addToken(TokenTypes.LITERAL_NUMBER_FLOAT); }
+	{ErrorNumberFormat}				{ addToken(TokenTypes.ERROR_NUMBER_FORMAT); }
 
 	/* Other punctuation, we'll highlight it as "identifiers." */
-    {annotation}                { addToken(Token.ANNOTATION); }
-	";"							{ addToken(Token.IDENTIFIER); }
+    {annotation}                { addToken(TokenTypes.ANNOTATION); }
+	";"							{ addToken(TokenTypes.IDENTIFIER); }
 
 	/* Ended with a line not in a string or comment. */
 	<<EOF>>						{ addNullToken(); return firstToken; }
 
 	/* Catch any other (unhandled) characters and flag them as bad. */
-	.							{ addToken(Token.ERROR_IDENTIFIER); }
+	.							{ addToken(TokenTypes.ERROR_IDENTIFIER); }
 
 }
 
 <LONG_STRING_1> {
-	[^\']+						{ addToken(Token.LITERAL_CHAR); }
-	"'''"						{ yybegin(YYINITIAL); addToken(Token.LITERAL_CHAR); }
-	"'"							{ addToken(Token.LITERAL_CHAR); }
+	[^\']+						{ addToken(TokenTypes.LITERAL_CHAR); }
+	"'''"						{ yybegin(YYINITIAL); addToken(TokenTypes.LITERAL_CHAR); }
+	"'"							{ addToken(TokenTypes.LITERAL_CHAR); }
 	<<EOF>>						{
 									if (firstToken==null) {
-										addToken(Token.LITERAL_CHAR); 
+										addToken(TokenTypes.LITERAL_CHAR);
 									}
 									return firstToken;
 								}
 }
 
 <LONG_STRING_2> {
-	[^\"]+						{ addToken(Token.LITERAL_STRING_DOUBLE_QUOTE); }
-	\"\"\"						{ yybegin(YYINITIAL); addToken(Token.LITERAL_STRING_DOUBLE_QUOTE); }
-	\"							{ addToken(Token.LITERAL_STRING_DOUBLE_QUOTE); }
+	[^\"]+						{ addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); }
+	\"\"\"						{ yybegin(YYINITIAL); addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); }
+	\"							{ addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); }
 	<<EOF>>						{
 									if (firstToken==null) {
-										addToken(Token.LITERAL_STRING_DOUBLE_QUOTE); 
+										addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
 									}
 									return firstToken;
 								}

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/PythonTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/PythonTokenMaker.java
@@ -16,6 +16,7 @@ import javax.swing.text.Segment;
 import org.fife.ui.rsyntaxtextarea.AbstractJFlexTokenMaker;
 import org.fife.ui.rsyntaxtextarea.Token;
 import org.fife.ui.rsyntaxtextarea.TokenImpl;
+import org.fife.ui.rsyntaxtextarea.TokenTypes;
 
 
 /**
@@ -708,16 +709,16 @@ public class PythonTokenMaker extends AbstractJFlexTokenMaker {
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = Token.NULL;
+		int state = TokenTypes.NULL;
 		switch (initialTokenType) {
-			case Token.LITERAL_STRING_DOUBLE_QUOTE:
+			case TokenTypes.LITERAL_STRING_DOUBLE_QUOTE:
 				state = LONG_STRING_2;
 				break;
-			case Token.LITERAL_CHAR:
+			case TokenTypes.LITERAL_CHAR:
 				state = LONG_STRING_1;
 				break;
 			default:
-				state = Token.NULL;
+				state = TokenTypes.NULL;
 		}
 
 		s = text;
@@ -1001,83 +1002,83 @@ public class PythonTokenMaker extends AbstractJFlexTokenMaker {
           }
         case 22: break;
         case 10:
-          { addToken(Token.LITERAL_CHAR);
+          { addToken(TokenTypes.LITERAL_CHAR);
           }
         case 23: break;
         case 8:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 24: break;
         case 12:
-          { addToken(Token.LITERAL_NUMBER_FLOAT);
+          { addToken(TokenTypes.LITERAL_NUMBER_FLOAT);
           }
         case 25: break;
         case 14:
-          { addToken(Token.RESERVED_WORD);
+          { addToken(TokenTypes.RESERVED_WORD);
           }
         case 26: break;
         case 9:
-          { addToken(Token.SEPARATOR);
+          { addToken(TokenTypes.SEPARATOR);
           }
         case 27: break;
         case 16:
-          { yybegin(LONG_STRING_1); addToken(Token.LITERAL_CHAR);
+          { yybegin(LONG_STRING_1); addToken(TokenTypes.LITERAL_CHAR);
           }
         case 28: break;
         case 2:
-          { addToken(Token.IDENTIFIER);
+          { addToken(TokenTypes.IDENTIFIER);
           }
         case 29: break;
         case 15:
-          { addToken(Token.FUNCTION);
+          { addToken(TokenTypes.FUNCTION);
           }
         case 30: break;
         case 18:
-          { addToken(Token.DATA_TYPE);
+          { addToken(TokenTypes.DATA_TYPE);
           }
         case 31: break;
         case 1:
-          { addToken(Token.ERROR_IDENTIFIER);
+          { addToken(TokenTypes.ERROR_IDENTIFIER);
           }
         case 32: break;
         case 13:
-          { addToken(Token.ANNOTATION);
+          { addToken(TokenTypes.ANNOTATION);
           }
         case 33: break;
         case 4:
-          { addToken(Token.LITERAL_STRING_DOUBLE_QUOTE);
+          { addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
           }
         case 34: break;
         case 21:
-          { addToken(Token.LITERAL_BOOLEAN);
+          { addToken(TokenTypes.LITERAL_BOOLEAN);
           }
         case 35: break;
         case 7:
-          { addToken(Token.COMMENT_EOL);
+          { addToken(TokenTypes.COMMENT_EOL);
           }
         case 36: break;
         case 11:
-          { addToken(Token.ERROR_NUMBER_FORMAT);
+          { addToken(TokenTypes.ERROR_NUMBER_FORMAT);
           }
         case 37: break;
         case 3:
-          { addToken(Token.LITERAL_NUMBER_DECIMAL_INT);
+          { addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT);
           }
         case 38: break;
         case 6:
-          { addToken(Token.OPERATOR);
+          { addToken(TokenTypes.OPERATOR);
           }
         case 39: break;
         case 20:
-          { yybegin(YYINITIAL); addToken(Token.LITERAL_STRING_DOUBLE_QUOTE);
+          { yybegin(YYINITIAL); addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
           }
         case 40: break;
         case 17:
-          { yybegin(LONG_STRING_2); addToken(Token.LITERAL_STRING_DOUBLE_QUOTE);
+          { yybegin(LONG_STRING_2); addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
           }
         case 41: break;
         case 19:
-          { yybegin(YYINITIAL); addToken(Token.LITERAL_CHAR);
+          { yybegin(YYINITIAL); addToken(TokenTypes.LITERAL_CHAR);
           }
         case 42: break;
         default:
@@ -1090,14 +1091,14 @@ public class PythonTokenMaker extends AbstractJFlexTokenMaker {
             case 277: break;
             case LONG_STRING_2: {
               if (firstToken==null) {
-										addToken(Token.LITERAL_STRING_DOUBLE_QUOTE);
+										addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
 									}
 									return firstToken;
             }
             case 278: break;
             case LONG_STRING_1: {
               if (firstToken==null) {
-										addToken(Token.LITERAL_CHAR);
+										addToken(TokenTypes.LITERAL_CHAR);
 									}
 									return firstToken;
             }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/RubyTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/RubyTokenMaker.flex
@@ -671,9 +671,9 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	{URL}					{
                                 int temp = zzStartRead;
                                 if (start <= zzStartRead - 1) {
-                                    addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION);
+                                    addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION);
                                 }
-                                addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_DOCUMENTATION);
+                                addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_DOCUMENTATION);
                                 start = zzMarkedPos;
                             }
 	[hwf]					{}

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/RubyTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/RubyTokenMaker.java
@@ -1434,9 +1434,9 @@ public class RubyTokenMaker extends AbstractJFlexTokenMaker {
         case 45:
           { int temp = zzStartRead;
                                 if (start <= zzStartRead - 1) {
-                                    addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION);
+                                    addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION);
                                 }
-                                addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_DOCUMENTATION);
+                                addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_DOCUMENTATION);
                                 start = zzMarkedPos;
           }
         case 59: break;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/RustTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/RustTokenMaker.flex
@@ -598,15 +598,15 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	\\u						{ /* Invalid Unicode character \\uXXXX */ validString = false; }
 	\\.						{ /* Skip all escaped chars. */ }
 	\\						{ /* Skip all escape chars for now, even though this isn't right */ }
-	\"						{ int type = validString ? Token.LITERAL_STRING_DOUBLE_QUOTE : Token.ERROR_STRING_DOUBLE; addToken(start,zzStartRead, type); yybegin(YYINITIAL); }
+	\"						{ int type = validString ? TokenTypes.LITERAL_STRING_DOUBLE_QUOTE : TokenTypes.ERROR_STRING_DOUBLE; addToken(start,zzStartRead, type); yybegin(YYINITIAL); }
 	<<EOF>>					{
                                 // Strings always continue to the next line
                                 if (validString) {
-                                    addToken(start, zzStartRead - 1, Token.LITERAL_STRING_DOUBLE_QUOTE);
+                                    addToken(start, zzStartRead - 1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
                                     addEndToken(INTERNAL_IN_STRING_VALID);
                                 }
                                 else {
-                                    addToken(start, zzStartRead - 1, Token.ERROR_STRING_DOUBLE);
+                                    addToken(start, zzStartRead - 1, TokenTypes.ERROR_STRING_DOUBLE);
                                     addEndToken(INTERNAL_IN_STRING_INVALID);
                                 }
                                 return firstToken;
@@ -621,15 +621,15 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
     \\u						{ /* All Unicode chars, valid or not, are not allowed in byte strings \\uXXXX */ validString = false; }
 	\\.						{ /* Skip all escaped chars. */ }
 	\\						{ /* Skip all escape chars for now, even though this isn't right */ }
-	\"						{ int type = validString ? Token.LITERAL_STRING_DOUBLE_QUOTE : Token.ERROR_STRING_DOUBLE; addToken(start,zzStartRead, type); yybegin(YYINITIAL); }
+	\"						{ int type = validString ? TokenTypes.LITERAL_STRING_DOUBLE_QUOTE : TokenTypes.ERROR_STRING_DOUBLE; addToken(start,zzStartRead, type); yybegin(YYINITIAL); }
 	<<EOF>>					{
                                 // Strings always continue to the next line
                                 if (validString) {
-                                    addToken(start, zzStartRead - 1, Token.LITERAL_STRING_DOUBLE_QUOTE);
+                                    addToken(start, zzStartRead - 1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
                                     addEndToken(INTERNAL_IN_BYTE_STRING_VALID);
                                 }
                                 else {
-                                    addToken(start, zzStartRead - 1, Token.ERROR_STRING_DOUBLE);
+                                    addToken(start, zzStartRead - 1, TokenTypes.ERROR_STRING_DOUBLE);
                                     addEndToken(INTERNAL_IN_BYTE_STRING_INVALID);
                                 }
                                 return firstToken;
@@ -645,7 +645,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
                                 // some reason)
                                 int tokenLength = yylength();
                                 if (tokenLength >= delimiter.length()) {
-                                    int type = validString ? Token.LITERAL_STRING_DOUBLE_QUOTE : Token.ERROR_STRING_DOUBLE;
+                                    int type = validString ? TokenTypes.LITERAL_STRING_DOUBLE_QUOTE : TokenTypes.ERROR_STRING_DOUBLE;
                                     int end = zzStartRead + delimiter.length();
                                     addToken(start, end - 1, type);
                                     zzStartRead = zzCurrentPos = zzMarkedPos = end;
@@ -657,11 +657,11 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	<<EOF>>					{
                                 // Strings always continue to the next line
                                 if (validString) {
-                                    addToken(start, zzStartRead - 1, Token.LITERAL_STRING_DOUBLE_QUOTE);
+                                    addToken(start, zzStartRead - 1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
                                     addRawStringLiteralEndToken(INTERNAL_IN_RAW_STRING_VALID);
                                 }
                                 else {
-                                    addToken(start, zzStartRead - 1, Token.ERROR_STRING_DOUBLE);
+                                    addToken(start, zzStartRead - 1, TokenTypes.ERROR_STRING_DOUBLE);
                                     addRawStringLiteralEndToken(INTERNAL_IN_RAW_STRING_INVALID);
                                 }
                                 return firstToken;
@@ -677,7 +677,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
                                 // some reason)
                                 int tokenLength = yylength();
                                 if (tokenLength >= delimiter.length()) {
-                                    int type = validString ? Token.LITERAL_STRING_DOUBLE_QUOTE : Token.ERROR_STRING_DOUBLE;
+                                    int type = validString ? TokenTypes.LITERAL_STRING_DOUBLE_QUOTE : TokenTypes.ERROR_STRING_DOUBLE;
                                     int end = zzStartRead + delimiter.length();
                                     addToken(start, end - 1, type);
                                     zzStartRead = zzCurrentPos = zzMarkedPos = end;
@@ -689,11 +689,11 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	<<EOF>>					{
                                 // Strings always continue to the next line
                                 if (validString) {
-                                    addToken(start, zzStartRead - 1, Token.LITERAL_STRING_DOUBLE_QUOTE);
+                                    addToken(start, zzStartRead - 1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
                                     addRawStringLiteralEndToken(INTERNAL_IN_RAW_BYTE_STRING_VALID);
                                 }
                                 else {
-                                    addToken(start, zzStartRead - 1, Token.ERROR_STRING_DOUBLE);
+                                    addToken(start, zzStartRead - 1, TokenTypes.ERROR_STRING_DOUBLE);
                                     addRawStringLiteralEndToken(INTERNAL_IN_RAW_BYTE_STRING_INVALID);
                                 }
                                 return firstToken;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/RustTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/RustTokenMaker.java
@@ -1431,7 +1431,7 @@ public class RustTokenMaker extends AbstractJFlexCTokenMaker {
                                 // some reason)
                                 int tokenLength = yylength();
                                 if (tokenLength >= delimiter.length()) {
-                                    int type = validString ? Token.LITERAL_STRING_DOUBLE_QUOTE : Token.ERROR_STRING_DOUBLE;
+                                    int type = validString ? TokenTypes.LITERAL_STRING_DOUBLE_QUOTE : TokenTypes.ERROR_STRING_DOUBLE;
                                     int end = zzStartRead + delimiter.length();
                                     addToken(start, end - 1, type);
                                     zzStartRead = zzCurrentPos = zzMarkedPos = end;
@@ -1523,7 +1523,7 @@ public class RustTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 64: break;
         case 13:
-          { int type = validString ? Token.LITERAL_STRING_DOUBLE_QUOTE : Token.ERROR_STRING_DOUBLE; addToken(start,zzStartRead, type); yybegin(YYINITIAL);
+          { int type = validString ? TokenTypes.LITERAL_STRING_DOUBLE_QUOTE : TokenTypes.ERROR_STRING_DOUBLE; addToken(start,zzStartRead, type); yybegin(YYINITIAL);
           }
         case 65: break;
         case 16:
@@ -1617,11 +1617,11 @@ public class RustTokenMaker extends AbstractJFlexCTokenMaker {
             case BYTE_STRING_LITERAL: {
               // Strings always continue to the next line
                                 if (validString) {
-                                    addToken(start, zzStartRead - 1, Token.LITERAL_STRING_DOUBLE_QUOTE);
+                                    addToken(start, zzStartRead - 1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
                                     addEndToken(INTERNAL_IN_BYTE_STRING_VALID);
                                 }
                                 else {
-                                    addToken(start, zzStartRead - 1, Token.ERROR_STRING_DOUBLE);
+                                    addToken(start, zzStartRead - 1, TokenTypes.ERROR_STRING_DOUBLE);
                                     addEndToken(INTERNAL_IN_BYTE_STRING_INVALID);
                                 }
                                 return firstToken;
@@ -1634,11 +1634,11 @@ public class RustTokenMaker extends AbstractJFlexCTokenMaker {
             case STRING: {
               // Strings always continue to the next line
                                 if (validString) {
-                                    addToken(start, zzStartRead - 1, Token.LITERAL_STRING_DOUBLE_QUOTE);
+                                    addToken(start, zzStartRead - 1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
                                     addEndToken(INTERNAL_IN_STRING_VALID);
                                 }
                                 else {
-                                    addToken(start, zzStartRead - 1, Token.ERROR_STRING_DOUBLE);
+                                    addToken(start, zzStartRead - 1, TokenTypes.ERROR_STRING_DOUBLE);
                                     addEndToken(INTERNAL_IN_STRING_INVALID);
                                 }
                                 return firstToken;
@@ -1651,11 +1651,11 @@ public class RustTokenMaker extends AbstractJFlexCTokenMaker {
             case RAW_STRING_LITERAL: {
               // Strings always continue to the next line
                                 if (validString) {
-                                    addToken(start, zzStartRead - 1, Token.LITERAL_STRING_DOUBLE_QUOTE);
+                                    addToken(start, zzStartRead - 1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
                                     addRawStringLiteralEndToken(INTERNAL_IN_RAW_STRING_VALID);
                                 }
                                 else {
-                                    addToken(start, zzStartRead - 1, Token.ERROR_STRING_DOUBLE);
+                                    addToken(start, zzStartRead - 1, TokenTypes.ERROR_STRING_DOUBLE);
                                     addRawStringLiteralEndToken(INTERNAL_IN_RAW_STRING_INVALID);
                                 }
                                 return firstToken;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/SASTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/SASTokenMaker.flex
@@ -127,7 +127,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 	 *         enabled.
 	 */
 	public boolean getMarkOccurrencesOfTokenType(int type) {
-		return type==Token.IDENTIFIER || type==Token.VARIABLE;
+		return type==TokenTypes.IDENTIFIER || type==TokenTypes.VARIABLE;
 	}
 
 
@@ -151,15 +151,15 @@ import org.fife.ui.rsyntaxtextarea.*;
 		// Start off in the proper state.
 		int state;
 		switch (initialTokenType) {
-			case Token.LITERAL_STRING_DOUBLE_QUOTE:
+			case TokenTypes.LITERAL_STRING_DOUBLE_QUOTE:
 				state = STRING;
 				start = text.offset;
 				break;
-			case Token.LITERAL_CHAR:
+			case TokenTypes.LITERAL_CHAR:
 				state = CHAR;
 				start = text.offset;
 				break;
-			case Token.COMMENT_MULTILINE:
+			case TokenTypes.COMMENT_MULTILINE:
 				state = MLC;
 				start = text.offset;
 				break;
@@ -475,7 +475,7 @@ MLCEnd			= ("*/")
 	"while" |
 	"with" |
 	"window" |
-	"x"				{ addToken(Token.RESERVED_WORD); }
+	"x"				{ addToken(TokenTypes.RESERVED_WORD); }
 
 	/* Base SAS procs. */
 	"append" |
@@ -520,12 +520,12 @@ MLCEnd			= ("*/")
 	"tabulate" |
 	"template" |
 	"timeplot" |
-	"transpose"			{ addToken(Token.DATA_TYPE); }
+	"transpose"			{ addToken(TokenTypes.DATA_TYPE); }
 
 	/* SAS/STAT procs. */
 	"corr" |
 	"freq" |
-	"univariate"			{ addToken(Token.DATA_TYPE); }
+	"univariate"			{ addToken(TokenTypes.DATA_TYPE); }
 
 	/* Macros. */
 	"%abort" |
@@ -579,7 +579,7 @@ MLCEnd			= ("*/")
 	"%until" |
 	"%upcase" |
 	"%while" |
-	"%window"				{ addToken(Token.FUNCTION); }
+	"%window"				{ addToken(TokenTypes.FUNCTION); }
 
 }
 
@@ -601,31 +601,31 @@ MLCEnd			= ("*/")
 									start = zzStartRead;
 									// Might not be any whitespace.
 									if (yylength()>1) {
-										addToken(zzStartRead,zzMarkedPos-2, Token.WHITESPACE);
+										addToken(zzStartRead,zzMarkedPos-2, TokenTypes.WHITESPACE);
 										zzStartRead = zzMarkedPos-1;
 									}
 									// Remember:  zzStartRead may now be updated,
 									// so we must check against 'start'.
 									if (start==s.offset) {
-										addToken(zzStartRead,zzEndRead, Token.COMMENT_EOL);
+										addToken(zzStartRead,zzEndRead, TokenTypes.COMMENT_EOL);
 										addNullToken();
 										return firstToken;
 									}
 									else {
-										addToken(zzStartRead,zzStartRead, Token.OPERATOR);
+										addToken(zzStartRead,zzStartRead, TokenTypes.OPERATOR);
 									}
 								}
 	{MLCBegin}					{ start = zzMarkedPos-2; yybegin(MLC); }
 
 	/* Do operators before identifiers since some of them are words. */
-	{Operator}					{ addToken(Token.OPERATOR); }
-	{Separator}					{ addToken(Token.SEPARATOR); }
+	{Operator}					{ addToken(TokenTypes.OPERATOR); }
+	{Separator}					{ addToken(TokenTypes.SEPARATOR); }
 
-	{Identifier}					{ addToken(Token.IDENTIFIER); }
-	{MacroVariable}				{ addToken(Token.VARIABLE); }
-	{Semicolon}					{ addToken(Token.IDENTIFIER); }
+	{Identifier}					{ addToken(TokenTypes.IDENTIFIER); }
+	{MacroVariable}				{ addToken(TokenTypes.VARIABLE); }
+	{Semicolon}					{ addToken(TokenTypes.IDENTIFIER); }
 
-	{Whitespace}					{ addToken(Token.WHITESPACE); }
+	{Whitespace}					{ addToken(TokenTypes.WHITESPACE); }
 
 	{StringBoundary}				{ start = zzMarkedPos-1; yybegin(STRING); }
 	{CharBoundary}					{ start = zzMarkedPos-1; yybegin(CHAR); }
@@ -634,34 +634,34 @@ MLCEnd			= ("*/")
 
 	/* Catch any other (unhandled) characters and flag them as OK;    */
 	/* This will include "." from statements like "from lib.dataset". */
-	.							{ addToken(Token.IDENTIFIER); }
+	.							{ addToken(TokenTypes.IDENTIFIER); }
 
 }
 
 <STRING> {
 
 	[^\n\"]+						{}
-	{LineTerminator}				{ addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken; }
-	{StringBoundary}				{ yybegin(YYINITIAL); addToken(start,zzStartRead, Token.LITERAL_STRING_DOUBLE_QUOTE); }
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken; }
+	{LineTerminator}				{ addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken; }
+	{StringBoundary}				{ yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken; }
 
 }
 
 <CHAR> {
 
 	[^\n\']+						{}
-	{LineTerminator}				{ yybegin(YYINITIAL); addToken(start,zzStartRead-1, Token.LITERAL_CHAR); return firstToken; }
-	{CharBoundary}					{ yybegin(YYINITIAL); addToken(start,zzStartRead, Token.LITERAL_CHAR); }
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.LITERAL_CHAR); return firstToken; }
+	{LineTerminator}				{ yybegin(YYINITIAL); addToken(start,zzStartRead-1, TokenTypes.LITERAL_CHAR); return firstToken; }
+	{CharBoundary}					{ yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.LITERAL_CHAR); }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.LITERAL_CHAR); return firstToken; }
 
 }
 
 <MLC> {
 
 	[^\n\*]+						{}
-	{LineTerminator}				{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken; }
-	{MLCEnd}						{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE); }
+	{LineTerminator}				{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken; }
+	{MLCEnd}						{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE); }
 	\*							{}
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken; }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken; }
 
 }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/SASTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/SASTokenMaker.java
@@ -996,7 +996,7 @@ public class SASTokenMaker extends AbstractJFlexTokenMaker {
 	 */
 	@Override
 	public boolean getMarkOccurrencesOfTokenType(int type) {
-		return type==Token.IDENTIFIER || type==Token.VARIABLE;
+		return type==TokenTypes.IDENTIFIER || type==TokenTypes.VARIABLE;
 	}
 
 
@@ -1021,15 +1021,15 @@ public class SASTokenMaker extends AbstractJFlexTokenMaker {
 		// Start off in the proper state.
 		int state;
 		switch (initialTokenType) {
-			case Token.LITERAL_STRING_DOUBLE_QUOTE:
+			case TokenTypes.LITERAL_STRING_DOUBLE_QUOTE:
 				state = STRING;
 				start = text.offset;
 				break;
-			case Token.LITERAL_CHAR:
+			case TokenTypes.LITERAL_CHAR:
 				state = CHAR;
 				start = text.offset;
 				break;
-			case Token.COMMENT_MULTILINE:
+			case TokenTypes.COMMENT_MULTILINE:
 				state = MLC;
 				start = text.offset;
 				break;
@@ -1349,7 +1349,7 @@ public final void yybegin(int newState) {
 
       switch (zzAction < 0 ? zzAction : ZZ_ACTION[zzAction]) {
         case 13:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead-1, Token.LITERAL_CHAR); return firstToken;
+          { yybegin(YYINITIAL); addToken(start,zzStartRead-1, TokenTypes.LITERAL_CHAR); return firstToken;
           }
         case 21: break;
         case 2:
@@ -1357,7 +1357,7 @@ public final void yybegin(int newState) {
           }
         case 22: break;
         case 18:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE);
           }
         case 23: break;
         case 17:
@@ -1365,7 +1365,7 @@ public final void yybegin(int newState) {
           }
         case 24: break;
         case 3:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 25: break;
         case 8:
@@ -1373,35 +1373,35 @@ public final void yybegin(int newState) {
           }
         case 26: break;
         case 5:
-          { addToken(Token.RESERVED_WORD);
+          { addToken(TokenTypes.RESERVED_WORD);
           }
         case 27: break;
         case 6:
-          { addToken(Token.SEPARATOR);
+          { addToken(TokenTypes.SEPARATOR);
           }
         case 28: break;
         case 16:
-          { addToken(Token.VARIABLE);
+          { addToken(TokenTypes.VARIABLE);
           }
         case 29: break;
         case 14:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead, Token.LITERAL_CHAR);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.LITERAL_CHAR);
           }
         case 30: break;
         case 1:
-          { addToken(Token.IDENTIFIER);
+          { addToken(TokenTypes.IDENTIFIER);
           }
         case 31: break;
         case 20:
-          { addToken(Token.FUNCTION);
+          { addToken(TokenTypes.FUNCTION);
           }
         case 32: break;
         case 19:
-          { addToken(Token.DATA_TYPE);
+          { addToken(TokenTypes.DATA_TYPE);
           }
         case 33: break;
         case 11:
-          { addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
           }
         case 34: break;
         case 9:
@@ -1415,18 +1415,18 @@ public final void yybegin(int newState) {
 									start = zzStartRead;
 									// Might not be any whitespace.
 									if (yylength()>1) {
-										addToken(zzStartRead,zzMarkedPos-2, Token.WHITESPACE);
+										addToken(zzStartRead,zzMarkedPos-2, TokenTypes.WHITESPACE);
 										zzStartRead = zzMarkedPos-1;
 									}
 									// Remember:  zzStartRead may now be updated,
 									// so we must check against 'start'.
 									if (start==s.offset) {
-										addToken(zzStartRead,zzEndRead, Token.COMMENT_EOL);
+										addToken(zzStartRead,zzEndRead, TokenTypes.COMMENT_EOL);
 										addNullToken();
 										return firstToken;
 									}
 									else {
-										addToken(zzStartRead,zzStartRead, Token.OPERATOR);
+										addToken(zzStartRead,zzStartRead, TokenTypes.OPERATOR);
 									}
           }
         case 35: break;
@@ -1435,11 +1435,11 @@ public final void yybegin(int newState) {
           }
         case 36: break;
         case 4:
-          { addToken(Token.OPERATOR);
+          { addToken(TokenTypes.OPERATOR);
           }
         case 37: break;
         case 12:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead, Token.LITERAL_STRING_DOUBLE_QUOTE);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
           }
         case 38: break;
         case 10:
@@ -1447,7 +1447,7 @@ public final void yybegin(int newState) {
           }
         case 39: break;
         case 15:
-          { addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken;
           }
         case 40: break;
         default:
@@ -1455,7 +1455,7 @@ public final void yybegin(int newState) {
             zzAtEOF = true;
             switch (zzLexicalState) {
             case STRING: {
-              addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
             }
             case 640: break;
             case YYINITIAL: {
@@ -1463,11 +1463,11 @@ public final void yybegin(int newState) {
             }
             case 641: break;
             case MLC: {
-              addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken;
             }
             case 642: break;
             case CHAR: {
-              addToken(start,zzStartRead-1, Token.LITERAL_CHAR); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.LITERAL_CHAR); return firstToken;
             }
             case 643: break;
             default:

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/SQLTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/SQLTokenMaker.flex
@@ -139,15 +139,15 @@ import org.fife.ui.rsyntaxtextarea.*;
 		// Start off in the proper state.
 		int state = YYINITIAL;
 		switch (initialTokenType) {
-			case Token.LITERAL_STRING_DOUBLE_QUOTE:
+			case TokenTypes.LITERAL_STRING_DOUBLE_QUOTE:
 				state = STRING;
 				start = text.offset;
 				break;
-			case Token.LITERAL_CHAR:
+			case TokenTypes.LITERAL_CHAR:
 				state = CHAR;
 				start = text.offset;
 				break;
-			case Token.COMMENT_MULTILINE:
+			case TokenTypes.COMMENT_MULTILINE:
 				state = MLC;
 				start = text.offset;
 				break;
@@ -370,14 +370,14 @@ MLCEnd			= "*/"
 	"WHEN" |
 	"WHERE" |
 	"WITH" |
-	"YESNO"					{ addToken(Token.RESERVED_WORD); }
+	"YESNO"					{ addToken(TokenTypes.RESERVED_WORD); }
 
 	/* SQL99 aggregate functions */
 	"AVG" |
 	"COUNT" |
 	"MIN" |
 	"MAX" |
-	"SUM"					{ addToken(Token.FUNCTION); }
+	"SUM"					{ addToken(TokenTypes.FUNCTION); }
 
 	/* SQL99 built-in scalar functions */
 	"CURRENT_DATE" |
@@ -385,14 +385,14 @@ MLCEnd			= "*/"
 	"CURRENT_TIMESTAMP" |
 	"CURRENT_USER" |
 	"SESSION_USER" |
-	"SYSTEM_USER"			{ addToken(Token.FUNCTION); }
+	"SYSTEM_USER"			{ addToken(TokenTypes.FUNCTION); }
 
 	/* SQL99 numeric scalar functions */
 	"BIT_LENGTH" |
 	"CHAR_LENGTH" |
 	"EXTRACT" |
 	"OCTET_LENGTH" |
-	"POSITION"				{ addToken(Token.FUNCTION); }
+	"POSITION"				{ addToken(TokenTypes.FUNCTION); }
 
 	/* SQL99 string functions */
 	"CONCATENATE" |
@@ -401,68 +401,68 @@ MLCEnd			= "*/"
 	"SUBSTRING" |
 	"TRANSLATE" |
 	"TRIM" |
-	"UPPER"					{ addToken(Token.FUNCTION); }
+	"UPPER"					{ addToken(TokenTypes.FUNCTION); }
 
 	{LineTerminator}				{ addNullToken(); return firstToken; }
 
-	{Identifier}					{ addToken(Token.IDENTIFIER); }
-	";"							{ addToken(Token.IDENTIFIER); }
+	{Identifier}					{ addToken(TokenTypes.IDENTIFIER); }
+	";"							{ addToken(TokenTypes.IDENTIFIER); }
 
-	{Parameter}					{ addToken(Token.IDENTIFIER); }
+	{Parameter}					{ addToken(TokenTypes.IDENTIFIER); }
 
-	{Comment}						{ addToken(Token.COMMENT_EOL); }
+	{Comment}						{ addToken(TokenTypes.COMMENT_EOL); }
 	{MLCBegin}					{ start = zzMarkedPos-2; yybegin(MLC); }
 
-	{Whitespace}					{ addToken(Token.WHITESPACE); }
+	{Whitespace}					{ addToken(TokenTypes.WHITESPACE); }
 
-	{Operator}					{ addToken(Token.OPERATOR); }
-	{Separator}					{ addToken(Token.SEPARATOR); }
+	{Operator}					{ addToken(TokenTypes.OPERATOR); }
+	{Separator}					{ addToken(TokenTypes.SEPARATOR); }
 
-	{Integer}						{ addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
-	{Float}						{ addToken(Token.LITERAL_NUMBER_FLOAT); }
-	{ApproxNum}					{ addToken(Token.LITERAL_NUMBER_FLOAT); }
+	{Integer}						{ addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT); }
+	{Float}						{ addToken(TokenTypes.LITERAL_NUMBER_FLOAT); }
+	{ApproxNum}					{ addToken(TokenTypes.LITERAL_NUMBER_FLOAT); }
 
 	"\""							{ start = zzMarkedPos-1; yybegin(STRING); }
 	"\'"							{ start = zzMarkedPos-1; yybegin(CHAR); }
 
     // MS-SQL square bracket identifiers
-	"["[^\]]*"]"					{ addToken(Token.PREPROCESSOR); }
-	"["[^\]]*						{ addToken(Token.ERROR_IDENTIFIER); addNullToken(); return firstToken; }
+	"["[^\]]*"]"					{ addToken(TokenTypes.PREPROCESSOR); }
+	"["[^\]]*						{ addToken(TokenTypes.ERROR_IDENTIFIER); addNullToken(); return firstToken; }
 
 	<<EOF>>						{ addNullToken(); return firstToken; }
 
 	/* Catch any other (unhandled) characters and flag them as OK; */
 	/* I don't know enough about SQL to know what's really invalid. */
-	.							{ addToken(Token.IDENTIFIER); }
+	.							{ addToken(TokenTypes.IDENTIFIER); }
 
 }
 
 <STRING> {
 
 	[^\n\"]+				{}
-	\n					{ addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken; }
+	\n					{ addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken; }
 	"\"\""				{}
-	"\""					{ yybegin(YYINITIAL); addToken(start,zzStartRead, Token.LITERAL_STRING_DOUBLE_QUOTE); }
-	<<EOF>>				{ addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken; }
+	"\""					{ yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); }
+	<<EOF>>				{ addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken; }
 
 }
 
 <CHAR> {
 
 	[^\n\']+				{}
-	\n					{ addToken(start,zzStartRead-1, Token.LITERAL_CHAR); return firstToken; }
+	\n					{ addToken(start,zzStartRead-1, TokenTypes.LITERAL_CHAR); return firstToken; }
 	"\'\'"				{}
-	"\'"					{ yybegin(YYINITIAL); addToken(start,zzStartRead, Token.LITERAL_CHAR); }
-	<<EOF>>				{ addToken(start,zzStartRead-1, Token.LITERAL_CHAR); return firstToken; }
+	"\'"					{ yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.LITERAL_CHAR); }
+	<<EOF>>				{ addToken(start,zzStartRead-1, TokenTypes.LITERAL_CHAR); return firstToken; }
 
 }
 
 <MLC> {
 
 	[^\n\*]+				{}
-	\n					{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken; }
-	{MLCEnd}				{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE); }
+	\n					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken; }
+	{MLCEnd}				{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE); }
 	\*					{}
-	<<EOF>>				{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken; }
+	<<EOF>>				{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken; }
 
 }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/SQLTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/SQLTokenMaker.java
@@ -717,15 +717,15 @@ public class SQLTokenMaker extends AbstractJFlexTokenMaker {
 		// Start off in the proper state.
 		int state = YYINITIAL;
 		switch (initialTokenType) {
-			case Token.LITERAL_STRING_DOUBLE_QUOTE:
+			case TokenTypes.LITERAL_STRING_DOUBLE_QUOTE:
 				state = STRING;
 				start = text.offset;
 				break;
-			case Token.LITERAL_CHAR:
+			case TokenTypes.LITERAL_CHAR:
 				state = CHAR;
 				start = text.offset;
 				break;
-			case Token.COMMENT_MULTILINE:
+			case TokenTypes.COMMENT_MULTILINE:
 				state = MLC;
 				start = text.offset;
 				break;
@@ -1010,7 +1010,7 @@ public class SQLTokenMaker extends AbstractJFlexTokenMaker {
 
       switch (zzAction < 0 ? zzAction : ZZ_ACTION[zzAction]) {
         case 20:
-          { addToken(Token.PREPROCESSOR);
+          { addToken(TokenTypes.PREPROCESSOR);
           }
         case 23: break;
         case 2:
@@ -1018,7 +1018,7 @@ public class SQLTokenMaker extends AbstractJFlexTokenMaker {
           }
         case 24: break;
         case 21:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE);
           }
         case 25: break;
         case 18:
@@ -1026,11 +1026,11 @@ public class SQLTokenMaker extends AbstractJFlexTokenMaker {
           }
         case 26: break;
         case 4:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 27: break;
         case 14:
-          { addToken(start,zzStartRead-1, Token.LITERAL_CHAR); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.LITERAL_CHAR); return firstToken;
           }
         case 28: break;
         case 9:
@@ -1038,35 +1038,35 @@ public class SQLTokenMaker extends AbstractJFlexTokenMaker {
           }
         case 29: break;
         case 7:
-          { addToken(Token.LITERAL_NUMBER_FLOAT);
+          { addToken(TokenTypes.LITERAL_NUMBER_FLOAT);
           }
         case 30: break;
         case 19:
-          { addToken(Token.RESERVED_WORD);
+          { addToken(TokenTypes.RESERVED_WORD);
           }
         case 31: break;
         case 6:
-          { addToken(Token.SEPARATOR);
+          { addToken(TokenTypes.SEPARATOR);
           }
         case 32: break;
         case 15:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead, Token.LITERAL_CHAR);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.LITERAL_CHAR);
           }
         case 33: break;
         case 1:
-          { addToken(Token.IDENTIFIER);
+          { addToken(TokenTypes.IDENTIFIER);
           }
         case 34: break;
         case 22:
-          { addToken(Token.FUNCTION);
+          { addToken(TokenTypes.FUNCTION);
           }
         case 35: break;
         case 12:
-          { addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
           }
         case 36: break;
         case 17:
-          { addToken(Token.COMMENT_EOL);
+          { addToken(TokenTypes.COMMENT_EOL);
           }
         case 37: break;
         case 8:
@@ -1074,19 +1074,19 @@ public class SQLTokenMaker extends AbstractJFlexTokenMaker {
           }
         case 38: break;
         case 3:
-          { addToken(Token.LITERAL_NUMBER_DECIMAL_INT);
+          { addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT);
           }
         case 39: break;
         case 5:
-          { addToken(Token.OPERATOR);
+          { addToken(TokenTypes.OPERATOR);
           }
         case 40: break;
         case 13:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead, Token.LITERAL_STRING_DOUBLE_QUOTE);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
           }
         case 41: break;
         case 10:
-          { addToken(Token.ERROR_IDENTIFIER); addNullToken(); return firstToken;
+          { addToken(TokenTypes.ERROR_IDENTIFIER); addNullToken(); return firstToken;
           }
         case 42: break;
         case 11:
@@ -1094,7 +1094,7 @@ public class SQLTokenMaker extends AbstractJFlexTokenMaker {
           }
         case 43: break;
         case 16:
-          { addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken;
           }
         case 44: break;
         default:
@@ -1102,7 +1102,7 @@ public class SQLTokenMaker extends AbstractJFlexTokenMaker {
             zzAtEOF = true;
             switch (zzLexicalState) {
             case STRING: {
-              addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
             }
             case 362: break;
             case YYINITIAL: {
@@ -1110,11 +1110,11 @@ public class SQLTokenMaker extends AbstractJFlexTokenMaker {
             }
             case 363: break;
             case MLC: {
-              addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken;
             }
             case 364: break;
             case CHAR: {
-              addToken(start,zzStartRead-1, Token.LITERAL_CHAR); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.LITERAL_CHAR); return firstToken;
             }
             case 365: break;
             default:

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/ScalaTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/ScalaTokenMaker.flex
@@ -151,10 +151,10 @@ import org.fife.ui.rsyntaxtextarea.*;
 		// Start off in the proper state.
 		int state = YYINITIAL;
 		switch (initialTokenType) {
-			case Token.LITERAL_STRING_DOUBLE_QUOTE:
+			case TokenTypes.LITERAL_STRING_DOUBLE_QUOTE:
 				state = MULTILINE_STRING_DOUBLE;
 				break;
-			case Token.COMMENT_MULTILINE:
+			case TokenTypes.COMMENT_MULTILINE:
 				state = MLC;
 				break;
 			default:
@@ -317,64 +317,64 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"var" |
 	"while" |
 	"with" |
-	"yield" 			{ addToken(Token.RESERVED_WORD); }
+	"yield" 			{ addToken(TokenTypes.RESERVED_WORD); }
 
 	{LineTerminator}				{ addNullToken(); return firstToken; }
 
-	{Id}						{ addToken(Token.IDENTIFIER); }
+	{Id}						{ addToken(TokenTypes.IDENTIFIER); }
 
-	{Whitespace}					{ addToken(Token.WHITESPACE); }
+	{Whitespace}					{ addToken(TokenTypes.WHITESPACE); }
 
 	/* String/Character literals. */
 	\"\"\"						{ start = zzMarkedPos-3; yybegin(MULTILINE_STRING_DOUBLE); }
-	{UnclosedCharLiteral}			{ addToken(Token.ERROR_CHAR); addNullToken(); return firstToken; }
-	{CharLiteral}				{ addToken(Token.LITERAL_CHAR); }
-	{UnclosedStringLiteral}			{ addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
-	{StringLiteral}				{ addToken(Token.LITERAL_STRING_DOUBLE_QUOTE); }
-	{UnclosedBacktickLiteral}		{ addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
-	{BacktickLiteral}				{ addToken(Token.LITERAL_BACKQUOTE); }
+	{UnclosedCharLiteral}			{ addToken(TokenTypes.ERROR_CHAR); addNullToken(); return firstToken; }
+	{CharLiteral}				{ addToken(TokenTypes.LITERAL_CHAR); }
+	{UnclosedStringLiteral}			{ addToken(TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
+	{StringLiteral}				{ addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); }
+	{UnclosedBacktickLiteral}		{ addToken(TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
+	{BacktickLiteral}				{ addToken(TokenTypes.LITERAL_BACKQUOTE); }
 
 	/* Comment literals. */
 	{MLCBegin}					{ start = zzMarkedPos-2; yybegin(MLC); }
 	{LineCommentBegin}				{ start = zzMarkedPos-2; yybegin(EOL_COMMENT); }
 
-	{Separator}					{ addToken(Token.SEPARATOR); }
+	{Separator}					{ addToken(TokenTypes.SEPARATOR); }
 
-	{IntegerLiteral}				{ addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
-	{HexLiteral}					{ addToken(Token.LITERAL_NUMBER_HEXADECIMAL); }
-	{FloatingPointLiteral}			{ addToken(Token.LITERAL_NUMBER_FLOAT); }
+	{IntegerLiteral}				{ addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT); }
+	{HexLiteral}					{ addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL); }
+	{FloatingPointLiteral}			{ addToken(TokenTypes.LITERAL_NUMBER_FLOAT); }
 
 	/* Ended with a line not in a string or comment. */
 	<<EOF>>						{ addNullToken(); return firstToken; }
 
 	/* Catch any other (unhandled) characters. */
-	.							{ addToken(Token.IDENTIFIER); }
+	.							{ addToken(TokenTypes.IDENTIFIER); }
 
 }
 
 <MULTILINE_STRING_DOUBLE> {
 	[^\"\\\n]*				{}
 	\\.?						{ /* Skip escaped chars, handles case: '\"""'. */ }
-	\"\"\"					{ addToken(start,zzStartRead+2, Token.LITERAL_STRING_DOUBLE_QUOTE); yybegin(YYINITIAL); }
+	\"\"\"					{ addToken(start,zzStartRead+2, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); yybegin(YYINITIAL); }
 	\"						{}
 	\n |
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken; }
 }
 
 <MLC> {
 	[^hwf\n\*]+				{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos; }
 	[hwf]					{}
-	{MLCEnd}					{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE); }
+	{MLCEnd}					{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE); }
 	\*						{}
 	\n |
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken; }
 }
 
 <EOL_COMMENT> {
 	[^hwf\n]+				{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos; }
 	[hwf]					{}
 	\n |
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken; }
 }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/ScalaTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/ScalaTokenMaker.java
@@ -18,6 +18,7 @@ import javax.swing.text.Segment;
 import org.fife.ui.rsyntaxtextarea.AbstractJFlexCTokenMaker;
 import org.fife.ui.rsyntaxtextarea.Token;
 import org.fife.ui.rsyntaxtextarea.TokenImpl;
+import org.fife.ui.rsyntaxtextarea.TokenTypes;
 
 
 /**
@@ -572,10 +573,10 @@ public class ScalaTokenMaker extends AbstractJFlexCTokenMaker {
 		// Start off in the proper state.
 		int state = YYINITIAL;
 		switch (initialTokenType) {
-			case Token.LITERAL_STRING_DOUBLE_QUOTE:
+			case TokenTypes.LITERAL_STRING_DOUBLE_QUOTE:
 				state = MULTILINE_STRING_DOUBLE;
 				break;
-			case Token.COMMENT_MULTILINE:
+			case TokenTypes.COMMENT_MULTILINE:
 				state = MLC;
 				break;
 			default:
@@ -865,7 +866,7 @@ public final void yybegin(int newState) {
           }
         case 26: break;
         case 15:
-          { addToken(Token.LITERAL_CHAR);
+          { addToken(TokenTypes.LITERAL_CHAR);
           }
         case 27: break;
         case 21:
@@ -873,7 +874,7 @@ public final void yybegin(int newState) {
           }
         case 28: break;
         case 19:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE);
           }
         case 29: break;
         case 18:
@@ -881,27 +882,27 @@ public final void yybegin(int newState) {
           }
         case 30: break;
         case 8:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 31: break;
         case 20:
-          { addToken(Token.LITERAL_NUMBER_HEXADECIMAL);
+          { addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL);
           }
         case 32: break;
         case 13:
-          { addToken(Token.LITERAL_NUMBER_FLOAT);
+          { addToken(TokenTypes.LITERAL_NUMBER_FLOAT);
           }
         case 33: break;
         case 14:
-          { addToken(Token.RESERVED_WORD);
+          { addToken(TokenTypes.RESERVED_WORD);
           }
         case 34: break;
         case 4:
-          { addToken(Token.SEPARATOR);
+          { addToken(TokenTypes.SEPARATOR);
           }
         case 35: break;
         case 22:
-          { addToken(Token.LITERAL_BACKQUOTE);
+          { addToken(TokenTypes.LITERAL_BACKQUOTE);
           }
         case 36: break;
         case 9:
@@ -909,11 +910,11 @@ public final void yybegin(int newState) {
           }
         case 37: break;
         case 2:
-          { addToken(Token.IDENTIFIER);
+          { addToken(TokenTypes.IDENTIFIER);
           }
         case 38: break;
         case 12:
-          { addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
           }
         case 39: break;
         case 17:
@@ -921,35 +922,35 @@ public final void yybegin(int newState) {
           }
         case 40: break;
         case 23:
-          { addToken(start,zzStartRead+2, Token.LITERAL_STRING_DOUBLE_QUOTE); yybegin(YYINITIAL);
+          { addToken(start,zzStartRead+2, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); yybegin(YYINITIAL);
           }
         case 41: break;
         case 5:
-          { addToken(Token.ERROR_CHAR); addNullToken(); return firstToken;
+          { addToken(TokenTypes.ERROR_CHAR); addNullToken(); return firstToken;
           }
         case 42: break;
         case 7:
-          { addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
+          { addToken(TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
           }
         case 43: break;
         case 16:
-          { addToken(Token.LITERAL_STRING_DOUBLE_QUOTE);
+          { addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
           }
         case 44: break;
         case 10:
-          { addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
           }
         case 45: break;
         case 25:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos;
           }
         case 46: break;
         case 24:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos;
           }
         case 47: break;
         case 3:
-          { addToken(Token.LITERAL_NUMBER_DECIMAL_INT);
+          { addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT);
           }
         case 48: break;
         case 1:
@@ -957,7 +958,7 @@ public final void yybegin(int newState) {
           }
         case 49: break;
         case 11:
-          { addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken;
           }
         case 50: break;
         default:
@@ -965,11 +966,11 @@ public final void yybegin(int newState) {
             zzAtEOF = true;
             switch (zzLexicalState) {
             case EOL_COMMENT: {
-              addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
             }
             case 185: break;
             case MULTILINE_STRING_DOUBLE: {
-              addToken(start,zzStartRead-1, Token.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); return firstToken;
             }
             case 186: break;
             case YYINITIAL: {
@@ -977,7 +978,7 @@ public final void yybegin(int newState) {
             }
             case 187: break;
             case MLC: {
-              addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); return firstToken;
             }
             case 188: break;
             default:

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/TclTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/TclTokenMaker.flex
@@ -134,7 +134,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = Token.NULL;
+		int state = TokenTypes.NULL;
 
 		s = text;
 		try {
@@ -234,165 +234,165 @@ ErrorIdentifier			= ({NonSeparator}+)
 %%
 
 /* Keywords */
-<YYINITIAL> "append"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "array"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "auto_mkindex"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "concat"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "console"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "eval"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "expr"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "format"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "global"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "set"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "trace"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "unset"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "upvar"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "join"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "lappend"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "lindex"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "linsert"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "list"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "llength"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "lrange"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "lreplace"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "lsearch"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "lsort"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "split"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "scan"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "string"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "regexp"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "regsub"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "if"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "else"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "elseif"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "switch"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "for"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "foreach"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "while"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "break"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "continue"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "proc"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "return"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "source"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "unkown"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "uplevel"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "cd"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "close"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "eof"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "file"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "flush"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "gets"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "glob"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "open"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "read"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "puts"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "pwd"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "seek"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "tell"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "catch"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "error"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "exec"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "pid"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "after"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "time"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "exit"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "history"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "rename"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "info"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "ceil"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "floor"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "round"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "incr"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "hypot"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "abs"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "acos"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "cos"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "cosh"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "asin"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "sin"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "sinh"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "atan"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "atan2"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "tan"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "tanh"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "log"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "log10"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "fmod"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "pow"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "hypot"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "sqrt"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "double"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "int"				{ addToken(Token.RESERVED_WORD); }
+<YYINITIAL> "append"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "array"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "auto_mkindex"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "concat"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "console"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "eval"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "expr"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "format"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "global"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "set"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "trace"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "unset"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "upvar"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "join"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "lappend"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "lindex"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "linsert"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "list"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "llength"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "lrange"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "lreplace"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "lsearch"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "lsort"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "split"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "scan"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "string"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "regexp"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "regsub"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "if"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "else"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "elseif"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "switch"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "for"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "foreach"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "while"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "break"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "continue"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "proc"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "return"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "source"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "unkown"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "uplevel"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "cd"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "close"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "eof"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "file"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "flush"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "gets"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "glob"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "open"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "read"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "puts"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "pwd"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "seek"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "tell"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "catch"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "error"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "exec"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "pid"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "after"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "time"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "exit"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "history"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "rename"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "info"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "ceil"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "floor"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "round"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "incr"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "hypot"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "abs"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "acos"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "cos"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "cosh"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "asin"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "sin"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "sinh"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "atan"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "atan2"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "tan"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "tanh"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "log"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "log10"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "fmod"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "pow"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "hypot"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "sqrt"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "double"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "int"				{ addToken(TokenTypes.RESERVED_WORD); }
 
-<YYINITIAL> "bind"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "button"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "canvas"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "checkbutton"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "destroy"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "entry"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "focus"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "frame"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "grab"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "image"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "label"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "listbox"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "lower"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "menu"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "menubutton"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "message"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "option"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "pack"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "placer"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "radiobutton"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "raise"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "scale"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "scrollbar"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "selection"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "send"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "text"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "tk"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "tkerror"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "tkwait"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "toplevel"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "update"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "winfo"				{ addToken(Token.RESERVED_WORD); }
-<YYINITIAL> "wm"				{ addToken(Token.RESERVED_WORD); }
+<YYINITIAL> "bind"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "button"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "canvas"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "checkbutton"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "destroy"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "entry"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "focus"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "frame"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "grab"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "image"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "label"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "listbox"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "lower"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "menu"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "menubutton"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "message"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "option"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "pack"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "placer"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "radiobutton"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "raise"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "scale"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "scrollbar"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "selection"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "send"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "text"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "tk"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "tkerror"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "tkwait"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "toplevel"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "update"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "winfo"				{ addToken(TokenTypes.RESERVED_WORD); }
+<YYINITIAL> "wm"				{ addToken(TokenTypes.RESERVED_WORD); }
 
 
 <YYINITIAL> {
 
 	{LineTerminator}				{ addNullToken(); return firstToken; }
 
-	{Identifier}					{ addToken(Token.IDENTIFIER); }
+	{Identifier}					{ addToken(TokenTypes.IDENTIFIER); }
 
-	{WhiteSpace}+					{ addToken(Token.WHITESPACE); }
+	{WhiteSpace}+					{ addToken(TokenTypes.WHITESPACE); }
 
 	/* String/Character literals. */
-	{StringLiteral}				{ addToken(Token.LITERAL_STRING_DOUBLE_QUOTE); }
-	{UnclosedStringLiteral}			{ addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
+	{StringLiteral}				{ addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); }
+	{UnclosedStringLiteral}			{ addToken(TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
 
 	/* Comment literals. */
-	{LineCommentBegin}.*			{ addToken(Token.COMMENT_EOL); addNullToken(); return firstToken; }
+	{LineCommentBegin}.*			{ addToken(TokenTypes.COMMENT_EOL); addNullToken(); return firstToken; }
 
 	/* Separators. */
-	{Separator}					{ addToken(Token.SEPARATOR); }
-	{Separator2}					{ addToken(Token.IDENTIFIER); }
+	{Separator}					{ addToken(TokenTypes.SEPARATOR); }
+	{Separator2}					{ addToken(TokenTypes.IDENTIFIER); }
 
 	/* Operators. */
-	{Operator}					{ addToken(Token.OPERATOR); }
+	{Operator}					{ addToken(TokenTypes.OPERATOR); }
 
 	/* Numbers */
-	{IntegerLiteral}				{ addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
-	{HexLiteral}					{ addToken(Token.LITERAL_NUMBER_HEXADECIMAL); }
-	{FloatLiteral}					{ addToken(Token.LITERAL_NUMBER_FLOAT); }
-	{ErrorNumberFormat}				{ addToken(Token.ERROR_NUMBER_FORMAT); }
+	{IntegerLiteral}				{ addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT); }
+	{HexLiteral}					{ addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL); }
+	{FloatLiteral}					{ addToken(TokenTypes.LITERAL_NUMBER_FLOAT); }
+	{ErrorNumberFormat}				{ addToken(TokenTypes.ERROR_NUMBER_FORMAT); }
 
-	{ErrorIdentifier}				{ addToken(Token.ERROR_IDENTIFIER); }
+	{ErrorIdentifier}				{ addToken(TokenTypes.ERROR_IDENTIFIER); }
 
 	/* Ended with a line not in a string or comment. */
 	<<EOF>>						{ addNullToken(); return firstToken; }
 
 	/* Catch any other (unhandled) characters and flag them as bad. */
-	.							{ addToken(Token.ERROR_IDENTIFIER); }
+	.							{ addToken(TokenTypes.ERROR_IDENTIFIER); }
 
 }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/TclTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/TclTokenMaker.java
@@ -713,7 +713,7 @@ public class TclTokenMaker extends AbstractJFlexCTokenMaker {
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = Token.NULL;
+		int state = TokenTypes.NULL;
 
 		s = text;
 		try {
@@ -993,51 +993,51 @@ public final void yybegin(int newState) {
 
       switch (zzAction < 0 ? zzAction : ZZ_ACTION[zzAction]) {
         case 14:
-          { addToken(Token.RESERVED_WORD);
+          { addToken(TokenTypes.RESERVED_WORD);
           }
         case 15: break;
         case 2:
-          { addToken(Token.IDENTIFIER);
+          { addToken(TokenTypes.IDENTIFIER);
           }
         case 16: break;
         case 13:
-          { addToken(Token.LITERAL_STRING_DOUBLE_QUOTE);
+          { addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
           }
         case 17: break;
         case 11:
-          { addToken(Token.LITERAL_NUMBER_FLOAT);
+          { addToken(TokenTypes.LITERAL_NUMBER_FLOAT);
           }
         case 18: break;
         case 4:
-          { addToken(Token.COMMENT_EOL); addNullToken(); return firstToken;
+          { addToken(TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
           }
         case 19: break;
         case 6:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 20: break;
         case 10:
-          { addToken(Token.ERROR_NUMBER_FORMAT);
+          { addToken(TokenTypes.ERROR_NUMBER_FORMAT);
           }
         case 21: break;
         case 1:
-          { addToken(Token.ERROR_IDENTIFIER);
+          { addToken(TokenTypes.ERROR_IDENTIFIER);
           }
         case 22: break;
         case 12:
-          { addToken(Token.LITERAL_NUMBER_HEXADECIMAL);
+          { addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL);
           }
         case 23: break;
         case 8:
-          { addToken(Token.OPERATOR);
+          { addToken(TokenTypes.OPERATOR);
           }
         case 24: break;
         case 3:
-          { addToken(Token.LITERAL_NUMBER_DECIMAL_INT);
+          { addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT);
           }
         case 25: break;
         case 7:
-          { addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
+          { addToken(TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
           }
         case 26: break;
         case 5:
@@ -1045,7 +1045,7 @@ public final void yybegin(int newState) {
           }
         case 27: break;
         case 9:
-          { addToken(Token.SEPARATOR);
+          { addToken(TokenTypes.SEPARATOR);
           }
         case 28: break;
         default:

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/TypeScriptTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/TypeScriptTokenMaker.flex
@@ -571,15 +571,15 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"void" |
 	"while" |
 	"with" |
-	"yield"                    { addToken(Token.RESERVED_WORD); }
-	"return"					{ addToken(Token.RESERVED_WORD_2); }
+	"yield"                    { addToken(TokenTypes.RESERVED_WORD); }
+	"return"					{ addToken(TokenTypes.RESERVED_WORD_2); }
 	
 	//e4X
-	"each" 						{if(e4xSupported){ addToken(Token.RESERVED_WORD);} else {addToken(Token.IDENTIFIER);} }
+	"each" 						{if(e4xSupported){ addToken(TokenTypes.RESERVED_WORD);} else {addToken(TokenTypes.IDENTIFIER);} }
 	//JavaScript 1.7
-	"let" 						{ addToken(Token.RESERVED_WORD); }
+	"let" 						{ addToken(TokenTypes.RESERVED_WORD); }
 	// e4x miscellaneous
-	{JS_E4xAttribute}			{ addToken(isE4xSupported() ? Token.MARKUP_TAG_ATTRIBUTE : Token.ERROR_IDENTIFIER); }
+	{JS_E4xAttribute}			{ addToken(isE4xSupported() ? TokenTypes.MARKUP_TAG_ATTRIBUTE : TokenTypes.ERROR_IDENTIFIER); }
 	
 	// TypeScript data types
 	"any" |
@@ -594,7 +594,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"float" |
 	"int" |
 	"long" |
-	"short"						{ addToken(Token.DATA_TYPE); }
+	"short"						{ addToken(TokenTypes.DATA_TYPE); }
 	
 	// Reserved words, mostly from older standards
 	"abstract" |
@@ -613,13 +613,13 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"throws" |
 	"transient" |
 	"volatile" |
-	"null"						{ addToken(Token.RESERVED_WORD); }
+	"null"						{ addToken(TokenTypes.RESERVED_WORD); }
 
 	// Literals.
 	"false" |
-	"true"						{ addToken(Token.LITERAL_BOOLEAN); }
+	"true"						{ addToken(TokenTypes.LITERAL_BOOLEAN); }
 	"NaN" |
-	"Infinity"					{ addToken(Token.RESERVED_WORD); }
+	"Infinity"					{ addToken(TokenTypes.RESERVED_WORD); }
 
 	// Functions.
 	"eval" |
@@ -628,11 +628,11 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"escape" |
 	"unescape" |
 	"isNaN" |
-	"isFinite"						{ addToken(Token.FUNCTION); }
+	"isFinite"						{ addToken(TokenTypes.FUNCTION); }
 
 	{LineTerminator}				{ addNullToken(); return firstToken; }
-	{JS_Identifier}					{ addToken(Token.IDENTIFIER); }
-	{Whitespace}					{ addToken(Token.WHITESPACE); }
+	{JS_Identifier}					{ addToken(TokenTypes.IDENTIFIER); }
+	{Whitespace}					{ addToken(TokenTypes.WHITESPACE); }
 
 	/* String/Character literals. */
 	[\']							{ start = zzMarkedPos-1; validJSString = true; yybegin(JS_CHAR); }
@@ -640,7 +640,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	[\`]							{ start = zzMarkedPos-1; validJSString = true; yybegin(JS_TEMPLATE_LITERAL); }
 
 	/* Comment literals. */
-	"/**/"							{ addToken(Token.COMMENT_MULTILINE); }
+	"/**/"							{ addToken(TokenTypes.COMMENT_MULTILINE); }
 	{JS_MLCBegin}					{ start = zzMarkedPos-2; yybegin(JS_MLC); }
 	{JS_DocCommentBegin}			{ start = zzMarkedPos-3; yybegin(JS_DOCCOMMENT); }
 	{JS_LineCommentBegin}			{ start = zzMarkedPos-2; yybegin(JS_EOL_COMMENT); }
@@ -649,7 +649,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	{JS_Regex}						{
 										boolean highlightedAsRegex = false;
 										if (firstToken==null) {
-											addToken(Token.REGEX);
+											addToken(TokenTypes.REGEX);
 											highlightedAsRegex = true;
 										}
 										else {
@@ -657,7 +657,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 											// the previous token, highlight it as such.
 											Token t = firstToken.getLastNonCommentNonWhitespaceToken();
 											if (RSyntaxUtilities.regexCanFollowInJavaScript(t)) {
-												addToken(Token.REGEX);
+												addToken(TokenTypes.REGEX);
 												highlightedAsRegex = true;
 											}
 										}
@@ -665,14 +665,14 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 										// individual tokens.
 										if (!highlightedAsRegex) {
 											int temp = zzStartRead + 1;
-											addToken(zzStartRead, zzStartRead, Token.OPERATOR);
+											addToken(zzStartRead, zzStartRead, TokenTypes.OPERATOR);
 											zzStartRead = zzCurrentPos = zzMarkedPos = temp;
 										}
 									}
 
 	/* Separators. */
-	{JS_Separator}					{ addToken(Token.SEPARATOR); }
-	{JS_Separator2}					{ addToken(Token.IDENTIFIER); }
+	{JS_Separator}					{ addToken(TokenTypes.SEPARATOR); }
+	{JS_Separator2}					{ addToken(TokenTypes.IDENTIFIER); }
 
 	/* Operators. */
 	[\+]?"="{Whitespace}*"<"		{
@@ -680,10 +680,10 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 										int operatorLen = yycharat(0)=='+' ? 2 : 1;
 										int yylen = yylength(); // Cache before first addToken() invalidates it
 										//System.out.println("'" + yytext() + "': " + yylength() + ", " + (operatorLen+1));
-										addToken(zzStartRead,zzStartRead+operatorLen-1, Token.OPERATOR);
+										addToken(zzStartRead,zzStartRead+operatorLen-1, TokenTypes.OPERATOR);
 										if (yylen>operatorLen+1) {
 											//System.out.println((start+operatorLen) + ", " + (zzMarkedPos-2));
-											addToken(start+operatorLen,zzMarkedPos-2, Token.WHITESPACE);
+											addToken(start+operatorLen,zzMarkedPos-2, TokenTypes.WHITESPACE);
 										}
 										zzStartRead = zzCurrentPos = zzMarkedPos = zzMarkedPos - 1;
 										if (isE4xSupported()) {
@@ -693,21 +693,21 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 										// Found e4x (or syntax error) but option not enabled;
 										// Scanning will continue at "<" as operator
 									}
-	{JS_Operator}					{ addToken(Token.OPERATOR); }
+	{JS_Operator}					{ addToken(TokenTypes.OPERATOR); }
 
 	/* Numbers */
-	{JS_IntegerLiteral}				{ addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
-	{JS_HexLiteral}				{ addToken(Token.LITERAL_NUMBER_HEXADECIMAL); }
-	{JS_FloatLiteral}				{ addToken(Token.LITERAL_NUMBER_FLOAT); }
-	{JS_ErrorNumberFormat}			{ addToken(Token.ERROR_NUMBER_FORMAT); }
+	{JS_IntegerLiteral}				{ addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT); }
+	{JS_HexLiteral}				{ addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL); }
+	{JS_FloatLiteral}				{ addToken(TokenTypes.LITERAL_NUMBER_FLOAT); }
+	{JS_ErrorNumberFormat}			{ addToken(TokenTypes.ERROR_NUMBER_FORMAT); }
 
-	{JS_ErrorIdentifier}			{ addToken(Token.ERROR_IDENTIFIER); }
+	{JS_ErrorIdentifier}			{ addToken(TokenTypes.ERROR_IDENTIFIER); }
 
 	/* Ended with a line not in a string or comment. */
 	<<EOF>>						{ addNullToken(); return firstToken; }
 
 	/* Catch any other (unhandled) characters and flag them as bad. */
-	.							{ addToken(Token.ERROR_IDENTIFIER); }
+	.							{ addToken(TokenTypes.ERROR_IDENTIFIER); }
 
 }
 
@@ -720,18 +720,18 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	\\.						{ /* Skip all escaped chars. */ }
 	\\						{ /* Line ending in '\' => continue to next line. */
 								if (validJSString) {
-									addToken(start,zzStartRead, Token.LITERAL_STRING_DOUBLE_QUOTE);
+									addToken(start,zzStartRead, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
 									addEndToken(INTERNAL_IN_JS_STRING_VALID);
 								}
 								else {
-									addToken(start,zzStartRead, Token.ERROR_STRING_DOUBLE);
+									addToken(start,zzStartRead, TokenTypes.ERROR_STRING_DOUBLE);
 									addEndToken(INTERNAL_IN_JS_STRING_INVALID);
 								}
 								return firstToken;
 							}
-	\"						{ int type = validJSString ? Token.LITERAL_STRING_DOUBLE_QUOTE : Token.ERROR_STRING_DOUBLE; addToken(start,zzStartRead, type); yybegin(YYINITIAL); }
+	\"						{ int type = validJSString ? TokenTypes.LITERAL_STRING_DOUBLE_QUOTE : TokenTypes.ERROR_STRING_DOUBLE; addToken(start,zzStartRead, type); yybegin(YYINITIAL); }
 	\n |
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
 }
 
 <JS_CHAR> {
@@ -743,18 +743,18 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	\\.						{ /* Skip all escaped chars. */ }
 	\\						{ /* Line ending in '\' => continue to next line. */
 								if (validJSString) {
-									addToken(start,zzStartRead, Token.LITERAL_CHAR);
+									addToken(start,zzStartRead, TokenTypes.LITERAL_CHAR);
 									addEndToken(INTERNAL_IN_JS_CHAR_VALID);
 								}
 								else {
-									addToken(start,zzStartRead, Token.ERROR_CHAR);
+									addToken(start,zzStartRead, TokenTypes.ERROR_CHAR);
 									addEndToken(INTERNAL_IN_JS_CHAR_INVALID);
 								}
 								return firstToken;
 							}
-	\'						{ int type = validJSString ? Token.LITERAL_CHAR : Token.ERROR_CHAR; addToken(start,zzStartRead, type); yybegin(YYINITIAL); }
+	\'						{ int type = validJSString ? TokenTypes.LITERAL_CHAR : TokenTypes.ERROR_CHAR; addToken(start,zzStartRead, type); yybegin(YYINITIAL); }
 	\n |
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.ERROR_CHAR); addNullToken(); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.ERROR_CHAR); addNullToken(); return firstToken; }
 }
 
 <JS_TEMPLATE_LITERAL> {
@@ -766,7 +766,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	\\.						{ /* Skip all escaped chars. */ }
 
 	{JS_TemplateLiteralExprStart}	{
-								addToken(start, zzStartRead - 1, Token.LITERAL_BACKQUOTE);
+								addToken(start, zzStartRead - 1, TokenTypes.LITERAL_BACKQUOTE);
 								start = zzMarkedPos-2;
 								if (varDepths==null) {
 									varDepths = new Stack<>();
@@ -779,16 +779,16 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 							}
 	"$"						{ /* Skip valid '$' that is not part of template literal expression start */ }
 	
-	\`						{ int type = validJSString ? Token.LITERAL_BACKQUOTE : Token.ERROR_STRING_DOUBLE; addToken(start,zzStartRead, type); yybegin(YYINITIAL); }
+	\`						{ int type = validJSString ? TokenTypes.LITERAL_BACKQUOTE : TokenTypes.ERROR_STRING_DOUBLE; addToken(start,zzStartRead, type); yybegin(YYINITIAL); }
 
 	/* Line ending in '\' => continue to next line, though not necessary in template strings. */
 	\\						{
 								if (validJSString) {
-									addToken(start,zzStartRead, Token.LITERAL_BACKQUOTE);
+									addToken(start,zzStartRead, TokenTypes.LITERAL_BACKQUOTE);
 									addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_VALID);
 								}
 								else {
-									addToken(start,zzStartRead, Token.ERROR_STRING_DOUBLE);
+									addToken(start,zzStartRead, TokenTypes.ERROR_STRING_DOUBLE);
 									addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_INVALID);
 								}
 								return firstToken;
@@ -796,11 +796,11 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	\n |
 	<<EOF>>					{
 								if (validJSString) {
-									addToken(start, zzStartRead - 1, Token.LITERAL_BACKQUOTE);
+									addToken(start, zzStartRead - 1, TokenTypes.LITERAL_BACKQUOTE);
 									addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_VALID);
 								}
 								else {
-									addToken(start,zzStartRead - 1, Token.ERROR_STRING_DOUBLE);
+									addToken(start,zzStartRead - 1, TokenTypes.ERROR_STRING_DOUBLE);
 									addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_INVALID);
 								}
 								return firstToken;
@@ -813,7 +813,7 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 							if (!varDepths.empty()) {
 								varDepths.pop();
 								if (varDepths.empty()) {
-									addToken(start,zzStartRead, Token.VARIABLE);
+									addToken(start,zzStartRead, TokenTypes.VARIABLE);
 									start = zzMarkedPos;
 									yybegin(JS_TEMPLATE_LITERAL);
 								}
@@ -824,109 +824,109 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	\n |
 	<<EOF>>				{
 							// TODO: This isn't right.  The expression and its depth should continue to the next line.
-							addToken(start,zzStartRead-1, Token.VARIABLE); addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_INVALID); return firstToken;
+							addToken(start,zzStartRead-1, TokenTypes.VARIABLE); addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_INVALID); return firstToken;
 						}
 }
 
 <JS_MLC> {
 	// JavaScript MLC's.  This state is essentially Java's MLC state.
 	[^hwf\n\*]+			{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos; }
 	[hwf]					{}
-	{JS_MLCEnd}				{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE); }
+	{JS_MLCEnd}				{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE); }
 	\*						{}
 	\n |
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_JS_MLC); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_JS_MLC); return firstToken; }
 }
 
 <JS_DOCCOMMENT> {
 	[^hwf\@\{\n\<\*]+			{}
-	{URL}						{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_DOCUMENTATION); start = zzMarkedPos; }
+	{URL}						{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_DOCUMENTATION); start = zzMarkedPos; }
 	[hwf]						{}
 
-	"@"{JS_BlockTag}			{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, Token.COMMENT_KEYWORD); start = zzMarkedPos; }
+	"@"{JS_BlockTag}			{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_KEYWORD); start = zzMarkedPos; }
 	"@"							{}
-	"{@"{JS_InlineTag}[^\}]*"}"	{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, Token.COMMENT_KEYWORD); start = zzMarkedPos; }
+	"{@"{JS_InlineTag}[^\}]*"}"	{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_KEYWORD); start = zzMarkedPos; }
 	"{"							{}
-	\n							{ addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addEndToken(INTERNAL_IN_JS_COMMENT_DOCUMENTATION); return firstToken; }
-	"<"[/]?({Letter}[^\>]*)?">"	{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, Token.COMMENT_MARKUP); start = zzMarkedPos; }
+	\n							{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addEndToken(INTERNAL_IN_JS_COMMENT_DOCUMENTATION); return firstToken; }
+	"<"[/]?({Letter}[^\>]*)?">"	{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MARKUP); start = zzMarkedPos; }
 	\<							{}
-	{JS_MLCEnd}					{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_DOCUMENTATION); }
+	{JS_MLCEnd}					{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_DOCUMENTATION); }
 	\*							{}
-	<<EOF>>						{ yybegin(YYINITIAL); addToken(start,zzEndRead, Token.COMMENT_DOCUMENTATION); addEndToken(INTERNAL_IN_JS_COMMENT_DOCUMENTATION); return firstToken; }
+	<<EOF>>						{ yybegin(YYINITIAL); addToken(start,zzEndRead, TokenTypes.COMMENT_DOCUMENTATION); addEndToken(INTERNAL_IN_JS_COMMENT_DOCUMENTATION); return firstToken; }
 }
 
 <JS_EOL_COMMENT> {
 	[^hwf\n]+				{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos; }
 	[hwf]					{}
 	\n |
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken; }
 }
 
 <E4X> {
 	"<!--"						{ start = zzStartRead; e4x_prevState = zzLexicalState; yybegin(E4X_COMMENT); }
-	{e4x_CDataBegin}			{ addToken(Token.MARKUP_CDATA_DELIMITER); start = zzMarkedPos; yybegin(E4X_CDATA); }
+	{e4x_CDataBegin}			{ addToken(TokenTypes.MARKUP_CDATA_DELIMITER); start = zzMarkedPos; yybegin(E4X_CDATA); }
 	"<!"						{ start = zzMarkedPos-2; e4x_inInternalDtd = false; yybegin(E4X_DTD); }
 	"<?"						{ start = zzMarkedPos-2; yybegin(E4X_PI); }
 	"<"{e4x_TagName}			{
 									int count = yylength();
-									addToken(zzStartRead,zzStartRead, Token.MARKUP_TAG_DELIMITER);
-									addToken(zzMarkedPos-(count-1), zzMarkedPos-1, Token.MARKUP_TAG_NAME);
+									addToken(zzStartRead,zzStartRead, TokenTypes.MARKUP_TAG_DELIMITER);
+									addToken(zzMarkedPos-(count-1), zzMarkedPos-1, TokenTypes.MARKUP_TAG_NAME);
 									yybegin(E4X_INTAG);
 								}
 	"</"{e4x_TagName}			{
 									int count = yylength();
-									addToken(zzStartRead,zzStartRead+1, Token.MARKUP_TAG_DELIMITER);
-									addToken(zzMarkedPos-(count-2), zzMarkedPos-1, Token.MARKUP_TAG_NAME);
+									addToken(zzStartRead,zzStartRead+1, TokenTypes.MARKUP_TAG_DELIMITER);
+									addToken(zzMarkedPos-(count-2), zzMarkedPos-1, TokenTypes.MARKUP_TAG_NAME);
 									yybegin(E4X_INTAG);
 								}
-	"<"							{ addToken(Token.MARKUP_TAG_DELIMITER); yybegin(E4X_INTAG); }
-	"</"						{ addToken(Token.MARKUP_TAG_DELIMITER); yybegin(E4X_INTAG); }
-	{e4x_Identifier}			{ addToken(Token.IDENTIFIER); }
-	{e4x_EndXml}				{ yybegin(YYINITIAL, LANG_INDEX_DEFAULT); addToken(Token.IDENTIFIER); }
-	{e4x_EntityReference}				{ addToken(Token.MARKUP_ENTITY_REFERENCE); }
-	{Whitespace}				{ addToken(Token.WHITESPACE); }
+	"<"							{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(E4X_INTAG); }
+	"</"						{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(E4X_INTAG); }
+	{e4x_Identifier}			{ addToken(TokenTypes.IDENTIFIER); }
+	{e4x_EndXml}				{ yybegin(YYINITIAL, LANG_INDEX_DEFAULT); addToken(TokenTypes.IDENTIFIER); }
+	{e4x_EntityReference}				{ addToken(TokenTypes.MARKUP_ENTITY_REFERENCE); }
+	{Whitespace}				{ addToken(TokenTypes.WHITESPACE); }
 	{LineTerminator} |
 	<<EOF>>						{ addEndToken(INTERNAL_E4X); return firstToken; }
 }
 
 <E4X_COMMENT> {
 	[^hwf\n\-]+					{}
-	{URL}						{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.MARKUP_COMMENT); addHyperlinkToken(temp,zzMarkedPos-1, Token.MARKUP_COMMENT); start = zzMarkedPos; }
+	{URL}						{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.MARKUP_COMMENT); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.MARKUP_COMMENT); start = zzMarkedPos; }
 	[hwf]						{}
-	"-->"						{ int temp = zzMarkedPos; addToken(start,zzStartRead+2, Token.MARKUP_COMMENT); start = temp; yybegin(e4x_prevState); }
+	"-->"						{ int temp = zzMarkedPos; addToken(start,zzStartRead+2, TokenTypes.MARKUP_COMMENT); start = temp; yybegin(e4x_prevState); }
 	"-"							{}
 	{LineTerminator} |
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.MARKUP_COMMENT); addEndToken(INTERNAL_IN_E4X_COMMENT - e4x_prevState); return firstToken; }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_COMMENT); addEndToken(INTERNAL_IN_E4X_COMMENT - e4x_prevState); return firstToken; }
 }
 
 <E4X_PI> {
 	[^\n\?]+					{}
-	"?>"						{ yybegin(E4X); addToken(start,zzStartRead+1, Token.MARKUP_PROCESSING_INSTRUCTION); }
+	"?>"						{ yybegin(E4X); addToken(start,zzStartRead+1, TokenTypes.MARKUP_PROCESSING_INSTRUCTION); }
 	"?"							{}
 	{LineTerminator} |
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.MARKUP_PROCESSING_INSTRUCTION); addEndToken(INTERNAL_E4X_MARKUP_PROCESSING_INSTRUCTION); return firstToken; }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_PROCESSING_INSTRUCTION); addEndToken(INTERNAL_E4X_MARKUP_PROCESSING_INSTRUCTION); return firstToken; }
 }
 
 <E4X_DTD> {
 	[^\n\[\]<>]+				{}
-	"<!--"						{ int temp = zzStartRead; addToken(start,zzStartRead-1, Token.MARKUP_DTD); start = temp; e4x_prevState = zzLexicalState; yybegin(E4X_COMMENT); }
+	"<!--"						{ int temp = zzStartRead; addToken(start,zzStartRead-1, TokenTypes.MARKUP_DTD); start = temp; e4x_prevState = zzLexicalState; yybegin(E4X_COMMENT); }
 	"<"							{}
 	"["							{ e4x_inInternalDtd = true; }
 	"]"							{ e4x_inInternalDtd = false; }
-	">"							{ if (!e4x_inInternalDtd) { yybegin(E4X); addToken(start,zzStartRead, Token.MARKUP_DTD); } }
+	">"							{ if (!e4x_inInternalDtd) { yybegin(E4X); addToken(start,zzStartRead, TokenTypes.MARKUP_DTD); } }
 	{LineTerminator} |
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.MARKUP_DTD); addEndToken(e4x_inInternalDtd ? INTERNAL_E4X_DTD_INTERNAL : INTERNAL_E4X_DTD); return firstToken; }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_DTD); addEndToken(e4x_inInternalDtd ? INTERNAL_E4X_DTD_INTERNAL : INTERNAL_E4X_DTD); return firstToken; }
 }
 
 <E4X_INTAG> {
-	{e4x_InTagIdentifier}		{ addToken(Token.MARKUP_TAG_ATTRIBUTE); }
-	{Whitespace}				{ addToken(Token.WHITESPACE); }
-	"="							{ addToken(Token.OPERATOR); }
-	"/"							{ addToken(Token.MARKUP_TAG_DELIMITER); /* Not valid but we'll still accept it */ }
-	"/>"						{ yybegin(E4X); addToken(Token.MARKUP_TAG_DELIMITER); }
-	">"							{ yybegin(E4X); addToken(Token.MARKUP_TAG_DELIMITER); }
+	{e4x_InTagIdentifier}		{ addToken(TokenTypes.MARKUP_TAG_ATTRIBUTE); }
+	{Whitespace}				{ addToken(TokenTypes.WHITESPACE); }
+	"="							{ addToken(TokenTypes.OPERATOR); }
+	"/"							{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); /* Not valid but we'll still accept it */ }
+	"/>"						{ yybegin(E4X); addToken(TokenTypes.MARKUP_TAG_DELIMITER); }
+	">"							{ yybegin(E4X); addToken(TokenTypes.MARKUP_TAG_DELIMITER); }
 	[\"]						{ start = zzMarkedPos-1; yybegin(E4X_INATTR_DOUBLE); }
 	[\']						{ start = zzMarkedPos-1; yybegin(E4X_INATTR_SINGLE); }
 	<<EOF>>						{ addToken(start,zzStartRead-1, INTERNAL_E4X_INTAG); return firstToken; }
@@ -934,19 +934,19 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 
 <E4X_INATTR_DOUBLE> {
 	[^\"]*						{}
-	[\"]						{ yybegin(E4X_INTAG); addToken(start,zzStartRead, Token.MARKUP_TAG_ATTRIBUTE_VALUE); }
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_E4X_ATTR_DOUBLE); return firstToken; }
+	[\"]						{ yybegin(E4X_INTAG); addToken(start,zzStartRead, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_E4X_ATTR_DOUBLE); return firstToken; }
 }
 
 <E4X_INATTR_SINGLE> {
 	[^\']*						{}
-	[\']						{ yybegin(E4X_INTAG); addToken(start,zzStartRead, Token.MARKUP_TAG_ATTRIBUTE_VALUE); }
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_E4X_ATTR_SINGLE); return firstToken; }
+	[\']						{ yybegin(E4X_INTAG); addToken(start,zzStartRead, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_E4X_ATTR_SINGLE); return firstToken; }
 }
 
 <E4X_CDATA> {
 	[^\]]+						{}
-	{e4x_CDataEnd}				{ int temp=zzStartRead; yybegin(E4X); addToken(start,zzStartRead-1, Token.MARKUP_CDATA); addToken(temp,zzMarkedPos-1, Token.MARKUP_CDATA_DELIMITER); }
+	{e4x_CDataEnd}				{ int temp=zzStartRead; yybegin(E4X); addToken(start,zzStartRead-1, TokenTypes.MARKUP_CDATA); addToken(temp,zzMarkedPos-1, TokenTypes.MARKUP_CDATA_DELIMITER); }
 	"]"							{}
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.MARKUP_CDATA); addEndToken(INTERNAL_E4X_MARKUP_CDATA); return firstToken; }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_CDATA); addEndToken(INTERNAL_E4X_MARKUP_CDATA); return firstToken; }
 }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/TypeScriptTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/TypeScriptTokenMaker.java
@@ -1753,10 +1753,10 @@ public class TypeScriptTokenMaker extends AbstractJFlexCTokenMaker {
 										int operatorLen = yycharat(0)=='+' ? 2 : 1;
 										int yylen = yylength(); // Cache before first addToken() invalidates it
 										//System.out.println("'" + yytext() + "': " + yylength() + ", " + (operatorLen+1));
-										addToken(zzStartRead,zzStartRead+operatorLen-1, Token.OPERATOR);
+										addToken(zzStartRead,zzStartRead+operatorLen-1, TokenTypes.OPERATOR);
 										if (yylen>operatorLen+1) {
 											//System.out.println((start+operatorLen) + ", " + (zzMarkedPos-2));
-											addToken(start+operatorLen,zzMarkedPos-2, Token.WHITESPACE);
+											addToken(start+operatorLen,zzMarkedPos-2, TokenTypes.WHITESPACE);
 										}
 										zzStartRead = zzCurrentPos = zzMarkedPos = zzMarkedPos - 1;
 										if (isE4xSupported()) {
@@ -1772,42 +1772,42 @@ public class TypeScriptTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 84: break;
         case 43:
-          { addToken(Token.ERROR_NUMBER_FORMAT);
+          { addToken(TokenTypes.ERROR_NUMBER_FORMAT);
           }
         case 85: break;
         case 80:
-          { addToken(Token.RESERVED_WORD_2);
+          { addToken(TokenTypes.RESERVED_WORD_2);
           }
         case 86: break;
         case 27:
-          { addToken(start,zzStartRead-1, Token.MARKUP_DTD); addEndToken(e4x_inInternalDtd ? INTERNAL_E4X_DTD_INTERNAL : INTERNAL_E4X_DTD); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.MARKUP_DTD); addEndToken(e4x_inInternalDtd ? INTERNAL_E4X_DTD_INTERNAL : INTERNAL_E4X_DTD); return firstToken;
           }
         case 87: break;
         case 40:
-          { int type = validJSString ? Token.LITERAL_BACKQUOTE : Token.ERROR_STRING_DOUBLE; addToken(start,zzStartRead, type); yybegin(YYINITIAL);
+          { int type = validJSString ? TokenTypes.LITERAL_BACKQUOTE : TokenTypes.ERROR_STRING_DOUBLE; addToken(start,zzStartRead, type); yybegin(YYINITIAL);
           }
         case 88: break;
         case 3:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 89: break;
         case 18:
-          { addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_JS_MLC); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_JS_MLC); return firstToken;
           }
         case 90: break;
         case 72:
-          { addToken(Token.FUNCTION);
+          { addToken(TokenTypes.FUNCTION);
           }
         case 91: break;
         case 56:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, Token.COMMENT_MARKUP); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MARKUP); start = zzMarkedPos;
           }
         case 92: break;
         case 42:
           { if (!varDepths.empty()) {
 								varDepths.pop();
 								if (varDepths.empty()) {
-									addToken(start,zzStartRead, Token.VARIABLE);
+									addToken(start,zzStartRead, TokenTypes.VARIABLE);
 									start = zzMarkedPos;
 									yybegin(JS_TEMPLATE_LITERAL);
 								}
@@ -1827,7 +1827,7 @@ public class TypeScriptTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 96: break;
         case 12:
-          { addToken(start,zzStartRead-1, Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
           }
         case 97: break;
         case 77:
@@ -1835,11 +1835,11 @@ public class TypeScriptTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 98: break;
         case 68:
-          { int temp=zzStartRead; yybegin(E4X); addToken(start,zzStartRead-1, Token.MARKUP_CDATA); addToken(temp,zzMarkedPos-1, Token.MARKUP_CDATA_DELIMITER);
+          { int temp=zzStartRead; yybegin(E4X); addToken(start,zzStartRead-1, TokenTypes.MARKUP_CDATA); addToken(temp,zzMarkedPos-1, TokenTypes.MARKUP_CDATA_DELIMITER);
           }
         case 99: break;
         case 61:
-          { addToken(start, zzStartRead - 1, Token.LITERAL_BACKQUOTE);
+          { addToken(start, zzStartRead - 1, TokenTypes.LITERAL_BACKQUOTE);
 								start = zzMarkedPos-2;
 								if (varDepths==null) {
 									varDepths = new Stack<>();
@@ -1860,7 +1860,7 @@ public class TypeScriptTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 102: break;
         case 69:
-          { addToken(Token.COMMENT_MULTILINE);
+          { addToken(TokenTypes.COMMENT_MULTILINE);
           }
         case 103: break;
         case 59:
@@ -1868,17 +1868,17 @@ public class TypeScriptTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 104: break;
         case 36:
-          { yybegin(E4X_INTAG); addToken(start,zzStartRead, Token.MARKUP_TAG_ATTRIBUTE_VALUE);
+          { yybegin(E4X_INTAG); addToken(start,zzStartRead, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE);
           }
         case 105: break;
         case 14:
-          { int type = validJSString ? Token.LITERAL_STRING_DOUBLE_QUOTE : Token.ERROR_STRING_DOUBLE; addToken(start,zzStartRead, type); yybegin(YYINITIAL);
+          { int type = validJSString ? TokenTypes.LITERAL_STRING_DOUBLE_QUOTE : TokenTypes.ERROR_STRING_DOUBLE; addToken(start,zzStartRead, type); yybegin(YYINITIAL);
           }
         case 106: break;
         case 63:
           { boolean highlightedAsRegex = false;
 										if (firstToken==null) {
-											addToken(Token.REGEX);
+											addToken(TokenTypes.REGEX);
 											highlightedAsRegex = true;
 										}
 										else {
@@ -1886,7 +1886,7 @@ public class TypeScriptTokenMaker extends AbstractJFlexCTokenMaker {
 											// the previous token, highlight it as such.
 											Token t = firstToken.getLastNonCommentNonWhitespaceToken();
 											if (RSyntaxUtilities.regexCanFollowInJavaScript(t)) {
-												addToken(Token.REGEX);
+												addToken(TokenTypes.REGEX);
 												highlightedAsRegex = true;
 											}
 										}
@@ -1894,17 +1894,17 @@ public class TypeScriptTokenMaker extends AbstractJFlexCTokenMaker {
 										// individual tokens.
 										if (!highlightedAsRegex) {
 											int temp = zzStartRead + 1;
-											addToken(zzStartRead, zzStartRead, Token.OPERATOR);
+											addToken(zzStartRead, zzStartRead, TokenTypes.OPERATOR);
 											zzStartRead = zzCurrentPos = zzMarkedPos = temp;
 										}
           }
         case 107: break;
         case 20:
-          { addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
           }
         case 108: break;
         case 24:
-          { yybegin(YYINITIAL, LANG_INDEX_DEFAULT); addToken(Token.IDENTIFIER);
+          { yybegin(YYINITIAL, LANG_INDEX_DEFAULT); addToken(TokenTypes.IDENTIFIER);
           }
         case 109: break;
         case 52:
@@ -1913,62 +1913,62 @@ public class TypeScriptTokenMaker extends AbstractJFlexCTokenMaker {
         case 110: break;
         case 41:
           { // TODO: This isn't right.  The expression and its depth should continue to the next line.
-							addToken(start,zzStartRead-1, Token.VARIABLE); addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_INVALID); return firstToken;
+							addToken(start,zzStartRead-1, TokenTypes.VARIABLE); addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_INVALID); return firstToken;
           }
         case 111: break;
         case 79:
-          { int temp = zzStartRead; addToken(start,zzStartRead-1, Token.MARKUP_DTD); start = temp; e4x_prevState = zzLexicalState; yybegin(E4X_COMMENT);
+          { int temp = zzStartRead; addToken(start,zzStartRead-1, TokenTypes.MARKUP_DTD); start = temp; e4x_prevState = zzLexicalState; yybegin(E4X_COMMENT);
           }
         case 112: break;
         case 71:
-          { if(e4xSupported){ addToken(Token.RESERVED_WORD);} else {addToken(Token.IDENTIFIER);}
+          { if(e4xSupported){ addToken(TokenTypes.RESERVED_WORD);} else {addToken(TokenTypes.IDENTIFIER);}
           }
         case 113: break;
         case 66:
           { int count = yylength();
-									addToken(zzStartRead,zzStartRead+1, Token.MARKUP_TAG_DELIMITER);
-									addToken(zzMarkedPos-(count-2), zzMarkedPos-1, Token.MARKUP_TAG_NAME);
+									addToken(zzStartRead,zzStartRead+1, TokenTypes.MARKUP_TAG_DELIMITER);
+									addToken(zzMarkedPos-(count-2), zzMarkedPos-1, TokenTypes.MARKUP_TAG_NAME);
 									yybegin(E4X_INTAG);
           }
         case 114: break;
         case 67:
-          { int temp = zzMarkedPos; addToken(start,zzStartRead+2, Token.MARKUP_COMMENT); start = temp; yybegin(e4x_prevState);
+          { int temp = zzMarkedPos; addToken(start,zzStartRead+2, TokenTypes.MARKUP_COMMENT); start = temp; yybegin(e4x_prevState);
           }
         case 115: break;
         case 7:
-          { addToken(Token.OPERATOR);
+          { addToken(TokenTypes.OPERATOR);
           }
         case 116: break;
         case 60:
-          { yybegin(E4X); addToken(start,zzStartRead+1, Token.MARKUP_PROCESSING_INSTRUCTION);
+          { yybegin(E4X); addToken(start,zzStartRead+1, TokenTypes.MARKUP_PROCESSING_INSTRUCTION);
           }
         case 117: break;
         case 55:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_DOCUMENTATION);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_DOCUMENTATION);
           }
         case 118: break;
         case 19:
-          { addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addEndToken(INTERNAL_IN_JS_COMMENT_DOCUMENTATION); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addEndToken(INTERNAL_IN_JS_COMMENT_DOCUMENTATION); return firstToken;
           }
         case 119: break;
         case 26:
-          { addToken(start,zzStartRead-1, Token.MARKUP_PROCESSING_INSTRUCTION); addEndToken(INTERNAL_E4X_MARKUP_PROCESSING_INSTRUCTION); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.MARKUP_PROCESSING_INSTRUCTION); addEndToken(INTERNAL_E4X_MARKUP_PROCESSING_INSTRUCTION); return firstToken;
           }
         case 120: break;
         case 5:
-          { addToken(Token.IDENTIFIER);
+          { addToken(TokenTypes.IDENTIFIER);
           }
         case 121: break;
         case 73:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_MULTILINE); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_MULTILINE); start = zzMarkedPos;
           }
         case 122: break;
         case 49:
-          { addToken(isE4xSupported() ? Token.MARKUP_TAG_ATTRIBUTE : Token.ERROR_IDENTIFIER);
+          { addToken(isE4xSupported() ? TokenTypes.MARKUP_TAG_ATTRIBUTE : TokenTypes.ERROR_IDENTIFIER);
           }
         case 123: break;
         case 76:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos;
           }
         case 124: break;
         case 64:
@@ -1984,7 +1984,7 @@ public class TypeScriptTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 127: break;
         case 25:
-          { addToken(start,zzStartRead-1, Token.MARKUP_COMMENT); addEndToken(INTERNAL_IN_E4X_COMMENT - e4x_prevState); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.MARKUP_COMMENT); addEndToken(INTERNAL_IN_E4X_COMMENT - e4x_prevState); return firstToken;
           }
         case 128: break;
         case 10:
@@ -1996,7 +1996,7 @@ public class TypeScriptTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 130: break;
         case 75:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_DOCUMENTATION); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_DOCUMENTATION); start = zzMarkedPos;
           }
         case 131: break;
         case 47:
@@ -2004,35 +2004,35 @@ public class TypeScriptTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 132: break;
         case 45:
-          { addToken(Token.LITERAL_NUMBER_HEXADECIMAL);
+          { addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL);
           }
         case 133: break;
         case 81:
-          { addToken(Token.MARKUP_CDATA_DELIMITER); start = zzMarkedPos; yybegin(E4X_CDATA);
+          { addToken(TokenTypes.MARKUP_CDATA_DELIMITER); start = zzMarkedPos; yybegin(E4X_CDATA);
           }
         case 134: break;
         case 32:
-          { addToken(Token.MARKUP_TAG_DELIMITER); /* Not valid but we'll still accept it */
+          { addToken(TokenTypes.MARKUP_TAG_DELIMITER); /* Not valid but we'll still accept it */
           }
         case 135: break;
         case 2:
-          { addToken(Token.ERROR_IDENTIFIER);
+          { addToken(TokenTypes.ERROR_IDENTIFIER);
           }
         case 136: break;
         case 78:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.MARKUP_COMMENT); addHyperlinkToken(temp,zzMarkedPos-1, Token.MARKUP_COMMENT); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.MARKUP_COMMENT); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.MARKUP_COMMENT); start = zzMarkedPos;
           }
         case 137: break;
         case 33:
-          { yybegin(E4X); addToken(Token.MARKUP_TAG_DELIMITER);
+          { yybegin(E4X); addToken(TokenTypes.MARKUP_TAG_DELIMITER);
           }
         case 138: break;
         case 23:
-          { addToken(Token.MARKUP_ENTITY_REFERENCE);
+          { addToken(TokenTypes.MARKUP_ENTITY_REFERENCE);
           }
         case 139: break;
         case 70:
-          { addToken(Token.LITERAL_BOOLEAN);
+          { addToken(TokenTypes.LITERAL_BOOLEAN);
           }
         case 140: break;
         case 4:
@@ -2040,73 +2040,73 @@ public class TypeScriptTokenMaker extends AbstractJFlexCTokenMaker {
           }
         case 141: break;
         case 50:
-          { addToken(Token.RESERVED_WORD);
+          { addToken(TokenTypes.RESERVED_WORD);
           }
         case 142: break;
         case 13:
           { /* Line ending in '\' => continue to next line. */
 								if (validJSString) {
-									addToken(start,zzStartRead, Token.LITERAL_STRING_DOUBLE_QUOTE);
+									addToken(start,zzStartRead, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
 									addEndToken(INTERNAL_IN_JS_STRING_VALID);
 								}
 								else {
-									addToken(start,zzStartRead, Token.ERROR_STRING_DOUBLE);
+									addToken(start,zzStartRead, TokenTypes.ERROR_STRING_DOUBLE);
 									addEndToken(INTERNAL_IN_JS_STRING_INVALID);
 								}
 								return firstToken;
           }
         case 143: break;
         case 54:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.COMMENT_MULTILINE);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.COMMENT_MULTILINE);
           }
         case 144: break;
         case 65:
-          { addToken(Token.DATA_TYPE);
+          { addToken(TokenTypes.DATA_TYPE);
           }
         case 145: break;
         case 22:
-          { addToken(Token.MARKUP_TAG_DELIMITER); yybegin(E4X_INTAG);
+          { addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(E4X_INTAG);
           }
         case 146: break;
         case 8:
-          { addToken(Token.SEPARATOR);
+          { addToken(TokenTypes.SEPARATOR);
           }
         case 147: break;
         case 38:
           { if (validJSString) {
-									addToken(start,zzStartRead, Token.LITERAL_BACKQUOTE);
+									addToken(start,zzStartRead, TokenTypes.LITERAL_BACKQUOTE);
 									addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_VALID);
 								}
 								else {
-									addToken(start,zzStartRead, Token.ERROR_STRING_DOUBLE);
+									addToken(start,zzStartRead, TokenTypes.ERROR_STRING_DOUBLE);
 									addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_INVALID);
 								}
 								return firstToken;
           }
         case 148: break;
         case 31:
-          { addToken(Token.MARKUP_TAG_ATTRIBUTE);
+          { addToken(TokenTypes.MARKUP_TAG_ATTRIBUTE);
           }
         case 149: break;
         case 16:
           { /* Line ending in '\' => continue to next line. */
 								if (validJSString) {
-									addToken(start,zzStartRead, Token.LITERAL_CHAR);
+									addToken(start,zzStartRead, TokenTypes.LITERAL_CHAR);
 									addEndToken(INTERNAL_IN_JS_CHAR_VALID);
 								}
 								else {
-									addToken(start,zzStartRead, Token.ERROR_CHAR);
+									addToken(start,zzStartRead, TokenTypes.ERROR_CHAR);
 									addEndToken(INTERNAL_IN_JS_CHAR_INVALID);
 								}
 								return firstToken;
           }
         case 150: break;
         case 74:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, Token.COMMENT_KEYWORD); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_DOCUMENTATION); addToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_KEYWORD); start = zzMarkedPos;
           }
         case 151: break;
         case 17:
-          { int type = validJSString ? Token.LITERAL_CHAR : Token.ERROR_CHAR; addToken(start,zzStartRead, type); yybegin(YYINITIAL);
+          { int type = validJSString ? TokenTypes.LITERAL_CHAR : TokenTypes.ERROR_CHAR; addToken(start,zzStartRead, type); yybegin(YYINITIAL);
           }
         case 152: break;
         case 46:
@@ -2119,21 +2119,21 @@ public class TypeScriptTokenMaker extends AbstractJFlexCTokenMaker {
         case 154: break;
         case 57:
           { int count = yylength();
-									addToken(zzStartRead,zzStartRead, Token.MARKUP_TAG_DELIMITER);
-									addToken(zzMarkedPos-(count-1), zzMarkedPos-1, Token.MARKUP_TAG_NAME);
+									addToken(zzStartRead,zzStartRead, TokenTypes.MARKUP_TAG_DELIMITER);
+									addToken(zzMarkedPos-(count-1), zzMarkedPos-1, TokenTypes.MARKUP_TAG_NAME);
 									yybegin(E4X_INTAG);
           }
         case 155: break;
         case 44:
-          { addToken(Token.LITERAL_NUMBER_FLOAT);
+          { addToken(TokenTypes.LITERAL_NUMBER_FLOAT);
           }
         case 156: break;
         case 28:
-          { if (!e4x_inInternalDtd) { yybegin(E4X); addToken(start,zzStartRead, Token.MARKUP_DTD); }
+          { if (!e4x_inInternalDtd) { yybegin(E4X); addToken(start,zzStartRead, TokenTypes.MARKUP_DTD); }
           }
         case 157: break;
         case 6:
-          { addToken(Token.LITERAL_NUMBER_DECIMAL_INT);
+          { addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT);
           }
         case 158: break;
         case 30:
@@ -2142,18 +2142,18 @@ public class TypeScriptTokenMaker extends AbstractJFlexCTokenMaker {
         case 159: break;
         case 37:
           { if (validJSString) {
-									addToken(start, zzStartRead - 1, Token.LITERAL_BACKQUOTE);
+									addToken(start, zzStartRead - 1, TokenTypes.LITERAL_BACKQUOTE);
 									addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_VALID);
 								}
 								else {
-									addToken(start,zzStartRead - 1, Token.ERROR_STRING_DOUBLE);
+									addToken(start,zzStartRead - 1, TokenTypes.ERROR_STRING_DOUBLE);
 									addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_INVALID);
 								}
 								return firstToken;
           }
         case 160: break;
         case 15:
-          { addToken(start,zzStartRead-1, Token.ERROR_CHAR); addNullToken(); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.ERROR_CHAR); addNullToken(); return firstToken;
           }
         case 161: break;
         case 1:
@@ -2165,7 +2165,7 @@ public class TypeScriptTokenMaker extends AbstractJFlexCTokenMaker {
             zzAtEOF = true;
             switch (zzLexicalState) {
             case JS_STRING: {
-              addToken(start,zzStartRead-1, Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
             }
             case 647: break;
             case E4X: {
@@ -2177,56 +2177,56 @@ public class TypeScriptTokenMaker extends AbstractJFlexCTokenMaker {
             }
             case 649: break;
             case E4X_PI: {
-              addToken(start,zzStartRead-1, Token.MARKUP_PROCESSING_INSTRUCTION); addEndToken(INTERNAL_E4X_MARKUP_PROCESSING_INSTRUCTION); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_PROCESSING_INSTRUCTION); addEndToken(INTERNAL_E4X_MARKUP_PROCESSING_INSTRUCTION); return firstToken;
             }
             case 650: break;
             case JS_MLC: {
-              addToken(start,zzStartRead-1, Token.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_JS_MLC); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_MULTILINE); addEndToken(INTERNAL_IN_JS_MLC); return firstToken;
             }
             case 651: break;
             case JS_CHAR: {
-              addToken(start,zzStartRead-1, Token.ERROR_CHAR); addNullToken(); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.ERROR_CHAR); addNullToken(); return firstToken;
             }
             case 652: break;
             case JS_EOL_COMMENT: {
-              addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
             }
             case 653: break;
             case E4X_COMMENT: {
-              addToken(start,zzStartRead-1, Token.MARKUP_COMMENT); addEndToken(INTERNAL_IN_E4X_COMMENT - e4x_prevState); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_COMMENT); addEndToken(INTERNAL_IN_E4X_COMMENT - e4x_prevState); return firstToken;
             }
             case 654: break;
             case JS_DOCCOMMENT: {
-              yybegin(YYINITIAL); addToken(start,zzEndRead, Token.COMMENT_DOCUMENTATION); addEndToken(INTERNAL_IN_JS_COMMENT_DOCUMENTATION); return firstToken;
+              yybegin(YYINITIAL); addToken(start,zzEndRead, TokenTypes.COMMENT_DOCUMENTATION); addEndToken(INTERNAL_IN_JS_COMMENT_DOCUMENTATION); return firstToken;
             }
             case 655: break;
             case E4X_DTD: {
-              addToken(start,zzStartRead-1, Token.MARKUP_DTD); addEndToken(e4x_inInternalDtd ? INTERNAL_E4X_DTD_INTERNAL : INTERNAL_E4X_DTD); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_DTD); addEndToken(e4x_inInternalDtd ? INTERNAL_E4X_DTD_INTERNAL : INTERNAL_E4X_DTD); return firstToken;
             }
             case 656: break;
             case JS_TEMPLATE_LITERAL: {
               if (validJSString) {
-									addToken(start, zzStartRead - 1, Token.LITERAL_BACKQUOTE);
+									addToken(start, zzStartRead - 1, TokenTypes.LITERAL_BACKQUOTE);
 									addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_VALID);
 								}
 								else {
-									addToken(start,zzStartRead - 1, Token.ERROR_STRING_DOUBLE);
+									addToken(start,zzStartRead - 1, TokenTypes.ERROR_STRING_DOUBLE);
 									addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_INVALID);
 								}
 								return firstToken;
             }
             case 657: break;
             case E4X_INATTR_SINGLE: {
-              addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_E4X_ATTR_SINGLE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_E4X_ATTR_SINGLE); return firstToken;
             }
             case 658: break;
             case E4X_INATTR_DOUBLE: {
-              addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_E4X_ATTR_DOUBLE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_E4X_ATTR_DOUBLE); return firstToken;
             }
             case 659: break;
             case JS_TEMPLATE_LITERAL_EXPR: {
               // TODO: This isn't right.  The expression and its depth should continue to the next line.
-							addToken(start,zzStartRead-1, Token.VARIABLE); addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_INVALID); return firstToken;
+							addToken(start,zzStartRead-1, TokenTypes.VARIABLE); addEndToken(INTERNAL_IN_JS_TEMPLATE_LITERAL_INVALID); return firstToken;
             }
             case 660: break;
             case YYINITIAL: {
@@ -2234,7 +2234,7 @@ public class TypeScriptTokenMaker extends AbstractJFlexCTokenMaker {
             }
             case 661: break;
             case E4X_CDATA: {
-              addToken(start,zzStartRead-1, Token.MARKUP_CDATA); addEndToken(INTERNAL_E4X_MARKUP_CDATA); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_CDATA); addEndToken(INTERNAL_E4X_MARKUP_CDATA); return firstToken;
             }
             case 662: break;
             default:

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/UnixShellTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/UnixShellTokenMaker.java
@@ -60,25 +60,25 @@ public class UnixShellTokenMaker extends AbstractTokenMaker {
 		switch (tokenType) {
 			// Since reserved words, functions, and data types are all passed into here
 			// as "identifiers," we have to see what the token really is...
-			case Token.IDENTIFIER:
+			case TokenTypes.IDENTIFIER:
 				int value = wordsToHighlight.get(segment, start,end);
 				if (value!=-1)
 					tokenType = value;
 				break;
-			case Token.WHITESPACE:
-			case Token.SEPARATOR:
-			case Token.OPERATOR:
-			case Token.LITERAL_NUMBER_DECIMAL_INT:
-			case Token.LITERAL_STRING_DOUBLE_QUOTE:
-			case Token.LITERAL_CHAR:
-			case Token.LITERAL_BACKQUOTE:
-			case Token.COMMENT_EOL:
-			case Token.PREPROCESSOR:
-			case Token.VARIABLE:
+			case TokenTypes.WHITESPACE:
+			case TokenTypes.SEPARATOR:
+			case TokenTypes.OPERATOR:
+			case TokenTypes.LITERAL_NUMBER_DECIMAL_INT:
+			case TokenTypes.LITERAL_STRING_DOUBLE_QUOTE:
+			case TokenTypes.LITERAL_CHAR:
+			case TokenTypes.LITERAL_BACKQUOTE:
+			case TokenTypes.COMMENT_EOL:
+			case TokenTypes.PREPROCESSOR:
+			case TokenTypes.VARIABLE:
 				break;
 
 			default:
-				tokenType = Token.IDENTIFIER;
+				tokenType = TokenTypes.IDENTIFIER;
 				break;
 
 		}
@@ -104,7 +104,7 @@ public class UnixShellTokenMaker extends AbstractTokenMaker {
 	 */
 	@Override
 	public boolean getMarkOccurrencesOfTokenType(int type) {
-		return type==Token.IDENTIFIER || type==Token.VARIABLE;
+		return type==TokenTypes.IDENTIFIER || type==TokenTypes.VARIABLE;
 	}
 
 
@@ -120,7 +120,7 @@ public class UnixShellTokenMaker extends AbstractTokenMaker {
 
 		TokenMap tokenMap = new TokenMap();
 
-		int reservedWord = Token.RESERVED_WORD;
+		int reservedWord = TokenTypes.RESERVED_WORD;
 		tokenMap.put("case",				reservedWord);
 		tokenMap.put("do",				reservedWord);
 		tokenMap.put("done",				reservedWord);
@@ -136,7 +136,7 @@ public class UnixShellTokenMaker extends AbstractTokenMaker {
 		tokenMap.put("until",			reservedWord);
 		tokenMap.put("while",			reservedWord);
 
-		int function = Token.FUNCTION;
+		int function = TokenTypes.FUNCTION;
 		tokenMap.put("addbib",			function);
 		tokenMap.put("admin",			function);
 		tokenMap.put("alias",			function);
@@ -434,7 +434,7 @@ public class UnixShellTokenMaker extends AbstractTokenMaker {
 
 			switch (currentTokenType) {
 
-				case Token.NULL:
+				case TokenTypes.NULL:
 
 					currentTokenStart = i;	// Starting a new token here.
 
@@ -442,89 +442,89 @@ public class UnixShellTokenMaker extends AbstractTokenMaker {
 
 						case ' ':
 						case '\t':
-							currentTokenType = Token.WHITESPACE;
+							currentTokenType = TokenTypes.WHITESPACE;
 							break;
 
 						case '`':
 							if (backslash) { // Escaped back quote => call '`' an identifier..
-								addToken(text, currentTokenStart,i, Token.IDENTIFIER, newStartOffset+currentTokenStart);
+								addToken(text, currentTokenStart,i, TokenTypes.IDENTIFIER, newStartOffset+currentTokenStart);
 								backslash = false;
 							}
 							else {
-								currentTokenType = Token.LITERAL_BACKQUOTE;
+								currentTokenType = TokenTypes.LITERAL_BACKQUOTE;
 							}
 							break;
 
 						case '"':
 							if (backslash) { // Escaped double quote => call '"' an identifier..
-								addToken(text, currentTokenStart,i, Token.IDENTIFIER, newStartOffset+currentTokenStart);
+								addToken(text, currentTokenStart,i, TokenTypes.IDENTIFIER, newStartOffset+currentTokenStart);
 								backslash = false;
 							}
 							else {
-								currentTokenType = Token.LITERAL_STRING_DOUBLE_QUOTE;
+								currentTokenType = TokenTypes.LITERAL_STRING_DOUBLE_QUOTE;
 							}
 							break;
 
 						case '\'':
 							if (backslash) { // Escaped single quote => call '\'' an identifier.
-								addToken(text, currentTokenStart,i, Token.IDENTIFIER, newStartOffset+currentTokenStart);
+								addToken(text, currentTokenStart,i, TokenTypes.IDENTIFIER, newStartOffset+currentTokenStart);
 								backslash = false;
 							}
 							else {
-								currentTokenType = Token.LITERAL_CHAR;
+								currentTokenType = TokenTypes.LITERAL_CHAR;
 							}
 							break;
 
 						case '\\':
-							addToken(text, currentTokenStart,i, Token.IDENTIFIER, newStartOffset+currentTokenStart);
-							currentTokenType = Token.NULL;
+							addToken(text, currentTokenStart,i, TokenTypes.IDENTIFIER, newStartOffset+currentTokenStart);
+							currentTokenType = TokenTypes.NULL;
 							backslash = !backslash;
 							break;
 
 						case '$':
 							if (backslash) { // Escaped dollar sign => call '$' an identifier..
-								addToken(text, currentTokenStart,i, Token.IDENTIFIER, newStartOffset+currentTokenStart);
+								addToken(text, currentTokenStart,i, TokenTypes.IDENTIFIER, newStartOffset+currentTokenStart);
 								backslash = false;
 							}
 							else {
-								currentTokenType = Token.VARIABLE;
+								currentTokenType = TokenTypes.VARIABLE;
 							}
 							break;
 
 						case '#':
 							backslash = false;
-							currentTokenType = Token.COMMENT_EOL;
+							currentTokenType = TokenTypes.COMMENT_EOL;
 							break;
 
 						default:
 							if (RSyntaxUtilities.isDigit(c)) {
-								currentTokenType = Token.LITERAL_NUMBER_DECIMAL_INT;
+								currentTokenType = TokenTypes.LITERAL_NUMBER_DECIMAL_INT;
 								break;
 							}
 							else if (RSyntaxUtilities.isLetter(c) || c=='/' || c=='_') {
-								currentTokenType = Token.IDENTIFIER;
+								currentTokenType = TokenTypes.IDENTIFIER;
 								break;
 							}
 							int indexOf = OPERATORS.indexOf(c);
 							if (indexOf>-1) {
-								addToken(text, currentTokenStart,i, Token.OPERATOR, newStartOffset+currentTokenStart);
-								currentTokenType = Token.NULL;
+								addToken(text, currentTokenStart,i, TokenTypes.OPERATOR, newStartOffset+currentTokenStart);
+								currentTokenType = TokenTypes.NULL;
 								break;
 							}
 							indexOf = SEPARATORS.indexOf(c);
 							if (indexOf>-1) {
-								addToken(text, currentTokenStart,i, Token.SEPARATOR, newStartOffset+currentTokenStart);
-								currentTokenType = Token.NULL;
+								addToken(text, currentTokenStart,i, TokenTypes.SEPARATOR, newStartOffset+currentTokenStart);
+								currentTokenType = TokenTypes.NULL;
 								break;
 							}
 							indexOf = SEPARATORS2.indexOf(c);
 							if (indexOf>-1) {
-								addToken(text, currentTokenStart,i, Token.IDENTIFIER, newStartOffset+currentTokenStart);
-								currentTokenType = Token.NULL;
+								addToken(text, currentTokenStart,i, TokenTypes.IDENTIFIER, newStartOffset+currentTokenStart);
+								currentTokenType = TokenTypes.NULL;
 								break;
 							}
 							else {
-								currentTokenType = Token.IDENTIFIER;
+								currentTokenType = TokenTypes.IDENTIFIER;
 								break;
 							}
 
@@ -532,7 +532,7 @@ public class UnixShellTokenMaker extends AbstractTokenMaker {
 
 					break;
 
-				case Token.WHITESPACE:
+				case TokenTypes.WHITESPACE:
 
 					switch (c) {
 
@@ -541,79 +541,79 @@ public class UnixShellTokenMaker extends AbstractTokenMaker {
 							break;	// Still whitespace.
 
 						case '\\':
-							addToken(text, currentTokenStart,i-1, Token.WHITESPACE, newStartOffset+currentTokenStart);
-							addToken(text, i,i, Token.IDENTIFIER, newStartOffset+i);
-							currentTokenType = Token.NULL;
+							addToken(text, currentTokenStart,i-1, TokenTypes.WHITESPACE, newStartOffset+currentTokenStart);
+							addToken(text, i,i, TokenTypes.IDENTIFIER, newStartOffset+i);
+							currentTokenType = TokenTypes.NULL;
 							backslash = true; // Previous char whitespace => this must be first backslash.
 							break;
 
 						case '`': // Don't need to worry about backslashes as previous char is space.
-							addToken(text, currentTokenStart,i-1, Token.WHITESPACE, newStartOffset+currentTokenStart);
+							addToken(text, currentTokenStart,i-1, TokenTypes.WHITESPACE, newStartOffset+currentTokenStart);
 							currentTokenStart = i;
-							currentTokenType = Token.LITERAL_BACKQUOTE;
+							currentTokenType = TokenTypes.LITERAL_BACKQUOTE;
 							backslash = false;
 							break;
 
 						case '"': // Don't need to worry about backslashes as previous char is space.
-							addToken(text, currentTokenStart,i-1, Token.WHITESPACE, newStartOffset+currentTokenStart);
+							addToken(text, currentTokenStart,i-1, TokenTypes.WHITESPACE, newStartOffset+currentTokenStart);
 							currentTokenStart = i;
-							currentTokenType = Token.LITERAL_STRING_DOUBLE_QUOTE;
+							currentTokenType = TokenTypes.LITERAL_STRING_DOUBLE_QUOTE;
 							backslash = false;
 							break;
 
 						case '\'': // Don't need to worry about backslashes as previous char is space.
-							addToken(text, currentTokenStart,i-1, Token.WHITESPACE, newStartOffset+currentTokenStart);
+							addToken(text, currentTokenStart,i-1, TokenTypes.WHITESPACE, newStartOffset+currentTokenStart);
 							currentTokenStart = i;
-							currentTokenType = Token.LITERAL_CHAR;
+							currentTokenType = TokenTypes.LITERAL_CHAR;
 							backslash = false;
 							break;
 
 						case '$': // Don't need to worry about backslashes as previous char is space.
-							addToken(text, currentTokenStart,i-1, Token.WHITESPACE, newStartOffset+currentTokenStart);
+							addToken(text, currentTokenStart,i-1, TokenTypes.WHITESPACE, newStartOffset+currentTokenStart);
 							currentTokenStart = i;
-							currentTokenType = Token.VARIABLE;
+							currentTokenType = TokenTypes.VARIABLE;
 							backslash = false;
 							break;
 
 						case '#':
-							addToken(text, currentTokenStart,i-1, Token.WHITESPACE, newStartOffset+currentTokenStart);
+							addToken(text, currentTokenStart,i-1, TokenTypes.WHITESPACE, newStartOffset+currentTokenStart);
 							currentTokenStart = i;
-							currentTokenType = Token.COMMENT_EOL;
+							currentTokenType = TokenTypes.COMMENT_EOL;
 							break;
 
 						default:	// Add the whitespace token and start anew.
 
-							addToken(text, currentTokenStart,i-1, Token.WHITESPACE, newStartOffset+currentTokenStart);
+							addToken(text, currentTokenStart,i-1, TokenTypes.WHITESPACE, newStartOffset+currentTokenStart);
 							currentTokenStart = i;
 
 							if (RSyntaxUtilities.isDigit(c)) {
-								currentTokenType = Token.LITERAL_NUMBER_DECIMAL_INT;
+								currentTokenType = TokenTypes.LITERAL_NUMBER_DECIMAL_INT;
 								break;
 							}
 							else if (RSyntaxUtilities.isLetter(c) || c=='/' || c=='_') {
-								currentTokenType = Token.IDENTIFIER;
+								currentTokenType = TokenTypes.IDENTIFIER;
 								break;
 							}
 							int indexOf = OPERATORS.indexOf(c);
 							if (indexOf>-1) {
-								addToken(text, i,i, Token.OPERATOR, newStartOffset+i);
-								currentTokenType = Token.NULL;
+								addToken(text, i,i, TokenTypes.OPERATOR, newStartOffset+i);
+								currentTokenType = TokenTypes.NULL;
 								break;
 							}
 							indexOf = SEPARATORS.indexOf(c);
 							if (indexOf>-1) {
-								addToken(text, i,i, Token.SEPARATOR, newStartOffset+i);
-								currentTokenType = Token.NULL;
+								addToken(text, i,i, TokenTypes.SEPARATOR, newStartOffset+i);
+								currentTokenType = TokenTypes.NULL;
 								break;
 							}
 							indexOf = SEPARATORS2.indexOf(c);
 							if (indexOf>-1) {
-								addToken(text, i,i, Token.IDENTIFIER, newStartOffset+i);
-								currentTokenType = Token.NULL;
+								addToken(text, i,i, TokenTypes.IDENTIFIER, newStartOffset+i);
+								currentTokenType = TokenTypes.NULL;
 								break;
 							}
 							else {
-								currentTokenType = Token.IDENTIFIER;
+								currentTokenType = TokenTypes.IDENTIFIER;
 							}
 
 					} // End of switch (c).
@@ -621,62 +621,62 @@ public class UnixShellTokenMaker extends AbstractTokenMaker {
 					break;
 
 				default: // Should never happen
-				case Token.IDENTIFIER:
+				case TokenTypes.IDENTIFIER:
 
 					switch (c) {
 
 						case ' ':
 						case '\t':
-							addToken(text, currentTokenStart,i-1, Token.IDENTIFIER, newStartOffset+currentTokenStart);
+							addToken(text, currentTokenStart,i-1, TokenTypes.IDENTIFIER, newStartOffset+currentTokenStart);
 							currentTokenStart = i;
-							currentTokenType = Token.WHITESPACE;
+							currentTokenType = TokenTypes.WHITESPACE;
 							break;
 
 						case '/': // Special-case to colorize commands like "echo" in "/bin/echo"
-							addToken(text, currentTokenStart,i, Token.IDENTIFIER, newStartOffset+currentTokenStart);
+							addToken(text, currentTokenStart,i, TokenTypes.IDENTIFIER, newStartOffset+currentTokenStart);
 							currentTokenStart = i+1;
-							currentTokenType = Token.NULL;
+							currentTokenType = TokenTypes.NULL;
 							break;
 
 						case '`': // Don't need to worry about backslashes as previous char is space.
-							addToken(text, currentTokenStart,i-1, Token.IDENTIFIER, newStartOffset+currentTokenStart);
+							addToken(text, currentTokenStart,i-1, TokenTypes.IDENTIFIER, newStartOffset+currentTokenStart);
 							currentTokenStart = i;
-							currentTokenType = Token.LITERAL_BACKQUOTE;
+							currentTokenType = TokenTypes.LITERAL_BACKQUOTE;
 							backslash = false;
 							break;
 
 						case '"': // Don't need to worry about backslashes as previous char is non-backslash.
-							addToken(text, currentTokenStart,i-1, Token.IDENTIFIER, newStartOffset+currentTokenStart);
+							addToken(text, currentTokenStart,i-1, TokenTypes.IDENTIFIER, newStartOffset+currentTokenStart);
 							currentTokenStart = i;
-							currentTokenType = Token.LITERAL_STRING_DOUBLE_QUOTE;
+							currentTokenType = TokenTypes.LITERAL_STRING_DOUBLE_QUOTE;
 							backslash = false;
 							break;
 
 						case '\'': // Don't need to worry about backslashes as previous char is non-backslash.
-							addToken(text, currentTokenStart,i-1, Token.IDENTIFIER, newStartOffset+currentTokenStart);
+							addToken(text, currentTokenStart,i-1, TokenTypes.IDENTIFIER, newStartOffset+currentTokenStart);
 							currentTokenStart = i;
-							currentTokenType = Token.LITERAL_CHAR;
+							currentTokenType = TokenTypes.LITERAL_CHAR;
 							backslash = false;
 							break;
 
 						case '\\':
-							addToken(text, currentTokenStart,i-1, Token.IDENTIFIER, newStartOffset+currentTokenStart);
-							addToken(text, i,i, Token.IDENTIFIER, newStartOffset+i);
-							currentTokenType = Token.NULL;
+							addToken(text, currentTokenStart,i-1, TokenTypes.IDENTIFIER, newStartOffset+currentTokenStart);
+							addToken(text, i,i, TokenTypes.IDENTIFIER, newStartOffset+i);
+							currentTokenType = TokenTypes.NULL;
 							backslash = true;
 							break;
 
 						case '$': // Don't need to worry about backslashes as previous char is non-backslash.
-							addToken(text, currentTokenStart,i-1, Token.IDENTIFIER, newStartOffset+currentTokenStart);
+							addToken(text, currentTokenStart,i-1, TokenTypes.IDENTIFIER, newStartOffset+currentTokenStart);
 							currentTokenStart = i;
-							currentTokenType = Token.VARIABLE;
+							currentTokenType = TokenTypes.VARIABLE;
 							backslash = false;
 							break;
 
 						case '=': // Special case here; when you have "identifier=<value>" in shell, "identifier" is a variable.
-							addToken(text, currentTokenStart,i-1, Token.VARIABLE, newStartOffset+currentTokenStart);
-							addToken(text, i,i, Token.OPERATOR, newStartOffset+i);
-							currentTokenType = Token.NULL;
+							addToken(text, currentTokenStart,i-1, TokenTypes.VARIABLE, newStartOffset+currentTokenStart);
+							addToken(text, i,i, TokenTypes.OPERATOR, newStartOffset+i);
+							currentTokenType = TokenTypes.NULL;
 							break;
 
 						default:
@@ -685,23 +685,23 @@ public class UnixShellTokenMaker extends AbstractTokenMaker {
 							}
 							int indexOf = OPERATORS.indexOf(c);
 							if (indexOf>-1) {
-								addToken(text, currentTokenStart,i-1, Token.IDENTIFIER, newStartOffset+currentTokenStart);
-								addToken(text, i,i, Token.OPERATOR, newStartOffset+i);
-								currentTokenType = Token.NULL;
+								addToken(text, currentTokenStart,i-1, TokenTypes.IDENTIFIER, newStartOffset+currentTokenStart);
+								addToken(text, i,i, TokenTypes.OPERATOR, newStartOffset+i);
+								currentTokenType = TokenTypes.NULL;
 								break;
 							}
 							indexOf = SEPARATORS.indexOf(c);
 							if (indexOf>-1) {
-								addToken(text, currentTokenStart,i-1, Token.IDENTIFIER, newStartOffset+currentTokenStart);
-								addToken(text, i,i, Token.SEPARATOR, newStartOffset+i);
-								currentTokenType = Token.NULL;
+								addToken(text, currentTokenStart,i-1, TokenTypes.IDENTIFIER, newStartOffset+currentTokenStart);
+								addToken(text, i,i, TokenTypes.SEPARATOR, newStartOffset+i);
+								currentTokenType = TokenTypes.NULL;
 								break;
 							}
 							indexOf = SEPARATORS2.indexOf(c);
 							if (indexOf>-1) {
-								addToken(text, currentTokenStart,i-1, Token.IDENTIFIER, newStartOffset+currentTokenStart);
-								addToken(text, i,i, Token.IDENTIFIER, newStartOffset+i);
-								currentTokenType = Token.NULL;
+								addToken(text, currentTokenStart,i-1, TokenTypes.IDENTIFIER, newStartOffset+currentTokenStart);
+								addToken(text, i,i, TokenTypes.IDENTIFIER, newStartOffset+i);
+								currentTokenType = TokenTypes.NULL;
 								break;
 							}
 							// Otherwise, we're still an identifier (?).
@@ -710,49 +710,49 @@ public class UnixShellTokenMaker extends AbstractTokenMaker {
 
 					break;
 
-				case Token.LITERAL_NUMBER_DECIMAL_INT:
+				case TokenTypes.LITERAL_NUMBER_DECIMAL_INT:
 
 					switch (c) {
 
 						case ' ':
 						case '\t':
-							addToken(text, currentTokenStart,i-1, Token.LITERAL_NUMBER_DECIMAL_INT, newStartOffset+currentTokenStart);
+							addToken(text, currentTokenStart,i-1, TokenTypes.LITERAL_NUMBER_DECIMAL_INT, newStartOffset+currentTokenStart);
 							currentTokenStart = i;
-							currentTokenType = Token.WHITESPACE;
+							currentTokenType = TokenTypes.WHITESPACE;
 							break;
 
 						case '`': // Don't need to worry about backslashes as previous char is space.
-							addToken(text, currentTokenStart,i-1, Token.LITERAL_NUMBER_DECIMAL_INT, newStartOffset+currentTokenStart);
+							addToken(text, currentTokenStart,i-1, TokenTypes.LITERAL_NUMBER_DECIMAL_INT, newStartOffset+currentTokenStart);
 							currentTokenStart = i;
-							currentTokenType = Token.LITERAL_BACKQUOTE;
+							currentTokenType = TokenTypes.LITERAL_BACKQUOTE;
 							backslash = false;
 							break;
 
 						case '"': // Don't need to worry about backslashes as previous char is non-backslash.
-							addToken(text, currentTokenStart,i-1, Token.LITERAL_NUMBER_DECIMAL_INT, newStartOffset+currentTokenStart);
+							addToken(text, currentTokenStart,i-1, TokenTypes.LITERAL_NUMBER_DECIMAL_INT, newStartOffset+currentTokenStart);
 							currentTokenStart = i;
-							currentTokenType = Token.LITERAL_STRING_DOUBLE_QUOTE;
+							currentTokenType = TokenTypes.LITERAL_STRING_DOUBLE_QUOTE;
 							backslash = false;
 							break;
 
 						case '\'': // Don't need to worry about backslashes as previous char is non-backslash.
-							addToken(text, currentTokenStart,i-1, Token.LITERAL_NUMBER_DECIMAL_INT, newStartOffset+currentTokenStart);
+							addToken(text, currentTokenStart,i-1, TokenTypes.LITERAL_NUMBER_DECIMAL_INT, newStartOffset+currentTokenStart);
 							currentTokenStart = i;
-							currentTokenType = Token.LITERAL_CHAR;
+							currentTokenType = TokenTypes.LITERAL_CHAR;
 							backslash = false;
 							break;
 
 						case '$': // Don't need to worry about backslashes as previous char is non-backslash.
-							addToken(text, currentTokenStart,i-1, Token.LITERAL_NUMBER_DECIMAL_INT, newStartOffset+currentTokenStart);
+							addToken(text, currentTokenStart,i-1, TokenTypes.LITERAL_NUMBER_DECIMAL_INT, newStartOffset+currentTokenStart);
 							currentTokenStart = i;
-							currentTokenType = Token.VARIABLE;
+							currentTokenType = TokenTypes.VARIABLE;
 							backslash = false;
 							break;
 
 						case '\\':
-							addToken(text, currentTokenStart,i-1, Token.LITERAL_NUMBER_DECIMAL_INT, newStartOffset+currentTokenStart);
-							addToken(text, i,i, Token.IDENTIFIER, newStartOffset+i);
-							currentTokenType = Token.NULL;
+							addToken(text, currentTokenStart,i-1, TokenTypes.LITERAL_NUMBER_DECIMAL_INT, newStartOffset+currentTokenStart);
+							addToken(text, i,i, TokenTypes.IDENTIFIER, newStartOffset+i);
+							currentTokenType = TokenTypes.NULL;
 							backslash = true;
 							break;
 
@@ -763,50 +763,50 @@ public class UnixShellTokenMaker extends AbstractTokenMaker {
 							}
 							int indexOf = OPERATORS.indexOf(c);
 							if (indexOf>-1) {
-								addToken(text, currentTokenStart,i-1, Token.LITERAL_NUMBER_DECIMAL_INT, newStartOffset+currentTokenStart);
-								addToken(text, i,i, Token.OPERATOR, newStartOffset+i);
-								currentTokenType = Token.NULL;
+								addToken(text, currentTokenStart,i-1, TokenTypes.LITERAL_NUMBER_DECIMAL_INT, newStartOffset+currentTokenStart);
+								addToken(text, i,i, TokenTypes.OPERATOR, newStartOffset+i);
+								currentTokenType = TokenTypes.NULL;
 								break;
 							}
 							indexOf = SEPARATORS.indexOf(c);
 							if (indexOf>-1) {
-								addToken(text, currentTokenStart,i-1, Token.LITERAL_NUMBER_DECIMAL_INT, newStartOffset+currentTokenStart);
-								addToken(text, i,i, Token.SEPARATOR, newStartOffset+i);
-								currentTokenType = Token.NULL;
+								addToken(text, currentTokenStart,i-1, TokenTypes.LITERAL_NUMBER_DECIMAL_INT, newStartOffset+currentTokenStart);
+								addToken(text, i,i, TokenTypes.SEPARATOR, newStartOffset+i);
+								currentTokenType = TokenTypes.NULL;
 								break;
 							}
 							indexOf = SEPARATORS2.indexOf(c);
 							if (indexOf>-1) {
-								addToken(text, currentTokenStart,i-1, Token.LITERAL_NUMBER_DECIMAL_INT, newStartOffset+currentTokenStart);
-								addToken(text, i,i, Token.IDENTIFIER, newStartOffset+i);
-								currentTokenType = Token.NULL;
+								addToken(text, currentTokenStart,i-1, TokenTypes.LITERAL_NUMBER_DECIMAL_INT, newStartOffset+currentTokenStart);
+								addToken(text, i,i, TokenTypes.IDENTIFIER, newStartOffset+i);
+								currentTokenType = TokenTypes.NULL;
 								break;
 							}
 
 							// Otherwise, remember this was a number and start over.
-							addToken(text, currentTokenStart,i-1, Token.LITERAL_NUMBER_DECIMAL_INT, newStartOffset+currentTokenStart);
+							addToken(text, currentTokenStart,i-1, TokenTypes.LITERAL_NUMBER_DECIMAL_INT, newStartOffset+currentTokenStart);
 							i--;
-							currentTokenType = Token.NULL;
+							currentTokenType = TokenTypes.NULL;
 
 					} // End of switch (c).
 
 					break;
 
-				case Token.VARIABLE:
+				case TokenTypes.VARIABLE:
 
 					// Note that we first arrive here AFTER the '$' character.
 					// First check if the variable name is enclosed in '{' and '}' characters.
 					if (c=='{') {
 						while (++i<end) {
 							if (array[i]=='}') {
-								addToken(text, currentTokenStart,i, Token.VARIABLE, newStartOffset+currentTokenStart);
-								currentTokenType = Token.NULL;
+								addToken(text, currentTokenStart,i, TokenTypes.VARIABLE, newStartOffset+currentTokenStart);
+								currentTokenType = TokenTypes.NULL;
 								break;
 							}
 						} // End of while (++i<end).
 						if (i==end) { // Happens when '}' wasn't found...
-							addToken(text, currentTokenStart,end-1, Token.VARIABLE, newStartOffset+currentTokenStart);
-							currentTokenType = Token.NULL;
+							addToken(text, currentTokenStart,end-1, TokenTypes.VARIABLE, newStartOffset+currentTokenStart);
+							currentTokenType = TokenTypes.NULL;
 						}
 						break;
 					} // End of if (i<end-1 && array[i+1]=='{').
@@ -815,9 +815,9 @@ public class UnixShellTokenMaker extends AbstractTokenMaker {
 					while (i<end) {
 						c = array[i];	// Not needed the first iteration, but can't think of a better way to do it...
 						if (!RSyntaxUtilities.isLetterOrDigit(c) && shellVariables.indexOf(c)==-1 && c!='_') {
-							addToken(text, currentTokenStart,i-1, Token.VARIABLE, newStartOffset+currentTokenStart);
+							addToken(text, currentTokenStart,i-1, TokenTypes.VARIABLE, newStartOffset+currentTokenStart);
 							i--;
-							currentTokenType = Token.NULL;
+							currentTokenType = TokenTypes.NULL;
 							break;
 						}
 						i++;
@@ -825,33 +825,33 @@ public class UnixShellTokenMaker extends AbstractTokenMaker {
 
 					// This only happens if we never found the end of the variable in the loop above.
 					if (i==end) {
-						addToken(text, currentTokenStart,i-1, Token.VARIABLE, newStartOffset+currentTokenStart);
-						currentTokenType = Token.NULL;
+						addToken(text, currentTokenStart,i-1, TokenTypes.VARIABLE, newStartOffset+currentTokenStart);
+						currentTokenType = TokenTypes.NULL;
 					}
 
 					break;
 
-				case Token.COMMENT_EOL:
+				case TokenTypes.COMMENT_EOL:
 					// If we got here, then the line != "#" only, so check for "#!".
 					if (c=='!')
-						currentTokenType = Token.PREPROCESSOR;
+						currentTokenType = TokenTypes.PREPROCESSOR;
 					i = end - 1;
 					addToken(text, currentTokenStart,i, currentTokenType, newStartOffset+currentTokenStart);
 					// We need to set token type to null so at the bottom we don't add one more token.
-					currentTokenType = Token.NULL;
+					currentTokenType = TokenTypes.NULL;
 
 					break;
 
-				case Token.LITERAL_CHAR:
+				case TokenTypes.LITERAL_CHAR:
 
 						if (c=='\\') {
 							backslash = !backslash; // Okay because if we got in here, backslash was initially false.
 						}
 						else {
 							if (c=='\'' && !backslash) {
-								addToken(text, currentTokenStart,i, Token.LITERAL_CHAR, newStartOffset+currentTokenStart);
+								addToken(text, currentTokenStart,i, TokenTypes.LITERAL_CHAR, newStartOffset+currentTokenStart);
 								currentTokenStart = i + 1;
-								currentTokenType = Token.NULL;
+								currentTokenType = TokenTypes.NULL;
 								// backslash is definitely false when we leave.
 							}
 
@@ -862,7 +862,7 @@ public class UnixShellTokenMaker extends AbstractTokenMaker {
 
 						break;
 
-				case Token.LITERAL_BACKQUOTE:
+				case TokenTypes.LITERAL_BACKQUOTE:
 
 						switch (c) {
 
@@ -872,8 +872,8 @@ public class UnixShellTokenMaker extends AbstractTokenMaker {
 
 							case '`':
 								if (!backslash) {
-									addToken(text, currentTokenStart,i, Token.LITERAL_BACKQUOTE, newStartOffset+currentTokenStart);
-									currentTokenType = Token.NULL;
+									addToken(text, currentTokenStart,i, TokenTypes.LITERAL_BACKQUOTE, newStartOffset+currentTokenStart);
+									currentTokenType = TokenTypes.NULL;
 									// backslash is definitely false when we leave.
 									break;
 								}
@@ -889,8 +889,8 @@ public class UnixShellTokenMaker extends AbstractTokenMaker {
 								}
 
 								// Add the string up-to the variable.
-								addToken(text, currentTokenStart,i-1, Token.LITERAL_BACKQUOTE, newStartOffset+currentTokenStart);
-								currentTokenType = Token.VARIABLE;
+								addToken(text, currentTokenStart,i-1, TokenTypes.LITERAL_BACKQUOTE, newStartOffset+currentTokenStart);
+								currentTokenType = TokenTypes.VARIABLE;
 								currentTokenStart = i;
 
 								// First check if the variable name is enclosed in '{' and '}' characters.
@@ -898,39 +898,39 @@ public class UnixShellTokenMaker extends AbstractTokenMaker {
 									i++; // Now we're on the '{' char.
 									while (++i<end) {
 										if (array[i]=='}') {
-											addToken(text, currentTokenStart,i, Token.VARIABLE, newStartOffset+currentTokenStart);
+											addToken(text, currentTokenStart,i, TokenTypes.VARIABLE, newStartOffset+currentTokenStart);
 											i++;
 											if (i<end) {
 												c = array[i];
 												if (c=='`') { // The only rub - back quote right after variable.
-													addToken(text, i,i, Token.LITERAL_BACKQUOTE, newStartOffset+i);
-													currentTokenType = Token.NULL;
+													addToken(text, i,i, TokenTypes.LITERAL_BACKQUOTE, newStartOffset+i);
+													currentTokenType = TokenTypes.NULL;
 													break;
 												}
 												else { // Continue on with the string.
 													currentTokenStart = i;
-													currentTokenType = Token.LITERAL_BACKQUOTE;
+													currentTokenType = TokenTypes.LITERAL_BACKQUOTE;
 													i--;
 													break;
 												}
 											}
 											else { // i==end = "trick" this method so that the string is continued to the next line.
 												currentTokenStart = i;
-												currentTokenType = Token.LITERAL_BACKQUOTE;
+												currentTokenType = TokenTypes.LITERAL_BACKQUOTE;
 												break; // So we don't hit the condition below.
 											}
 										} // End of if (array[i]=='}').
 									} // End of while (++i<end).
 									if (i==end) { // Happens when '}' wasn't found...
-										addToken(text, currentTokenStart,end-1, Token.VARIABLE, newStartOffset+currentTokenStart);
+										addToken(text, currentTokenStart,end-1, TokenTypes.VARIABLE, newStartOffset+currentTokenStart);
 										currentTokenStart = end; // ???
-										currentTokenType = Token.LITERAL_BACKQUOTE;
+										currentTokenType = TokenTypes.LITERAL_BACKQUOTE;
 										break;
 									}
 								} // End of if (i<end-1 && array[i+1]=='{').
 
 								// If we reached the end of the variable, get out.
-								if (currentTokenType==Token.NULL || currentTokenType==Token.LITERAL_BACKQUOTE)
+								if (currentTokenType==TokenTypes.NULL || currentTokenType==TokenTypes.LITERAL_BACKQUOTE)
 									break;
 
 								// If we didn't find the '{' character, find the end of the variable...
@@ -938,15 +938,15 @@ public class UnixShellTokenMaker extends AbstractTokenMaker {
 								while (++i<end) {
 									c = array[i];
 									if (!RSyntaxUtilities.isLetterOrDigit(c) && shellVariables.indexOf(c)==-1 && c!='_') {
-										addToken(text, currentTokenStart,i-1, Token.VARIABLE, newStartOffset+currentTokenStart);
+										addToken(text, currentTokenStart,i-1, TokenTypes.VARIABLE, newStartOffset+currentTokenStart);
 										if (c=='`') { // The only rub.
-											addToken(text, i,i, Token.LITERAL_BACKQUOTE, newStartOffset+i);
-											currentTokenType = Token.NULL;
+											addToken(text, i,i, TokenTypes.LITERAL_BACKQUOTE, newStartOffset+i);
+											currentTokenType = TokenTypes.NULL;
 											break;
 										}
 										else {
 											currentTokenStart = i;
-											currentTokenType = Token.LITERAL_BACKQUOTE;
+											currentTokenType = TokenTypes.LITERAL_BACKQUOTE;
 											i--;
 											break;
 										}
@@ -956,9 +956,9 @@ public class UnixShellTokenMaker extends AbstractTokenMaker {
 								// This only happens if we never found the end of the variable in the loop above.
 								// We "trick" this method so that the backquote string token is at the end.
 								if (i==end) {
-									addToken(text, currentTokenStart,i-1, Token.VARIABLE, newStartOffset+currentTokenStart);
+									addToken(text, currentTokenStart,i-1, TokenTypes.VARIABLE, newStartOffset+currentTokenStart);
 									currentTokenStart = i;
-									currentTokenType = Token.LITERAL_BACKQUOTE;
+									currentTokenType = TokenTypes.LITERAL_BACKQUOTE;
 								}
 
 								break;
@@ -971,7 +971,7 @@ public class UnixShellTokenMaker extends AbstractTokenMaker {
 
 						break;
 
-				case Token.LITERAL_STRING_DOUBLE_QUOTE:
+				case TokenTypes.LITERAL_STRING_DOUBLE_QUOTE:
 
 						switch (c) {
 
@@ -981,8 +981,8 @@ public class UnixShellTokenMaker extends AbstractTokenMaker {
 
 							case '"':
 								if (!backslash) {
-									addToken(text, currentTokenStart,i, Token.LITERAL_STRING_DOUBLE_QUOTE, newStartOffset+currentTokenStart);
-									currentTokenType = Token.NULL;
+									addToken(text, currentTokenStart,i, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE, newStartOffset+currentTokenStart);
+									currentTokenType = TokenTypes.NULL;
 									// backslash is definitely false when we leave.
 									break;
 								}
@@ -998,8 +998,8 @@ public class UnixShellTokenMaker extends AbstractTokenMaker {
 								}
 
 								// Add the string up-to the variable.
-								addToken(text, currentTokenStart,i-1, Token.LITERAL_STRING_DOUBLE_QUOTE, newStartOffset+currentTokenStart);
-								currentTokenType = Token.VARIABLE;
+								addToken(text, currentTokenStart,i-1, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE, newStartOffset+currentTokenStart);
+								currentTokenType = TokenTypes.VARIABLE;
 								currentTokenStart = i;
 
 								// First check if the variable name is enclosed in '{' and '}' characters.
@@ -1007,39 +1007,39 @@ public class UnixShellTokenMaker extends AbstractTokenMaker {
 									i++; // Now we're on the '{' char.
 									while (++i<end) {
 										if (array[i]=='}') {
-											addToken(text, currentTokenStart,i, Token.VARIABLE, newStartOffset+currentTokenStart);
+											addToken(text, currentTokenStart,i, TokenTypes.VARIABLE, newStartOffset+currentTokenStart);
 											i++;
 											if (i<end) {
 												c = array[i];
 												if (c=='"') { // The only rub - double-quote right after variable.
-													addToken(text, i,i, Token.LITERAL_STRING_DOUBLE_QUOTE, newStartOffset+i);
-													currentTokenType = Token.NULL;
+													addToken(text, i,i, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE, newStartOffset+i);
+													currentTokenType = TokenTypes.NULL;
 													break;
 												}
 												else { // Continue on with the string.
 													currentTokenStart = i;
-													currentTokenType = Token.LITERAL_STRING_DOUBLE_QUOTE;
+													currentTokenType = TokenTypes.LITERAL_STRING_DOUBLE_QUOTE;
 													i--;
 													break;
 												}
 											}
 											else { // i==end = "trick" this method so that the string is continued to the next line.
 												currentTokenStart = i;
-												currentTokenType = Token.LITERAL_STRING_DOUBLE_QUOTE;
+												currentTokenType = TokenTypes.LITERAL_STRING_DOUBLE_QUOTE;
 												break; // So we don't hit the condition below.
 											}
 										} // End of if (array[i]=='}').
 									} // End of while (++i<end).
 									if (i==end) { // Happens when '}' wasn't found...
-										addToken(text, currentTokenStart,end-1, Token.VARIABLE, newStartOffset+currentTokenStart);
+										addToken(text, currentTokenStart,end-1, TokenTypes.VARIABLE, newStartOffset+currentTokenStart);
 										currentTokenStart = end; // ???
-										currentTokenType = Token.LITERAL_STRING_DOUBLE_QUOTE;
+										currentTokenType = TokenTypes.LITERAL_STRING_DOUBLE_QUOTE;
 										break;
 									}
 								} // End of if (i<end-1 && array[i+1]=='{').
 
 								// If we reached the end of the variable, get out.
-								if (currentTokenType==Token.NULL || currentTokenType==Token.LITERAL_STRING_DOUBLE_QUOTE)
+								if (currentTokenType==TokenTypes.NULL || currentTokenType==TokenTypes.LITERAL_STRING_DOUBLE_QUOTE)
 									break;
 
 								// If we didn't find the '{' character, find the end of the variable...
@@ -1047,15 +1047,15 @@ public class UnixShellTokenMaker extends AbstractTokenMaker {
 								while (++i<end) {
 									c = array[i];
 									if (!RSyntaxUtilities.isLetterOrDigit(c) && shellVariables.indexOf(c)==-1 && c!='_') {
-										addToken(text, currentTokenStart,i-1, Token.VARIABLE, newStartOffset+currentTokenStart);
+										addToken(text, currentTokenStart,i-1, TokenTypes.VARIABLE, newStartOffset+currentTokenStart);
 										if (c=='"') { // The only rub.
-											addToken(text, i,i, Token.LITERAL_STRING_DOUBLE_QUOTE, newStartOffset+i);
-											currentTokenType = Token.NULL;
+											addToken(text, i,i, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE, newStartOffset+i);
+											currentTokenType = TokenTypes.NULL;
 											break;
 										}
 										else {
 											currentTokenStart = i;
-											currentTokenType = Token.LITERAL_STRING_DOUBLE_QUOTE;
+											currentTokenType = TokenTypes.LITERAL_STRING_DOUBLE_QUOTE;
 											i--;
 											break;
 										}
@@ -1065,9 +1065,9 @@ public class UnixShellTokenMaker extends AbstractTokenMaker {
 								// This only happens if we never found the end of the variable in the loop above.
 								// We "trick" this method so that the double-quote string token is at the end.
 								if (i==end) {
-									addToken(text, currentTokenStart,i-1, Token.VARIABLE, newStartOffset+currentTokenStart);
+									addToken(text, currentTokenStart,i-1, TokenTypes.VARIABLE, newStartOffset+currentTokenStart);
 									currentTokenStart = i;
-									currentTokenType = Token.LITERAL_STRING_DOUBLE_QUOTE;
+									currentTokenType = TokenTypes.LITERAL_STRING_DOUBLE_QUOTE;
 								}
 
 								break;
@@ -1087,14 +1087,14 @@ public class UnixShellTokenMaker extends AbstractTokenMaker {
 		switch (currentTokenType) {
 
 			// Remember what token type to begin the next line with.
-			case Token.LITERAL_BACKQUOTE:
-			case Token.LITERAL_STRING_DOUBLE_QUOTE:
-			case Token.LITERAL_CHAR:
+			case TokenTypes.LITERAL_BACKQUOTE:
+			case TokenTypes.LITERAL_STRING_DOUBLE_QUOTE:
+			case TokenTypes.LITERAL_CHAR:
 						addToken(text, currentTokenStart,end-1, currentTokenType, newStartOffset+currentTokenStart);
 						break;
 
 			// Do nothing if everything was okay.
-			case Token.NULL:
+			case TokenTypes.NULL:
 						addNullToken();
 						break;
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/VhdlTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/VhdlTokenMaker.flex
@@ -20,6 +20,7 @@ import javax.swing.text.Segment;
 import org.fife.ui.rsyntaxtextarea.AbstractJFlexTokenMaker;
 import org.fife.ui.rsyntaxtextarea.Token;
 import org.fife.ui.rsyntaxtextarea.TokenImpl;
+import org.fife.ui.rsyntaxtextarea.TokenTypes;
 
  
  
@@ -274,7 +275,7 @@ Comment = "--".*
 "wait" |
 "when" |
 "while" |
-"with"  { addToken(Token.RESERVED_WORD); }
+"with"  { addToken(TokenTypes.RESERVED_WORD); }
 
 /* Keywords 2 (JUST AN OPTIONAL SET OF KEYWORDS COLORED DIFFERENTLY) */
 "'ACTIVE" |
@@ -306,18 +307,18 @@ Comment = "--".*
 "'SUCCESS" |
 "'TRANSACTION" |
 "'VAL" |
-"'VALUE"    { addToken(Token.RESERVED_WORD); }
+"'VALUE"    { addToken(TokenTypes.RESERVED_WORD); }
 
 /* Numbers */
-{integer_literal}    { addToken(Token.LITERAL_NUMBER_DECIMAL_INT) ;}
-{binary_literal}     { addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
-{octal_literal}      { addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
-{hex_literal}        { addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
-{exponent}           { addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
-{floatnumber}        { addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
+{integer_literal}    { addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT) ;}
+{binary_literal}     { addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT); }
+{octal_literal}      { addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT); }
+{hex_literal}        { addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT); }
+{exponent}           { addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT); }
+{floatnumber}        { addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT); }
 
 /* WhiteSpace */
-{WhiteSpace}+        { addToken(Token.WHITESPACE); }
+{WhiteSpace}+        { addToken(TokenTypes.WHITESPACE); }
 
  /* Separators */
 "(" |
@@ -330,7 +331,7 @@ Comment = "--".*
 "|" |
 "=>"|
 "<="|
-":="                 { addToken(Token.SEPARATOR); }
+":="                 { addToken(TokenTypes.SEPARATOR); }
 
 /* Data Types */
 "bit" |
@@ -343,7 +344,7 @@ Comment = "--".*
 "std_logic" |
 "std_logic_unsigned" |
 "std_logic_vector" |
-"std_logic_signed"		{ addToken(Token.DATA_TYPE); }
+"std_logic_signed"		{ addToken(TokenTypes.DATA_TYPE); }
 	
 /* Functions */
 "'-'" |
@@ -356,7 +357,7 @@ Comment = "--".*
 "'X'" |
 "'Z'" |
 "false" |
-"true"		{ addToken(Token.FUNCTION); }
+"true"		{ addToken(TokenTypes.FUNCTION); }
 
 /* OPERATORS. */
 "&" |
@@ -376,18 +377,18 @@ Comment = "--".*
 "nand" |
 "nor" |
 "xor" |
-"xnor"		{ addToken(Token.OPERATOR); }
+"xnor"		{ addToken(TokenTypes.OPERATOR); }
 
 /* String/Character Literals. */
-{stringliteral}				{ addToken(Token.LITERAL_STRING_DOUBLE_QUOTE); }
+{stringliteral}				{ addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); }
 
 /*COMMENTS*/
-{Comment}                 {  addToken(Token.COMMENT_EOL); }
+{Comment}                 {  addToken(TokenTypes.COMMENT_EOL); }
 
 
-{Identifier}             { addToken(Token.IDENTIFIER);}
+{Identifier}             { addToken(TokenTypes.IDENTIFIER);}
 
-.                        { addToken(Token.ERROR_IDENTIFIER); }
+.                        { addToken(TokenTypes.ERROR_IDENTIFIER); }
 
 {LineTerminator}         { addNullToken(); return firstToken; }
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/VhdlTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/VhdlTokenMaker.java
@@ -22,6 +22,7 @@ import javax.swing.text.Segment;
 import org.fife.ui.rsyntaxtextarea.AbstractJFlexTokenMaker;
 import org.fife.ui.rsyntaxtextarea.Token;
 import org.fife.ui.rsyntaxtextarea.TokenImpl;
+import org.fife.ui.rsyntaxtextarea.TokenTypes;
 
 
 /**
@@ -942,47 +943,47 @@ public class VhdlTokenMaker extends AbstractJFlexTokenMaker {
 
       switch (zzAction < 0 ? zzAction : ZZ_ACTION[zzAction]) {
         case 10:
-          { addToken(Token.RESERVED_WORD);
+          { addToken(TokenTypes.RESERVED_WORD);
           }
         case 14: break;
         case 5:
-          { addToken(Token.IDENTIFIER);
+          { addToken(TokenTypes.IDENTIFIER);
           }
         case 15: break;
         case 13:
-          { addToken(Token.FUNCTION);
+          { addToken(TokenTypes.FUNCTION);
           }
         case 16: break;
         case 8:
-          { addToken(Token.LITERAL_STRING_DOUBLE_QUOTE);
+          { addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
           }
         case 17: break;
         case 3:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 18: break;
         case 4:
-          { addToken(Token.LITERAL_NUMBER_DECIMAL_INT) ;
+          { addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT) ;
           }
         case 19: break;
         case 12:
-          { addToken(Token.DATA_TYPE);
+          { addToken(TokenTypes.DATA_TYPE);
           }
         case 20: break;
         case 9:
-          { addToken(Token.COMMENT_EOL);
+          { addToken(TokenTypes.COMMENT_EOL);
           }
         case 21: break;
         case 1:
-          { addToken(Token.ERROR_IDENTIFIER);
+          { addToken(TokenTypes.ERROR_IDENTIFIER);
           }
         case 22: break;
         case 7:
-          { addToken(Token.OPERATOR);
+          { addToken(TokenTypes.OPERATOR);
           }
         case 23: break;
         case 11:
-          { addToken(Token.LITERAL_NUMBER_DECIMAL_INT);
+          { addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT);
           }
         case 24: break;
         case 2:
@@ -990,7 +991,7 @@ public class VhdlTokenMaker extends AbstractJFlexTokenMaker {
           }
         case 25: break;
         case 6:
-          { addToken(Token.SEPARATOR);
+          { addToken(TokenTypes.SEPARATOR);
           }
         case 26: break;
         default:

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/VisualBasicTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/VisualBasicTokenMaker.flex
@@ -394,8 +394,8 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"With" |
 	"WithEvents" |
 	"WriteOnly" |
-	"Xor"						{ addToken(Token.RESERVED_WORD); }
-	"Return"					{ addToken(Token.RESERVED_WORD_2); }
+	"Xor"						{ addToken(TokenTypes.RESERVED_WORD); }
+	"Return"					{ addToken(TokenTypes.RESERVED_WORD_2); }
 
 	/* Data types. */
 	"Boolean" |
@@ -413,45 +413,45 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	"String" |
 	"UInteger" |
 	"ULong" |
-	"UShort"					{ addToken(Token.DATA_TYPE); }
+	"UShort"					{ addToken(TokenTypes.DATA_TYPE); }
 
-	{BooleanLiteral}			{ addToken(Token.LITERAL_BOOLEAN); }
+	{BooleanLiteral}			{ addToken(TokenTypes.LITERAL_BOOLEAN); }
 
 	{LineTerminator}			{ addNullToken(); return firstToken; }
 
-	{Identifier}				{ addToken(Token.IDENTIFIER); }
+	{Identifier}				{ addToken(TokenTypes.IDENTIFIER); }
 
-	{WhiteSpace}+				{ addToken(Token.WHITESPACE); }
+	{WhiteSpace}+				{ addToken(TokenTypes.WHITESPACE); }
 
-	{StringLiteral}				{ addToken(Token.LITERAL_STRING_DOUBLE_QUOTE); }
-	{UnclosedStringLiteral}		{ addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
+	{StringLiteral}				{ addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); }
+	{UnclosedStringLiteral}		{ addToken(TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
 
 	{LineCommentBegin}			{ start = zzMarkedPos-1; yybegin(EOL_COMMENT); }
 
-	{Separator}					{ addToken(Token.SEPARATOR); }
-	{Separator2}				{ addToken(Token.IDENTIFIER); }
-	{Operator}					{ addToken(Token.OPERATOR); }
+	{Separator}					{ addToken(TokenTypes.SEPARATOR); }
+	{Separator2}				{ addToken(TokenTypes.IDENTIFIER); }
+	{Operator}					{ addToken(TokenTypes.OPERATOR); }
 
-	{IntegerLiteral}			{ addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
-	{HexLiteral}				{ addToken(Token.LITERAL_NUMBER_HEXADECIMAL); }
-	{FloatLiteral}				{ addToken(Token.LITERAL_NUMBER_FLOAT); }
-	{ErrorNumberFormat}			{ addToken(Token.ERROR_NUMBER_FORMAT); }
+	{IntegerLiteral}			{ addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT); }
+	{HexLiteral}				{ addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL); }
+	{FloatLiteral}				{ addToken(TokenTypes.LITERAL_NUMBER_FLOAT); }
+	{ErrorNumberFormat}			{ addToken(TokenTypes.ERROR_NUMBER_FORMAT); }
 
-	{ErrorIdentifier}			{ addToken(Token.ERROR_IDENTIFIER); }
+	{ErrorIdentifier}			{ addToken(TokenTypes.ERROR_IDENTIFIER); }
 
 	/* Ended with a line not in a string or comment. */
 	<<EOF>>						{ addNullToken(); return firstToken; }
 
 	/* Catch any other (unhandled) characters. */
-	.							{ addToken(Token.IDENTIFIER); }
+	.							{ addToken(TokenTypes.IDENTIFIER); }
 
 }
 
 
 <EOL_COMMENT> {
 	[^hwf\n]+				{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos; }
+	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos; }
 	[hwf]					{}
-	\n						{ addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken; }
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken; }
+	\n						{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken; }
+	<<EOF>>					{ addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken; }
 }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/VisualBasicTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/VisualBasicTokenMaker.java
@@ -1514,63 +1514,63 @@ public final void yybegin(int newState) {
           }
         case 21: break;
         case 6:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 22: break;
         case 16:
-          { addToken(Token.LITERAL_NUMBER_HEXADECIMAL);
+          { addToken(TokenTypes.LITERAL_NUMBER_HEXADECIMAL);
           }
         case 23: break;
         case 13:
-          { addToken(Token.LITERAL_NUMBER_FLOAT);
+          { addToken(TokenTypes.LITERAL_NUMBER_FLOAT);
           }
         case 24: break;
         case 15:
-          { addToken(Token.RESERVED_WORD);
+          { addToken(TokenTypes.RESERVED_WORD);
           }
         case 25: break;
         case 9:
-          { addToken(Token.SEPARATOR);
+          { addToken(TokenTypes.SEPARATOR);
           }
         case 26: break;
         case 2:
-          { addToken(Token.IDENTIFIER);
+          { addToken(TokenTypes.IDENTIFIER);
           }
         case 27: break;
         case 11:
-          { addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
           }
         case 28: break;
         case 7:
-          { addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
+          { addToken(TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
           }
         case 29: break;
         case 1:
-          { addToken(Token.ERROR_IDENTIFIER);
+          { addToken(TokenTypes.ERROR_IDENTIFIER);
           }
         case 30: break;
         case 17:
-          { addToken(Token.DATA_TYPE);
+          { addToken(TokenTypes.DATA_TYPE);
           }
         case 31: break;
         case 18:
-          { addToken(Token.LITERAL_BOOLEAN);
+          { addToken(TokenTypes.LITERAL_BOOLEAN);
           }
         case 32: break;
         case 14:
-          { addToken(Token.LITERAL_STRING_DOUBLE_QUOTE);
+          { addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
           }
         case 33: break;
         case 19:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.COMMENT_EOL); start = zzMarkedPos;
           }
         case 34: break;
         case 20:
-          { addToken(Token.RESERVED_WORD_2);
+          { addToken(TokenTypes.RESERVED_WORD_2);
           }
         case 35: break;
         case 12:
-          { addToken(Token.ERROR_NUMBER_FORMAT);
+          { addToken(TokenTypes.ERROR_NUMBER_FORMAT);
           }
         case 36: break;
         case 8:
@@ -1578,11 +1578,11 @@ public final void yybegin(int newState) {
           }
         case 37: break;
         case 3:
-          { addToken(Token.LITERAL_NUMBER_DECIMAL_INT);
+          { addToken(TokenTypes.LITERAL_NUMBER_DECIMAL_INT);
           }
         case 38: break;
         case 4:
-          { addToken(Token.OPERATOR);
+          { addToken(TokenTypes.OPERATOR);
           }
         case 39: break;
         case 10:
@@ -1594,7 +1594,7 @@ public final void yybegin(int newState) {
             zzAtEOF = true;
             switch (zzLexicalState) {
             case EOL_COMMENT: {
-              addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.COMMENT_EOL); addNullToken(); return firstToken;
             }
             case 418: break;
             case YYINITIAL: {

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/WindowsBatchTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/WindowsBatchTokenMaker.java
@@ -56,7 +56,7 @@ public class WindowsBatchTokenMaker extends AbstractTokenMaker {
 			// Since reserved words, functions, and data types are all passed
 			// into here as "identifiers," we have to see what the token
 			// really is...
-			case Token.IDENTIFIER:
+			case TokenTypes.IDENTIFIER:
 				int value = wordsToHighlight.get(segment, start,end);
 				if (value!=-1)
 					tokenType = value;
@@ -84,7 +84,7 @@ public class WindowsBatchTokenMaker extends AbstractTokenMaker {
 	 */
 	@Override
 	public boolean getMarkOccurrencesOfTokenType(int type) {
-		return type==Token.IDENTIFIER || type==Token.VARIABLE;
+		return type==TokenTypes.IDENTIFIER || type==TokenTypes.VARIABLE;
 	}
 
 
@@ -99,7 +99,7 @@ public class WindowsBatchTokenMaker extends AbstractTokenMaker {
 	public TokenMap getWordsToHighlight() {
 
 		TokenMap tokenMap = new TokenMap(true); // Ignore case.
-		int reservedWord = Token.RESERVED_WORD;
+		int reservedWord = TokenTypes.RESERVED_WORD;
 
 		// Batch-file specific stuff (?)
 		tokenMap.put("goto",			reservedWord);
@@ -268,7 +268,7 @@ public class WindowsBatchTokenMaker extends AbstractTokenMaker {
 
 			switch (currentTokenType) {
 
-				case Token.NULL:
+				case TokenTypes.NULL:
 
 					currentTokenStart = i;	// Starting a new token here.
 
@@ -276,29 +276,29 @@ public class WindowsBatchTokenMaker extends AbstractTokenMaker {
 
 						case ' ':
 						case '\t':
-							currentTokenType = Token.WHITESPACE;
+							currentTokenType = TokenTypes.WHITESPACE;
 							break;
 
 						case '"':
-							currentTokenType = Token.ERROR_STRING_DOUBLE;
+							currentTokenType = TokenTypes.ERROR_STRING_DOUBLE;
 							break;
 
 						case '%':
-							currentTokenType = Token.VARIABLE;
+							currentTokenType = TokenTypes.VARIABLE;
 							break;
 
 						// The "separators".
 						case '(':
 						case ')':
-							addToken(text, currentTokenStart,i, Token.SEPARATOR, newStartOffset+currentTokenStart);
-							currentTokenType = Token.NULL;
+							addToken(text, currentTokenStart,i, TokenTypes.SEPARATOR, newStartOffset+currentTokenStart);
+							currentTokenType = TokenTypes.NULL;
 							break;
 
 						// The "separators2".
 						case ',':
 						case ';':
-							addToken(text, currentTokenStart,i, Token.IDENTIFIER, newStartOffset+currentTokenStart);
-							currentTokenType = Token.NULL;
+							addToken(text, currentTokenStart,i, TokenTypes.IDENTIFIER, newStartOffset+currentTokenStart);
+							currentTokenType = TokenTypes.NULL;
 							break;
 
 						// Newer version of EOL comments, or a label
@@ -307,14 +307,14 @@ public class WindowsBatchTokenMaker extends AbstractTokenMaker {
 							// a new-style comment or a label
 							if (firstToken==null) {
 								if (i<end-1 && array[i+1]==':') { // new-style comment
-									currentTokenType = Token.COMMENT_EOL;
+									currentTokenType = TokenTypes.COMMENT_EOL;
 								}
 								else { // Label
-									currentTokenType = Token.PREPROCESSOR;
+									currentTokenType = TokenTypes.PREPROCESSOR;
 								}
 							}
 							else { // Just a colon
-								currentTokenType = Token.IDENTIFIER;
+								currentTokenType = TokenTypes.IDENTIFIER;
 							}
 							break;
 
@@ -322,18 +322,18 @@ public class WindowsBatchTokenMaker extends AbstractTokenMaker {
 
 							// Just to speed things up a tad, as this will usually be the case (if spaces above failed).
 							if (RSyntaxUtilities.isLetterOrDigit(c) || c=='\\') {
-								currentTokenType = Token.IDENTIFIER;
+								currentTokenType = TokenTypes.IDENTIFIER;
 								break;
 							}
 
 							int indexOf = OPERATORS.indexOf(c);
 							if (indexOf>-1) {
-								addToken(text, currentTokenStart,i, Token.OPERATOR, newStartOffset+currentTokenStart);
-								currentTokenType = Token.NULL;
+								addToken(text, currentTokenStart,i, TokenTypes.OPERATOR, newStartOffset+currentTokenStart);
+								currentTokenType = TokenTypes.NULL;
 								break;
 							}
 							else {
-								currentTokenType = Token.IDENTIFIER;
+								currentTokenType = TokenTypes.IDENTIFIER;
 								break;
 							}
 
@@ -341,7 +341,7 @@ public class WindowsBatchTokenMaker extends AbstractTokenMaker {
 
 					break;
 
-				case Token.WHITESPACE:
+				case TokenTypes.WHITESPACE:
 
 					switch (c) {
 
@@ -350,71 +350,71 @@ public class WindowsBatchTokenMaker extends AbstractTokenMaker {
 							break;	// Still whitespace.
 
 						case '"':
-							addToken(text, currentTokenStart,i-1, Token.WHITESPACE, newStartOffset+currentTokenStart);
+							addToken(text, currentTokenStart,i-1, TokenTypes.WHITESPACE, newStartOffset+currentTokenStart);
 							currentTokenStart = i;
-							currentTokenType = Token.ERROR_STRING_DOUBLE;
+							currentTokenType = TokenTypes.ERROR_STRING_DOUBLE;
 							break;
 
 						case '%':
-							addToken(text, currentTokenStart,i-1, Token.WHITESPACE, newStartOffset+currentTokenStart);
+							addToken(text, currentTokenStart,i-1, TokenTypes.WHITESPACE, newStartOffset+currentTokenStart);
 							currentTokenStart = i;
-							currentTokenType = Token.VARIABLE;
+							currentTokenType = TokenTypes.VARIABLE;
 							break;
 
 						// The "separators".
 						case '(':
 						case ')':
-							addToken(text, currentTokenStart,i-1, Token.WHITESPACE, newStartOffset+currentTokenStart);
-							addToken(text, i,i, Token.SEPARATOR, newStartOffset+i);
-							currentTokenType = Token.NULL;
+							addToken(text, currentTokenStart,i-1, TokenTypes.WHITESPACE, newStartOffset+currentTokenStart);
+							addToken(text, i,i, TokenTypes.SEPARATOR, newStartOffset+i);
+							currentTokenType = TokenTypes.NULL;
 							break;
 
 						// The "separators2".
 						case ',':
 						case ';':
-							addToken(text, currentTokenStart,i-1, Token.WHITESPACE, newStartOffset+currentTokenStart);
-							addToken(text, i,i, Token.IDENTIFIER, newStartOffset+i);
-							currentTokenType = Token.NULL;
+							addToken(text, currentTokenStart,i-1, TokenTypes.WHITESPACE, newStartOffset+currentTokenStart);
+							addToken(text, i,i, TokenTypes.IDENTIFIER, newStartOffset+i);
+							currentTokenType = TokenTypes.NULL;
 							break;
 
 						// Newer version of EOL comments, or a label
 						case ':':
-							addToken(text, currentTokenStart,i-1, Token.WHITESPACE, newStartOffset+currentTokenStart);
+							addToken(text, currentTokenStart,i-1, TokenTypes.WHITESPACE, newStartOffset+currentTokenStart);
 							currentTokenStart = i;
 							// If the previous (whitespace) token was the first token
 							// added, this is a new-style comment or a label
 							if (firstToken.getNextToken()==null) {
 								if (i<end-1 && array[i+1]==':') { // new-style comment
-									currentTokenType = Token.COMMENT_EOL;
+									currentTokenType = TokenTypes.COMMENT_EOL;
 								}
 								else { // Label
-									currentTokenType = Token.PREPROCESSOR;
+									currentTokenType = TokenTypes.PREPROCESSOR;
 								}
 							}
 							else { // Just a colon
-								currentTokenType = Token.IDENTIFIER;
+								currentTokenType = TokenTypes.IDENTIFIER;
 							}
 							break;
 
 						default:	// Add the whitespace token and start anew.
 
-							addToken(text, currentTokenStart,i-1, Token.WHITESPACE, newStartOffset+currentTokenStart);
+							addToken(text, currentTokenStart,i-1, TokenTypes.WHITESPACE, newStartOffset+currentTokenStart);
 							currentTokenStart = i;
 
 							// Just to speed things up a tad, as this will usually be the case (if spaces above failed).
 							if (RSyntaxUtilities.isLetterOrDigit(c) || c=='\\') {
-								currentTokenType = Token.IDENTIFIER;
+								currentTokenType = TokenTypes.IDENTIFIER;
 								break;
 							}
 
 							int indexOf = OPERATORS.indexOf(c);
 							if (indexOf>-1) {
-								addToken(text, currentTokenStart,i, Token.OPERATOR, newStartOffset+currentTokenStart);
-								currentTokenType = Token.NULL;
+								addToken(text, currentTokenStart,i, TokenTypes.OPERATOR, newStartOffset+currentTokenStart);
+								currentTokenType = TokenTypes.NULL;
 								break;
 							}
 							else {
-								currentTokenType = Token.IDENTIFIER;
+								currentTokenType = TokenTypes.IDENTIFIER;
 							}
 
 					} // End of switch (c).
@@ -422,7 +422,7 @@ public class WindowsBatchTokenMaker extends AbstractTokenMaker {
 					break;
 
 				default: // Should never happen
-				case Token.IDENTIFIER:
+				case TokenTypes.IDENTIFIER:
 
 					switch (c) {
 
@@ -433,24 +433,24 @@ public class WindowsBatchTokenMaker extends AbstractTokenMaker {
 								(array[i-3]=='r' || array[i-3]=='R') &&
 								(array[i-2]=='e' || array[i-2]=='E') &&
 								(array[i-1]=='m' || array[i-1]=='M')) {
-									currentTokenType = Token.COMMENT_EOL;
+									currentTokenType = TokenTypes.COMMENT_EOL;
 									break;
 							}
-							addToken(text, currentTokenStart,i-1, Token.IDENTIFIER, newStartOffset+currentTokenStart);
+							addToken(text, currentTokenStart,i-1, TokenTypes.IDENTIFIER, newStartOffset+currentTokenStart);
 							currentTokenStart = i;
-							currentTokenType = Token.WHITESPACE;
+							currentTokenType = TokenTypes.WHITESPACE;
 							break;
 
 						case '"':
-							addToken(text, currentTokenStart,i-1, Token.IDENTIFIER, newStartOffset+currentTokenStart);
+							addToken(text, currentTokenStart,i-1, TokenTypes.IDENTIFIER, newStartOffset+currentTokenStart);
 							currentTokenStart = i;
-							currentTokenType = Token.ERROR_STRING_DOUBLE;
+							currentTokenType = TokenTypes.ERROR_STRING_DOUBLE;
 							break;
 
 						case '%':
-							addToken(text, currentTokenStart,i-1, Token.IDENTIFIER, newStartOffset+currentTokenStart);
+							addToken(text, currentTokenStart,i-1, TokenTypes.IDENTIFIER, newStartOffset+currentTokenStart);
 							currentTokenStart = i;
-							currentTokenType = Token.VARIABLE;
+							currentTokenType = TokenTypes.VARIABLE;
 							break;
 
 						// Should be part of identifiers, but not at end of "REM".
@@ -460,7 +460,7 @@ public class WindowsBatchTokenMaker extends AbstractTokenMaker {
 								(array[i-3]=='r' || array[i-3]=='R') &&
 								(array[i-2]=='e' || array[i-2]=='E') &&
 								(array[i-1]=='m' || array[i-1]=='M')) {
-									currentTokenType = Token.COMMENT_EOL;
+									currentTokenType = TokenTypes.COMMENT_EOL;
 							}
 							break;
 
@@ -471,17 +471,17 @@ public class WindowsBatchTokenMaker extends AbstractTokenMaker {
 						// The "separators".
 						case '(':
 						case ')':
-							addToken(text, currentTokenStart,i-1, Token.IDENTIFIER, newStartOffset+currentTokenStart);
-							addToken(text, i,i, Token.SEPARATOR, newStartOffset+i);
-							currentTokenType = Token.NULL;
+							addToken(text, currentTokenStart,i-1, TokenTypes.IDENTIFIER, newStartOffset+currentTokenStart);
+							addToken(text, i,i, TokenTypes.SEPARATOR, newStartOffset+i);
+							currentTokenType = TokenTypes.NULL;
 							break;
 
 						// The "separators2".
 						case ',':
 						case ';':
-							addToken(text, currentTokenStart,i-1, Token.IDENTIFIER, newStartOffset+currentTokenStart);
-							addToken(text, i,i, Token.IDENTIFIER, newStartOffset+i);
-							currentTokenType = Token.NULL;
+							addToken(text, currentTokenStart,i-1, TokenTypes.IDENTIFIER, newStartOffset+currentTokenStart);
+							addToken(text, i,i, TokenTypes.IDENTIFIER, newStartOffset+i);
+							currentTokenType = TokenTypes.NULL;
 							break;
 
 						default:
@@ -493,9 +493,9 @@ public class WindowsBatchTokenMaker extends AbstractTokenMaker {
 
 							int indexOf = OPERATORS.indexOf(c);
 							if (indexOf>-1) {
-								addToken(text, currentTokenStart,i-1, Token.IDENTIFIER, newStartOffset+currentTokenStart);
-								addToken(text, i,i, Token.OPERATOR, newStartOffset+i);
-								currentTokenType = Token.NULL;
+								addToken(text, currentTokenStart,i-1, TokenTypes.IDENTIFIER, newStartOffset+currentTokenStart);
+								addToken(text, i,i, TokenTypes.OPERATOR, newStartOffset+i);
+								currentTokenType = TokenTypes.NULL;
 								break;
 							}
 
@@ -505,32 +505,32 @@ public class WindowsBatchTokenMaker extends AbstractTokenMaker {
 
 					break;
 
-				case Token.COMMENT_EOL:
+				case TokenTypes.COMMENT_EOL:
 					i = end - 1;
-					addToken(text, currentTokenStart,i, Token.COMMENT_EOL, newStartOffset+currentTokenStart);
+					addToken(text, currentTokenStart,i, TokenTypes.COMMENT_EOL, newStartOffset+currentTokenStart);
 					// We need to set token type to null so at the bottom we don't add one more token.
-					currentTokenType = Token.NULL;
+					currentTokenType = TokenTypes.NULL;
 					break;
 
-				case Token.PREPROCESSOR: // Used for labels
+				case TokenTypes.PREPROCESSOR: // Used for labels
 					i = end - 1;
-					addToken(text, currentTokenStart,i, Token.PREPROCESSOR, newStartOffset+currentTokenStart);
+					addToken(text, currentTokenStart,i, TokenTypes.PREPROCESSOR, newStartOffset+currentTokenStart);
 					// We need to set token type to null so at the bottom we don't add one more token.
-					currentTokenType = Token.NULL;
+					currentTokenType = TokenTypes.NULL;
 					break;
 
-				case Token.ERROR_STRING_DOUBLE:
+				case TokenTypes.ERROR_STRING_DOUBLE:
 
 					if (c=='"') {
-						addToken(text, currentTokenStart,i, Token.LITERAL_STRING_DOUBLE_QUOTE, newStartOffset+currentTokenStart);
+						addToken(text, currentTokenStart,i, TokenTypes.LITERAL_STRING_DOUBLE_QUOTE, newStartOffset+currentTokenStart);
 						currentTokenStart = i + 1;
-						currentTokenType = Token.NULL;
+						currentTokenType = TokenTypes.NULL;
 					}
 					// Otherwise, we're still an unclosed string...
 
 					break;
 
-				case Token.VARIABLE:
+				case TokenTypes.VARIABLE:
 
 					if (i==currentTokenStart+1) { // first character after '%'.
 						varType = VariableType.NORMAL_VAR;
@@ -549,14 +549,14 @@ public class WindowsBatchTokenMaker extends AbstractTokenMaker {
 									break;
 								}
 								else if (RSyntaxUtilities.isDigit(c)) { // Single-digit command-line argument ("%1").
-									addToken(text, currentTokenStart,i, Token.VARIABLE, newStartOffset+currentTokenStart);
-									currentTokenType = Token.NULL;
+									addToken(text, currentTokenStart,i, TokenTypes.VARIABLE, newStartOffset+currentTokenStart);
+									currentTokenType = TokenTypes.NULL;
 									break;
 								}
 								else { // Anything else, ???.
-									addToken(text, currentTokenStart,i-1, Token.VARIABLE, newStartOffset+currentTokenStart); // ???
+									addToken(text, currentTokenStart,i-1, TokenTypes.VARIABLE, newStartOffset+currentTokenStart); // ???
 									i--;
-									currentTokenType = Token.NULL;
+									currentTokenType = TokenTypes.NULL;
 									break;
 								}
 						} // End of switch (c).
@@ -565,15 +565,15 @@ public class WindowsBatchTokenMaker extends AbstractTokenMaker {
 						switch (varType) {
 							case BRACKET_VAR:
 								if (c=='}') {
-									addToken(text, currentTokenStart,i, Token.VARIABLE, newStartOffset+currentTokenStart);
-									currentTokenType = Token.NULL;
+									addToken(text, currentTokenStart,i, TokenTypes.VARIABLE, newStartOffset+currentTokenStart);
+									currentTokenType = TokenTypes.NULL;
 								}
 								break;
 							case TILDE_VAR:
 								if (!RSyntaxUtilities.isLetterOrDigit(c)) {
-									addToken(text, currentTokenStart,i-1, Token.VARIABLE, newStartOffset+currentTokenStart);
+									addToken(text, currentTokenStart,i-1, TokenTypes.VARIABLE, newStartOffset+currentTokenStart);
 									i--;
-									currentTokenType = Token.NULL;
+									currentTokenType = TokenTypes.NULL;
 								}
 								break;
 							case DOUBLE_PERCENT_VAR:
@@ -582,20 +582,20 @@ public class WindowsBatchTokenMaker extends AbstractTokenMaker {
 								if (c=='%') {
 									if (i<end-1 && array[i+1]=='%') {
 										i++;
-										addToken(text, currentTokenStart,i, Token.VARIABLE, newStartOffset+currentTokenStart);
-										currentTokenType = Token.NULL;
+										addToken(text, currentTokenStart,i, TokenTypes.VARIABLE, newStartOffset+currentTokenStart);
+										currentTokenType = TokenTypes.NULL;
 									}
 								}
 								else if (!RSyntaxUtilities.isLetterOrDigit(c) && c!=':' && c!='~' && c!=',' && c!='-') {
-									addToken(text, currentTokenStart,i-1, Token.VARIABLE, newStartOffset+currentTokenStart);
-									currentTokenType = Token.NULL;
+									addToken(text, currentTokenStart,i-1, TokenTypes.VARIABLE, newStartOffset+currentTokenStart);
+									currentTokenType = TokenTypes.NULL;
 									i--;
 								}
 								break;
 							default:
 								if (c=='%') {
-									addToken(text, currentTokenStart,i, Token.VARIABLE, newStartOffset+currentTokenStart);
-									currentTokenType = Token.NULL;
+									addToken(text, currentTokenStart,i, TokenTypes.VARIABLE, newStartOffset+currentTokenStart);
+									currentTokenType = TokenTypes.NULL;
 								}
 								break;
 						}
@@ -607,14 +607,14 @@ public class WindowsBatchTokenMaker extends AbstractTokenMaker {
 		} // End of for (int i=offset; i<end; i++).
 
 		// Deal with the (possibly there) last token.
-		if (currentTokenType != Token.NULL) {
+		if (currentTokenType != TokenTypes.NULL) {
 
 				// Check for REM comments.
 				if (end-currentTokenStart==3 &&
 					(array[end-3]=='r' || array[end-3]=='R') &&
 					(array[end-2]=='e' || array[end-2]=='E') &&
 					(array[end-1]=='m' || array[end-1]=='M')) {
-						currentTokenType = Token.COMMENT_EOL;
+						currentTokenType = TokenTypes.COMMENT_EOL;
 				}
 
 				addToken(text, currentTokenStart,end-1, currentTokenType, newStartOffset+currentTokenStart);

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/XMLTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/XMLTokenMaker.flex
@@ -226,14 +226,14 @@ import org.fife.ui.rsyntaxtextarea.*;
 
 
 	/**
-	 * Returns <code>Token.MARKUP_TAG_NAME</code>.
+	 * Returns <code>TokenTypes.MARKUP_TAG_NAME</code>.
 	 *
 	 * @param type The token type.
 	 * @return Whether tokens of this type should have "mark occurrences"
 	 *         enabled.
 	 */
 	public boolean getMarkOccurrencesOfTokenType(int type) {
-		return type==Token.MARKUP_TAG_NAME;
+		return type==TokenTypes.MARKUP_TAG_NAME;
 	}
 
 
@@ -259,7 +259,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 		// Start off in the proper state.
 		int state = YYINITIAL;
 		switch (initialTokenType) {
-			case Token.MARKUP_COMMENT:
+			case TokenTypes.MARKUP_COMMENT:
 				state = COMMENT;
 				break;
 			case INTERNAL_DTD:
@@ -275,13 +275,13 @@ import org.fife.ui.rsyntaxtextarea.*;
 			case INTERNAL_ATTR_SINGLE:
 				state = INATTR_SINGLE;
 				break;
-			case Token.MARKUP_PROCESSING_INSTRUCTION:
+			case TokenTypes.MARKUP_PROCESSING_INSTRUCTION:
 				state = PI;
 				break;
 			case INTERNAL_INTAG:
 				state = INTAG;
 				break;
-			case Token.MARKUP_CDATA:
+			case TokenTypes.MARKUP_CDATA:
 				state = CDATA;
 				break;
 			default:
@@ -296,7 +296,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 					prevState = -initialTokenType&0xff;
 				}
 				else { // Shouldn't happen
-					state = Token.NULL;
+					state = TokenTypes.NULL;
 				}
 		}
 
@@ -399,66 +399,66 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 
 <YYINITIAL> {
 	"<!--"							{ start = zzStartRead; prevState = zzLexicalState; yybegin(COMMENT); }
-	{CDataBegin}					{ addToken(Token.MARKUP_CDATA_DELIMITER); start = zzMarkedPos; yybegin(CDATA); }
+	{CDataBegin}					{ addToken(TokenTypes.MARKUP_CDATA_DELIMITER); start = zzMarkedPos; yybegin(CDATA); }
 	"<!"							{ start = zzMarkedPos-2; inInternalDtd = false; yybegin(DTD); }
 	"<?"							{ start = zzMarkedPos-2; yybegin(PI); }
 	"<"{TagName}				{
 									int count = yylength();
-									addToken(zzStartRead,zzStartRead, Token.MARKUP_TAG_DELIMITER);
-									addToken(zzMarkedPos-(count-1), zzMarkedPos-1, Token.MARKUP_TAG_NAME);
+									addToken(zzStartRead,zzStartRead, TokenTypes.MARKUP_TAG_DELIMITER);
+									addToken(zzMarkedPos-(count-1), zzMarkedPos-1, TokenTypes.MARKUP_TAG_NAME);
 									yybegin(INTAG);
 								}
 	"</"{TagName}				{
 									int count = yylength();
-									addToken(zzStartRead,zzStartRead+1, Token.MARKUP_TAG_DELIMITER);
-									addToken(zzMarkedPos-(count-2), zzMarkedPos-1, Token.MARKUP_TAG_NAME);
+									addToken(zzStartRead,zzStartRead+1, TokenTypes.MARKUP_TAG_DELIMITER);
+									addToken(zzMarkedPos-(count-2), zzMarkedPos-1, TokenTypes.MARKUP_TAG_NAME);
 									yybegin(INTAG);
 								}
-	"<"							{ addToken(Token.MARKUP_TAG_DELIMITER); yybegin(INTAG); }
-	"</"						{ addToken(Token.MARKUP_TAG_DELIMITER); yybegin(INTAG); }
+	"<"							{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(INTAG); }
+	"</"						{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(INTAG); }
 	{LineTerminator}				{ addNullToken(); return firstToken; }
-	{Identifier}					{ addToken(Token.IDENTIFIER); }
-	{EntityReference}				{ addToken(Token.MARKUP_ENTITY_REFERENCE); }
-	{Whitespace}+					{ addToken(Token.WHITESPACE); }
+	{Identifier}					{ addToken(TokenTypes.IDENTIFIER); }
+	{EntityReference}				{ addToken(TokenTypes.MARKUP_ENTITY_REFERENCE); }
+	{Whitespace}+					{ addToken(TokenTypes.WHITESPACE); }
 	<<EOF>>						{ addNullToken(); return firstToken; }
 }
 
 <COMMENT> {
 	[^hwf\n\-]+					{}
-	{URL}						{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.MARKUP_COMMENT); addHyperlinkToken(temp,zzMarkedPos-1, Token.MARKUP_COMMENT); start = zzMarkedPos; }
+	{URL}						{ int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.MARKUP_COMMENT); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.MARKUP_COMMENT); start = zzMarkedPos; }
 	[hwf]						{}
-	"-->"						{ int temp = zzMarkedPos; addToken(start,zzStartRead+2, Token.MARKUP_COMMENT); start = temp; yybegin(prevState); }
+	"-->"						{ int temp = zzMarkedPos; addToken(start,zzStartRead+2, TokenTypes.MARKUP_COMMENT); start = temp; yybegin(prevState); }
 	"-"							{}
 	{LineTerminator} |
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.MARKUP_COMMENT); addEndToken(INTERNAL_IN_XML_COMMENT - prevState); return firstToken; }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_COMMENT); addEndToken(INTERNAL_IN_XML_COMMENT - prevState); return firstToken; }
 }
 
 <PI> {
 	[^\n\?]+						{}
-	{LineTerminator}				{ addToken(start,zzStartRead-1, Token.MARKUP_PROCESSING_INSTRUCTION); return firstToken; }
-	"?>"							{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.MARKUP_PROCESSING_INSTRUCTION); }
+	{LineTerminator}				{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_PROCESSING_INSTRUCTION); return firstToken; }
+	"?>"							{ yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.MARKUP_PROCESSING_INSTRUCTION); }
 	"?"							{}
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.MARKUP_PROCESSING_INSTRUCTION); return firstToken; }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_PROCESSING_INSTRUCTION); return firstToken; }
 }
 
 <DTD> {
 	[^\n\[\]<>]+				{}
-	"<!--"						{ int temp = zzStartRead; addToken(start,zzStartRead-1, Token.MARKUP_DTD); start = temp; prevState = zzLexicalState; yybegin(COMMENT); }
+	"<!--"						{ int temp = zzStartRead; addToken(start,zzStartRead-1, TokenTypes.MARKUP_DTD); start = temp; prevState = zzLexicalState; yybegin(COMMENT); }
 	"<"							{}
 	"["							{ inInternalDtd = true; }
 	"]"							{ inInternalDtd = false; }
-	">"							{ if (!inInternalDtd) { yybegin(YYINITIAL); addToken(start,zzStartRead, Token.MARKUP_DTD); } }
+	">"							{ if (!inInternalDtd) { yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.MARKUP_DTD); } }
 	{LineTerminator} |
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.MARKUP_DTD); addEndToken(inInternalDtd ? INTERNAL_DTD_INTERNAL : INTERNAL_DTD); return firstToken; }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_DTD); addEndToken(inInternalDtd ? INTERNAL_DTD_INTERNAL : INTERNAL_DTD); return firstToken; }
 }
 
 <INTAG> {
-	{InTagIdentifier}				{ addToken(Token.MARKUP_TAG_ATTRIBUTE); }
-	{Whitespace}+					{ addToken(Token.WHITESPACE); }
-	"="							{ addToken(Token.OPERATOR); }
-	"/"							{ addToken(Token.MARKUP_TAG_DELIMITER); /* Not valid but we'll still accept it */ }
-	"/>"						{ yybegin(YYINITIAL); addToken(Token.MARKUP_TAG_DELIMITER); }
-	">"							{ yybegin(YYINITIAL); addToken(Token.MARKUP_TAG_DELIMITER); }
+	{InTagIdentifier}				{ addToken(TokenTypes.MARKUP_TAG_ATTRIBUTE); }
+	{Whitespace}+					{ addToken(TokenTypes.WHITESPACE); }
+	"="							{ addToken(TokenTypes.OPERATOR); }
+	"/"							{ addToken(TokenTypes.MARKUP_TAG_DELIMITER); /* Not valid but we'll still accept it */ }
+	"/>"						{ yybegin(YYINITIAL); addToken(TokenTypes.MARKUP_TAG_DELIMITER); }
+	">"							{ yybegin(YYINITIAL); addToken(TokenTypes.MARKUP_TAG_DELIMITER); }
 	[\"]						{ start = zzMarkedPos-1; yybegin(INATTR_DOUBLE); }
 	[\']						{ start = zzMarkedPos-1; yybegin(INATTR_SINGLE); }
 	<<EOF>>						{ addToken(start,zzStartRead-1, INTERNAL_INTAG); return firstToken; }
@@ -466,19 +466,19 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 
 <INATTR_DOUBLE> {
 	[^\"]*						{}
-	[\"]						{ yybegin(INTAG); addToken(start,zzStartRead, Token.MARKUP_TAG_ATTRIBUTE_VALUE); }
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE); return firstToken; }
+	[\"]						{ yybegin(INTAG); addToken(start,zzStartRead, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE); return firstToken; }
 }
 
 <INATTR_SINGLE> {
 	[^\']*						{}
-	[\']						{ yybegin(INTAG); addToken(start,zzStartRead, Token.MARKUP_TAG_ATTRIBUTE_VALUE); }
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE); return firstToken; }
+	[\']						{ yybegin(INTAG); addToken(start,zzStartRead, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE); return firstToken; }
 }
 
 <CDATA> {
 	[^\]]+						{}
-	{CDataEnd}					{ int temp=zzStartRead; yybegin(YYINITIAL); addToken(start,zzStartRead-1, Token.MARKUP_CDATA); addToken(temp,zzMarkedPos-1, Token.MARKUP_CDATA_DELIMITER); }
+	{CDataEnd}					{ int temp=zzStartRead; yybegin(YYINITIAL); addToken(start,zzStartRead-1, TokenTypes.MARKUP_CDATA); addToken(temp,zzMarkedPos-1, TokenTypes.MARKUP_CDATA_DELIMITER); }
 	"]"							{}
-	<<EOF>>						{ addToken(start,zzStartRead-1, Token.MARKUP_CDATA); return firstToken; }
+	<<EOF>>						{ addToken(start,zzStartRead-1, TokenTypes.MARKUP_CDATA); return firstToken; }
 }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/XMLTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/XMLTokenMaker.java
@@ -457,14 +457,14 @@ public class XMLTokenMaker extends AbstractMarkupTokenMaker {
 
 
 	/**
-	 * Returns <code>Token.MARKUP_TAG_NAME</code>.
+	 * Returns <code>TokenTypes.MARKUP_TAG_NAME</code>.
 	 *
 	 * @param type The token type.
 	 * @return Whether tokens of this type should have "mark occurrences"
 	 *         enabled.
 	 */
 	public boolean getMarkOccurrencesOfTokenType(int type) {
-		return type==Token.MARKUP_TAG_NAME;
+		return type==TokenTypes.MARKUP_TAG_NAME;
 	}
 
 
@@ -490,7 +490,7 @@ public class XMLTokenMaker extends AbstractMarkupTokenMaker {
 		// Start off in the proper state.
 		int state = YYINITIAL;
 		switch (initialTokenType) {
-			case Token.MARKUP_COMMENT:
+			case TokenTypes.MARKUP_COMMENT:
 				state = COMMENT;
 				break;
 			case INTERNAL_DTD:
@@ -506,13 +506,13 @@ public class XMLTokenMaker extends AbstractMarkupTokenMaker {
 			case INTERNAL_ATTR_SINGLE:
 				state = INATTR_SINGLE;
 				break;
-			case Token.MARKUP_PROCESSING_INSTRUCTION:
+			case TokenTypes.MARKUP_PROCESSING_INSTRUCTION:
 				state = PI;
 				break;
 			case INTERNAL_INTAG:
 				state = INTAG;
 				break;
-			case Token.MARKUP_CDATA:
+			case TokenTypes.MARKUP_CDATA:
 				state = CDATA;
 				break;
 			default:
@@ -527,7 +527,7 @@ public class XMLTokenMaker extends AbstractMarkupTokenMaker {
 					prevState = -initialTokenType&0xff;
 				}
 				else { // Shouldn't happen
-					state = Token.NULL;
+					state = TokenTypes.NULL;
 				}
 		}
 
@@ -820,11 +820,11 @@ public class XMLTokenMaker extends AbstractMarkupTokenMaker {
 
       switch (zzAction < 0 ? zzAction : ZZ_ACTION[zzAction]) {
         case 25:
-          { int temp = zzMarkedPos; addToken(start,zzStartRead+2, Token.MARKUP_COMMENT); start = temp; yybegin(prevState);
+          { int temp = zzMarkedPos; addToken(start,zzStartRead+2, TokenTypes.MARKUP_COMMENT); start = temp; yybegin(prevState);
           }
         case 31: break;
         case 19:
-          { yybegin(INTAG); addToken(start,zzStartRead, Token.MARKUP_TAG_ATTRIBUTE_VALUE);
+          { yybegin(INTAG); addToken(start,zzStartRead, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE);
           }
         case 32: break;
         case 3:
@@ -832,7 +832,7 @@ public class XMLTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 33: break;
         case 29:
-          { int temp = zzStartRead; addToken(start,zzStartRead-1, Token.MARKUP_DTD); start = temp; prevState = zzLexicalState; yybegin(COMMENT);
+          { int temp = zzStartRead; addToken(start,zzStartRead-1, TokenTypes.MARKUP_DTD); start = temp; prevState = zzLexicalState; yybegin(COMMENT);
           }
         case 34: break;
         case 11:
@@ -840,23 +840,23 @@ public class XMLTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 35: break;
         case 4:
-          { addToken(Token.MARKUP_TAG_DELIMITER); yybegin(INTAG);
+          { addToken(TokenTypes.MARKUP_TAG_DELIMITER); yybegin(INTAG);
           }
         case 36: break;
         case 9:
-          { addToken(start,zzStartRead-1, Token.MARKUP_DTD); addEndToken(inInternalDtd ? INTERNAL_DTD_INTERNAL : INTERNAL_DTD); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.MARKUP_DTD); addEndToken(inInternalDtd ? INTERNAL_DTD_INTERNAL : INTERNAL_DTD); return firstToken;
           }
         case 37: break;
         case 16:
-          { addToken(Token.MARKUP_TAG_DELIMITER); /* Not valid but we'll still accept it */
+          { addToken(TokenTypes.MARKUP_TAG_DELIMITER); /* Not valid but we'll still accept it */
           }
         case 38: break;
         case 7:
-          { addToken(start,zzStartRead-1, Token.MARKUP_COMMENT); addEndToken(INTERNAL_IN_XML_COMMENT - prevState); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.MARKUP_COMMENT); addEndToken(INTERNAL_IN_XML_COMMENT - prevState); return firstToken;
           }
         case 39: break;
         case 5:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 40: break;
         case 27:
@@ -864,26 +864,26 @@ public class XMLTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 41: break;
         case 26:
-          { int temp=zzStartRead; yybegin(YYINITIAL); addToken(start,zzStartRead-1, Token.MARKUP_CDATA); addToken(temp,zzMarkedPos-1, Token.MARKUP_CDATA_DELIMITER);
+          { int temp=zzStartRead; yybegin(YYINITIAL); addToken(start,zzStartRead-1, TokenTypes.MARKUP_CDATA); addToken(temp,zzMarkedPos-1, TokenTypes.MARKUP_CDATA_DELIMITER);
           }
         case 42: break;
         case 20:
           { int count = yylength();
-									addToken(zzStartRead,zzStartRead, Token.MARKUP_TAG_DELIMITER);
-									addToken(zzMarkedPos-(count-1), zzMarkedPos-1, Token.MARKUP_TAG_NAME);
+									addToken(zzStartRead,zzStartRead, TokenTypes.MARKUP_TAG_DELIMITER);
+									addToken(zzMarkedPos-(count-1), zzMarkedPos-1, TokenTypes.MARKUP_TAG_NAME);
 									yybegin(INTAG);
           }
         case 43: break;
         case 6:
-          { addToken(Token.MARKUP_ENTITY_REFERENCE);
+          { addToken(TokenTypes.MARKUP_ENTITY_REFERENCE);
           }
         case 44: break;
         case 12:
-          { if (!inInternalDtd) { yybegin(YYINITIAL); addToken(start,zzStartRead, Token.MARKUP_DTD); }
+          { if (!inInternalDtd) { yybegin(YYINITIAL); addToken(start,zzStartRead, TokenTypes.MARKUP_DTD); }
           }
         case 45: break;
         case 2:
-          { addToken(Token.IDENTIFIER);
+          { addToken(TokenTypes.IDENTIFIER);
           }
         case 46: break;
         case 10:
@@ -891,7 +891,7 @@ public class XMLTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 47: break;
         case 23:
-          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, Token.MARKUP_PROCESSING_INSTRUCTION);
+          { yybegin(YYINITIAL); addToken(start,zzStartRead+1, TokenTypes.MARKUP_PROCESSING_INSTRUCTION);
           }
         case 48: break;
         case 21:
@@ -903,7 +903,7 @@ public class XMLTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 50: break;
         case 8:
-          { addToken(start,zzStartRead-1, Token.MARKUP_PROCESSING_INSTRUCTION); return firstToken;
+          { addToken(start,zzStartRead-1, TokenTypes.MARKUP_PROCESSING_INSTRUCTION); return firstToken;
           }
         case 51: break;
         case 14:
@@ -911,11 +911,11 @@ public class XMLTokenMaker extends AbstractMarkupTokenMaker {
           }
         case 52: break;
         case 28:
-          { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.MARKUP_COMMENT); addHyperlinkToken(temp,zzMarkedPos-1, Token.MARKUP_COMMENT); start = zzMarkedPos;
+          { int temp=zzStartRead; addToken(start,zzStartRead-1, TokenTypes.MARKUP_COMMENT); addHyperlinkToken(temp,zzMarkedPos-1, TokenTypes.MARKUP_COMMENT); start = zzMarkedPos;
           }
         case 53: break;
         case 15:
-          { yybegin(YYINITIAL); addToken(Token.MARKUP_TAG_DELIMITER);
+          { yybegin(YYINITIAL); addToken(TokenTypes.MARKUP_TAG_DELIMITER);
           }
         case 54: break;
         case 17:
@@ -924,21 +924,21 @@ public class XMLTokenMaker extends AbstractMarkupTokenMaker {
         case 55: break;
         case 24:
           { int count = yylength();
-									addToken(zzStartRead,zzStartRead+1, Token.MARKUP_TAG_DELIMITER);
-									addToken(zzMarkedPos-(count-2), zzMarkedPos-1, Token.MARKUP_TAG_NAME);
+									addToken(zzStartRead,zzStartRead+1, TokenTypes.MARKUP_TAG_DELIMITER);
+									addToken(zzMarkedPos-(count-2), zzMarkedPos-1, TokenTypes.MARKUP_TAG_NAME);
 									yybegin(INTAG);
           }
         case 56: break;
         case 18:
-          { addToken(Token.OPERATOR);
+          { addToken(TokenTypes.OPERATOR);
           }
         case 57: break;
         case 30:
-          { addToken(Token.MARKUP_CDATA_DELIMITER); start = zzMarkedPos; yybegin(CDATA);
+          { addToken(TokenTypes.MARKUP_CDATA_DELIMITER); start = zzMarkedPos; yybegin(CDATA);
           }
         case 58: break;
         case 13:
-          { addToken(Token.MARKUP_TAG_ATTRIBUTE);
+          { addToken(TokenTypes.MARKUP_TAG_ATTRIBUTE);
           }
         case 59: break;
         case 1:
@@ -954,11 +954,11 @@ public class XMLTokenMaker extends AbstractMarkupTokenMaker {
             }
             case 84: break;
             case DTD: {
-              addToken(start,zzStartRead-1, Token.MARKUP_DTD); addEndToken(inInternalDtd ? INTERNAL_DTD_INTERNAL : INTERNAL_DTD); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_DTD); addEndToken(inInternalDtd ? INTERNAL_DTD_INTERNAL : INTERNAL_DTD); return firstToken;
             }
             case 85: break;
             case INATTR_DOUBLE: {
-              addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_DOUBLE); return firstToken;
             }
             case 86: break;
             case YYINITIAL: {
@@ -966,19 +966,19 @@ public class XMLTokenMaker extends AbstractMarkupTokenMaker {
             }
             case 87: break;
             case COMMENT: {
-              addToken(start,zzStartRead-1, Token.MARKUP_COMMENT); addEndToken(INTERNAL_IN_XML_COMMENT - prevState); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_COMMENT); addEndToken(INTERNAL_IN_XML_COMMENT - prevState); return firstToken;
             }
             case 88: break;
             case CDATA: {
-              addToken(start,zzStartRead-1, Token.MARKUP_CDATA); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_CDATA); return firstToken;
             }
             case 89: break;
             case INATTR_SINGLE: {
-              addToken(start,zzStartRead-1, Token.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_TAG_ATTRIBUTE_VALUE); addEndToken(INTERNAL_ATTR_SINGLE); return firstToken;
             }
             case 90: break;
             case PI: {
-              addToken(start,zzStartRead-1, Token.MARKUP_PROCESSING_INSTRUCTION); return firstToken;
+              addToken(start,zzStartRead-1, TokenTypes.MARKUP_PROCESSING_INSTRUCTION); return firstToken;
             }
             case 91: break;
             default:

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/YamlTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/YamlTokenMaker.flex
@@ -216,20 +216,20 @@ ErrorStringLiteral		= ({UnclosedStringLiteral}[\"])
 %%
 
 <YYINITIAL> {
-	{Identifier}		{ addToken(Token.IDENTIFIER); }
-	{Whitespace}		{ addToken(Token.WHITESPACE); }
-	{Separator}			{ addToken(Token.SEPARATOR); }
-	{Separator2}		{ addToken(Token.IDENTIFIER); }
-	{Operator}			{ addToken(Token.OPERATOR); }
+	{Identifier}		{ addToken(TokenTypes.IDENTIFIER); }
+	{Whitespace}		{ addToken(TokenTypes.WHITESPACE); }
+	{Separator}			{ addToken(TokenTypes.SEPARATOR); }
+	{Separator2}		{ addToken(TokenTypes.IDENTIFIER); }
+	{Operator}			{ addToken(TokenTypes.OPERATOR); }
 	
-	{Comment}			{ addToken(Token.COMMENT_EOL); }
+	{Comment}			{ addToken(TokenTypes.COMMENT_EOL); }
 	
-	{CharLiteral}				{ addToken(Token.LITERAL_CHAR); }
-	{UnclosedCharLiteral}		{ addToken(Token.ERROR_CHAR); addNullToken(); return firstToken; }
-	{ErrorCharLiteral}			{ addToken(Token.ERROR_CHAR); }
-	{StringLiteral}				{ addToken(Token.LITERAL_STRING_DOUBLE_QUOTE); }
-	{UnclosedStringLiteral}		{ addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
-	{ErrorStringLiteral}		{ addToken(Token.ERROR_STRING_DOUBLE); }
+	{CharLiteral}				{ addToken(TokenTypes.LITERAL_CHAR); }
+	{UnclosedCharLiteral}		{ addToken(TokenTypes.ERROR_CHAR); addNullToken(); return firstToken; }
+	{ErrorCharLiteral}			{ addToken(TokenTypes.ERROR_CHAR); }
+	{StringLiteral}				{ addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE); }
+	{UnclosedStringLiteral}		{ addToken(TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
+	{ErrorStringLiteral}		{ addToken(TokenTypes.ERROR_STRING_DOUBLE); }
 
 	\n |
 	<<EOF>>				{ addNullToken(); return firstToken; }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/YamlTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/YamlTokenMaker.java
@@ -16,6 +16,7 @@ import javax.swing.text.Segment;
 import org.fife.ui.rsyntaxtextarea.AbstractJFlexTokenMaker;
 import org.fife.ui.rsyntaxtextarea.Token;
 import org.fife.ui.rsyntaxtextarea.TokenImpl;
+import org.fife.ui.rsyntaxtextarea.TokenTypes;
 
 
 /**
@@ -610,39 +611,39 @@ public class YamlTokenMaker extends AbstractJFlexTokenMaker {
 
       switch (zzAction < 0 ? zzAction : ZZ_ACTION[zzAction]) {
         case 1:
-          { addToken(Token.IDENTIFIER);
+          { addToken(TokenTypes.IDENTIFIER);
           }
         case 13: break;
         case 10:
-          { addToken(Token.LITERAL_STRING_DOUBLE_QUOTE);
+          { addToken(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE);
           }
         case 14: break;
         case 2:
-          { addToken(Token.ERROR_CHAR); addNullToken(); return firstToken;
+          { addToken(TokenTypes.ERROR_CHAR); addNullToken(); return firstToken;
           }
         case 15: break;
         case 8:
-          { addToken(Token.WHITESPACE);
+          { addToken(TokenTypes.WHITESPACE);
           }
         case 16: break;
         case 11:
-          { addToken(Token.ERROR_CHAR);
+          { addToken(TokenTypes.ERROR_CHAR);
           }
         case 17: break;
         case 7:
-          { addToken(Token.COMMENT_EOL);
+          { addToken(TokenTypes.COMMENT_EOL);
           }
         case 18: break;
         case 5:
-          { addToken(Token.OPERATOR);
+          { addToken(TokenTypes.OPERATOR);
           }
         case 19: break;
         case 9:
-          { addToken(Token.LITERAL_CHAR);
+          { addToken(TokenTypes.LITERAL_CHAR);
           }
         case 20: break;
         case 4:
-          { addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
+          { addToken(TokenTypes.ERROR_STRING_DOUBLE); addNullToken(); return firstToken;
           }
         case 21: break;
         case 3:
@@ -650,11 +651,11 @@ public class YamlTokenMaker extends AbstractJFlexTokenMaker {
           }
         case 22: break;
         case 12:
-          { addToken(Token.ERROR_STRING_DOUBLE);
+          { addToken(TokenTypes.ERROR_STRING_DOUBLE);
           }
         case 23: break;
         case 6:
-          { addToken(Token.SEPARATOR);
+          { addToken(TokenTypes.SEPARATOR);
           }
         case 24: break;
         default:

--- a/RSyntaxTextAreaDemo/src/main/java/org/fife/ui/rsyntaxtextarea/demo/SyntaxSchemeDemo.java
+++ b/RSyntaxTextAreaDemo/src/main/java/org/fife/ui/rsyntaxtextarea/demo/SyntaxSchemeDemo.java
@@ -93,10 +93,10 @@ public final class SyntaxSchemeDemo extends JFrame implements ActionListener {
 
       // Change a few things here and there.
       SyntaxScheme scheme = textArea.getSyntaxScheme();
-      scheme.getStyle(Token.RESERVED_WORD).background = Color.pink;
-      scheme.getStyle(Token.DATA_TYPE).foreground = Color.blue;
-      scheme.getStyle(Token.LITERAL_STRING_DOUBLE_QUOTE).underline = true;
-      scheme.getStyle(Token.COMMENT_EOL).font = new Font("Georgia",
+      scheme.getStyle(TokenTypes.RESERVED_WORD).background = Color.pink;
+      scheme.getStyle(TokenTypes.DATA_TYPE).foreground = Color.blue;
+      scheme.getStyle(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE).underline = true;
+      scheme.getStyle(TokenTypes.COMMENT_EOL).font = new Font("Georgia",
             Font.ITALIC, 18);
 
       textArea.revalidate();


### PR DESCRIPTION
We're very inconsistent here, but in most places we refer to token type constants, e.g. `TokenTypes.RESERVED_WORD`, with `Token.RESERVED_WORD`. This comes from the times before there was a `TokenTypes` interface. This PR updates all code to use `TokenTypes` for these constants for consistency.