### PR TITLE
refactor: Move bracket matching logic into its own class

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/BracketMatchingSupport.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/BracketMatchingSupport.java
@@ -1,0 +1,518 @@
+/*
+ * This library is distributed under a modified BSD license.  See the included
+ * LICENSE file for details.
+ */
+package org.fife.ui.rsyntaxtextarea;
+
+import java.awt.Color;
+import java.awt.Container;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Window;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+import javax.swing.JViewport;
+import javax.swing.SwingUtilities;
+import javax.swing.Timer;
+import javax.swing.event.CaretEvent;
+import javax.swing.event.CaretListener;
+import javax.swing.text.BadLocationException;
+
+import org.fife.util.SwingUtils;
+
+
+/**
+ * Handles matching the bracket at (or near) the caret position with its
+ * corresponding bracket, if any, and painting the match.
+ *
+ * @author Robert Futrell
+ * @version 1.0
+ */
+class BracketMatchingSupport {
+
+	private final RSyntaxTextArea textArea;
+
+	/**
+	 * The rectangle surrounding the "matched bracket" if bracket matching
+	 * is enabled.
+	 */
+	private Rectangle match;
+
+	/**
+	 * The rectangle surrounding the current offset if both bracket matching
+	 * and "match both brackets" are enabled.
+	 */
+	private Rectangle dotRect;
+
+	/**
+	 * Used to store the location of the bracket at the caret position
+	 * (either just before or just after it) and the location of its match.
+	 */
+	private Point bracketInfo;
+
+	/**
+	 * Colors used for the "matched bracket" if bracket matching is enabled.
+	 */
+	private Color matchedBracketBGColor;
+	private Color matchedBracketBorderColor;
+
+	/** The location of the last matched bracket. */
+	private int lastBracketMatchPos;
+
+	/** Whether bracket matching is enabled. */
+	private boolean bracketMatchingEnabled;
+
+	/** Whether bracket matching is animated. */
+	private boolean animateBracketMatching;
+
+	/** Whether <b>both</b> brackets are highlighted when bracket matching. */
+	private boolean paintMatchedBracketPair;
+
+	/** Whether a popup showing matched bracket lines when they're off-screen. */
+	private boolean showMatchedBracketPopup;
+
+	private BracketMatchingTimer bracketRepaintTimer;
+
+	private MatchedBracketPopupTimer matchedBracketPopupTimer;
+
+
+	/**
+	 * Constructor.
+	 *
+	 * @param textArea The text area whose bracket matching this instance
+	 *        will manage.
+	 */
+	BracketMatchingSupport(RSyntaxTextArea textArea) {
+		this.textArea = textArea;
+		lastBracketMatchPos = -1;
+	}
+
+
+	/**
+	 * If the caret is on a bracket, this method finds the matching bracket,
+	 * and if it exists, highlights it.
+	 */
+	void doBracketMatching() {
+
+		// We always need to repaint the "matched bracket" highlight if it
+		// exists.
+		if (match!=null) {
+			textArea.repaint(match);
+			if (dotRect!=null) {
+				textArea.repaint(dotRect);
+			}
+		}
+
+		// If a matching bracket is found, get its bounds and paint it!
+		int lastCaretBracketPos = bracketInfo==null ? -1 : bracketInfo.x;
+		bracketInfo = RSyntaxUtilities.getMatchingBracketPosition(textArea,
+				bracketInfo);
+		if (bracketInfo.y>-1 &&
+				(bracketInfo.y!=lastBracketMatchPos ||
+				 bracketInfo.x!=lastCaretBracketPos)) {
+			try {
+				match = SwingUtils.getBounds(textArea, bracketInfo.y);
+				if (match!=null) { // Happens if we're not yet visible
+					if (paintMatchedBracketPair) {
+						dotRect = SwingUtils.getBounds(textArea, bracketInfo.x);
+					}
+					else {
+						dotRect = null;
+					}
+					if (animateBracketMatching) {
+						bracketRepaintTimer.restart();
+					}
+					textArea.repaint(match);
+					if (dotRect!=null) {
+						textArea.repaint(dotRect);
+					}
+
+					if (showMatchedBracketPopup) {
+						Container parent = textArea.getParent();
+						if (parent instanceof JViewport) {
+							Rectangle visibleRect = textArea.getVisibleRect();
+							if (match.y + match.height < visibleRect.getY()) {
+								if (matchedBracketPopupTimer == null) {
+									matchedBracketPopupTimer =
+											new MatchedBracketPopupTimer();
+								}
+								matchedBracketPopupTimer.restart(bracketInfo.y);
+							}
+						}
+					}
+
+				}
+			} catch (BadLocationException ble) {
+				ble.printStackTrace(); // Shouldn't happen.
+			}
+		}
+		else if (bracketInfo.y==-1) {
+			// Set match to null so the old value isn't still repainted.
+			match = null;
+			dotRect = null;
+			bracketRepaintTimer.stop();
+		}
+		lastBracketMatchPos = bracketInfo.y;
+
+	}
+
+
+	/**
+	 * Returns whether bracket matching should be animated.
+	 *
+	 * @return Whether bracket matching should be animated.
+	 * @see #setAnimateBracketMatching(boolean)
+	 */
+	boolean getAnimateBracketMatching() {
+		return animateBracketMatching;
+	}
+
+
+	/**
+	 * Returns the caret's offset's rectangle, or <code>null</code> if there
+	 * is currently no matched bracket, bracket matching is disabled, or "paint
+	 * both matched brackets" is disabled.  This should never be called by the
+	 * programmer directly.
+	 *
+	 * @return The rectangle surrounding the matched bracket.
+	 * @see #getMatchRectangle()
+	 */
+	Rectangle getDotRectangle() {
+		return dotRect;
+	}
+
+
+	/**
+	 * Gets the color used as the background for a matched bracket.
+	 *
+	 * @return The color used.  If this is <code>null</code>, no special
+	 *         background is painted behind a matched bracket.
+	 * @see #setMatchedBracketBGColor(Color)
+	 * @see #getMatchedBracketBorderColor()
+	 */
+	Color getMatchedBracketBGColor() {
+		return matchedBracketBGColor;
+	}
+
+
+	/**
+	 * Gets the color used as the border for a matched bracket.
+	 *
+	 * @return The color used.
+	 * @see #setMatchedBracketBorderColor(Color)
+	 * @see #getMatchedBracketBGColor()
+	 */
+	Color getMatchedBracketBorderColor() {
+		return matchedBracketBorderColor;
+	}
+
+
+	/**
+	 * Returns the matched bracket's rectangle, or <code>null</code> if there
+	 * is currently no matched bracket.  This should never be called by the
+	 * programmer directly.
+	 *
+	 * @return The rectangle surrounding the matched bracket.
+	 * @see #getDotRectangle()
+	 */
+	Rectangle getMatchRectangle() {
+		return match;
+	}
+
+
+	/**
+	 * Returns whether the bracket at the caret position is painted as a
+	 * "match" when a matched bracket is found.  Note that this property does
+	 * nothing if {@link #isEnabled()} returns <code>false</code>.
+	 *
+	 * @return Whether both brackets in a bracket pair are highlighted when
+	 *         bracket matching is enabled.
+	 * @see #setPaintMatchedBracketPair(boolean)
+	 * @see #isEnabled()
+	 * @see #setEnabled(boolean)
+	 */
+	boolean getPaintMatchedBracketPair() {
+		return paintMatchedBracketPair;
+	}
+
+
+	/**
+	 * Returns whether a small popup window should display the text on the
+	 * line containing a matched bracket whenever a matched bracket is off-
+	 * screen.
+	 *
+	 * @return Whether to show the popup.
+	 * @see #setShowMatchedBracketPopup(boolean)
+	 */
+	boolean getShowMatchedBracketPopup() {
+		return showMatchedBracketPopup;
+	}
+
+
+	/**
+	 * Forces the bracket match, if any, to be recomputed from the current
+	 * caret position.  This should be called whenever something that affects
+	 * the bracket's painted bounds changes, such as the font or color
+	 * scheme.
+	 */
+	void forceReMatch() {
+		lastBracketMatchPos = -1;
+		doBracketMatching();
+	}
+
+
+	/**
+	 * Hides any currently matched bracket's highlight, without recomputing
+	 * the match.
+	 */
+	void hideMatch() {
+		match = null;
+		dotRect = null;
+	}
+
+
+	/**
+	 * Returns whether bracket matching is enabled.
+	 *
+	 * @return <code>true</code> iff bracket matching is enabled.
+	 * @see #setEnabled(boolean)
+	 */
+	boolean isEnabled() {
+		return bracketMatchingEnabled;
+	}
+
+
+	/**
+	 * Sets whether bracket matching should be animated.
+	 *
+	 * @param animate Whether to animate bracket matching.
+	 * @see #getAnimateBracketMatching()
+	 */
+	void setAnimateBracketMatching(boolean animate) {
+		if (animate!=animateBracketMatching) {
+			animateBracketMatching = animate;
+			if (animate && bracketRepaintTimer==null) {
+				bracketRepaintTimer = new BracketMatchingTimer();
+			}
+			textArea.firePropertyChange(
+					RSyntaxTextArea.ANIMATE_BRACKET_MATCHING_PROPERTY,
+					!animate, animate);
+		}
+	}
+
+
+	/**
+	 * Sets whether bracket matching is enabled.
+	 *
+	 * @param enabled Whether bracket matching should be enabled.
+	 * @see #isEnabled()
+	 */
+	void setEnabled(boolean enabled) {
+		if (enabled!=bracketMatchingEnabled) {
+			bracketMatchingEnabled = enabled;
+			textArea.repaint();
+			textArea.firePropertyChange(
+					RSyntaxTextArea.BRACKET_MATCHING_PROPERTY, !enabled, enabled);
+		}
+	}
+
+
+	/**
+	 * Sets the color used as the background for a matched bracket.
+	 *
+	 * @param color The color to use.  If this is <code>null</code>, then no
+	 *        special background is painted behind a matched bracket.
+	 * @see #getMatchedBracketBGColor()
+	 * @see #setMatchedBracketBorderColor(Color)
+	 */
+	void setMatchedBracketBGColor(Color color) {
+		matchedBracketBGColor = color;
+		if (match!=null) {
+			textArea.repaint();
+		}
+	}
+
+
+	/**
+	 * Sets the color used as the border for a matched bracket.
+	 *
+	 * @param color The color to use.
+	 * @see #getMatchedBracketBorderColor()
+	 * @see #setMatchedBracketBGColor(Color)
+	 */
+	void setMatchedBracketBorderColor(Color color) {
+		matchedBracketBorderColor = color;
+		if (match!=null) {
+			textArea.repaint();
+		}
+	}
+
+
+	/**
+	 * Sets whether the bracket at the caret position is painted as a "match"
+	 * when a matched bracket is found.  Note that this property does nothing
+	 * if {@link #isEnabled()} returns <code>false</code>.
+	 *
+	 * @param paintPair Whether both brackets in a bracket pair should be
+	 *        highlighted when bracket matching is enabled.
+	 * @see #getPaintMatchedBracketPair()
+	 * @see #isEnabled()
+	 * @see #setEnabled(boolean)
+	 */
+	void setPaintMatchedBracketPair(boolean paintPair) {
+		if (paintPair!=paintMatchedBracketPair) {
+			paintMatchedBracketPair = paintPair;
+			doBracketMatching();
+			textArea.repaint();
+			textArea.firePropertyChange(
+					RSyntaxTextArea.PAINT_MATCHED_BRACKET_PAIR_PROPERTY,
+					!paintMatchedBracketPair, paintMatchedBracketPair);
+		}
+	}
+
+
+	/**
+	 * Sets whether a small popup window should display the text on the
+	 * line containing a matched bracket whenever a matched bracket is off-
+	 * screen.
+	 *
+	 * @param show Whether to show the popup.
+	 * @see #getShowMatchedBracketPopup()
+	 */
+	void setShowMatchedBracketPopup(boolean show) {
+		showMatchedBracketPopup = show;
+	}
+
+
+	/**
+	 * A timer that animates the "bracket matching" animation.
+	 */
+	private class BracketMatchingTimer extends Timer implements ActionListener {
+
+		private int pulseCount;
+
+		BracketMatchingTimer() {
+			super(20, null);
+			addActionListener(this);
+			setCoalesce(false);
+		}
+
+		@Override
+		public void actionPerformed(ActionEvent e) {
+			if (bracketMatchingEnabled) {
+				if (match!=null) {
+					updateAndInvalidate(match);
+				}
+				if (dotRect!=null && paintMatchedBracketPair) {
+					updateAndInvalidate(dotRect);
+				}
+				if (++pulseCount==8) {
+					pulseCount = 0;
+					stop();
+				}
+			}
+		}
+
+		private void init(Rectangle r) {
+			r.x += 3;
+			r.y += 3;
+			r.width -= 6;
+			r.height -= 6; // So animation can "grow" match
+		}
+
+		@Override
+		public void start() {
+			init(match);
+			if (dotRect!=null && paintMatchedBracketPair) {
+				init(dotRect);
+			}
+			pulseCount = 0;
+			super.start();
+		}
+
+		private void updateAndInvalidate(Rectangle r) {
+			if (pulseCount<5) {
+				r.x--;
+				r.y--;
+				r.width += 2;
+				r.height += 2;
+				textArea.repaint(r.x,r.y, r.width,r.height);
+			}
+			else if (pulseCount<7) {
+				r.x++;
+				r.y++;
+				r.width -= 2;
+				r.height -= 2;
+				textArea.repaint(r.x-2,r.y-2, r.width+5,r.height+5);
+			}
+		}
+
+	}
+
+
+	/**
+	 * Handles showing and hiding the popup with the text of a matched
+	 * bracket's line, when that line is off-screen.
+	 */
+	private final class MatchedBracketPopupTimer extends Timer
+			implements ActionListener, CaretListener {
+
+		private MatchedBracketPopup popup;
+		private int origDot;
+		private int matchedBracketOffs;
+
+		private MatchedBracketPopupTimer() {
+			super(350, null);
+			addActionListener(this);
+			setRepeats(false);
+		}
+
+		@Override
+		public void actionPerformed(ActionEvent e) {
+
+			if (popup != null) {
+				popup.dispose();
+			}
+
+			if (textArea.hasFocus()) {
+				Window window = SwingUtilities.getWindowAncestor(textArea);
+				popup = new MatchedBracketPopup(window, textArea, matchedBracketOffs);
+				popup.pack();
+				popup.setVisible(true);
+			}
+		}
+
+		@Override
+		public void caretUpdate(CaretEvent e) {
+			int dot = e.getDot();
+			if (dot != origDot) {
+				stop();
+				textArea.removeCaretListener(this);
+				if (popup != null) {
+					popup.dispose();
+				}
+			}
+		}
+
+		/**
+		 * Restarts this timer, and stores a new offset to paint.
+		 *
+		 * @param matchedBracketOffs The offset of the new matched bracket.
+		 */
+		public void restart(int matchedBracketOffs) {
+			this.origDot = textArea.getCaretPosition();
+			this.matchedBracketOffs = matchedBracketOffs;
+			this.restart();
+		}
+
+		@Override
+		public void start() {
+			super.start();
+			textArea.addCaretListener(this);
+		}
+
+	}
+
+
+}

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextArea.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextArea.java
@@ -19,7 +19,6 @@ import java.util.ResourceBundle;
 
 import javax.swing.*;
 import javax.swing.event.CaretEvent;
-import javax.swing.event.CaretListener;
 import javax.swing.event.HyperlinkEvent;
 import javax.swing.event.HyperlinkListener;
 import javax.swing.text.BadLocationException;
@@ -35,7 +34,6 @@ import org.fife.ui.rsyntaxtextarea.parser.Parser;
 import org.fife.ui.rsyntaxtextarea.parser.ParserNotice;
 import org.fife.ui.rsyntaxtextarea.parser.ToolTipInfo;
 import org.fife.ui.rtextarea.*;
-import org.fife.util.SwingUtils;
 
 
 /**
@@ -169,45 +167,8 @@ public class RSyntaxTextArea extends RTextArea implements SyntaxConstants {
 	/** Whether templates are enabled. */
 	private static boolean templatesEnabled;
 
-	/**
-	 * The rectangle surrounding the "matched bracket" if bracket matching
-	 * is enabled.
-	 */
-	private Rectangle match;
-
-	/**
-	 * The rectangle surrounding the current offset if both bracket matching and
-	 * "match both brackets" are enabled.
-	 */
-	private Rectangle dotRect;
-
-	/**
-	 * Used to store the location of the bracket at the caret position (either
-	 * just before or just after it) and the location of its match.
-	 */
-	private Point bracketInfo;
-
-	/**
-	 * Colors used for the "matched bracket" if bracket matching is enabled.
-	 */
-	private Color matchedBracketBGColor;
-	private Color matchedBracketBorderColor;
-
-	/** The location of the last matched bracket. */
-	private int lastBracketMatchPos;
-
-	/** Whether bracket matching is enabled. */
-	private boolean bracketMatchingEnabled;
-
-	/** Whether bracket matching is animated. */
-	private boolean animateBracketMatching;
-
-	/** Whether <b>both</b> brackets are highlighted when bracket matching. */
-	private boolean paintMatchedBracketPair;
-
-	private BracketMatchingTimer bracketRepaintTimer;
-
-	private MatchedBracketPopupTimer matchedBracketPopupTimer;
+	/** Handles bracket matching support. */
+	private BracketMatchingSupport bracketMatchingSupport;
 
 	private boolean metricsNeverRefreshed;
 
@@ -315,9 +276,6 @@ public class RSyntaxTextArea extends RTextArea implements SyntaxConstants {
 
 	/** Renders tokens. */
 	private TokenPainter tokenPainter;
-
-	/** Whether a popup showing matched bracket lines when they're off-screen. */
-	private boolean showMatchedBracketPopup;
 
 	private int lineHeight;		// Height of a line of text; same for default, bold & italic.
 	private int maxAscent;
@@ -832,67 +790,7 @@ public class RSyntaxTextArea extends RTextArea implements SyntaxConstants {
 	 * and if it exists, highlights it.
 	 */
 	protected final void doBracketMatching() {
-
-		// We always need to repaint the "matched bracket" highlight if it
-		// exists.
-		if (match!=null) {
-			repaint(match);
-			if (dotRect!=null) {
-				repaint(dotRect);
-			}
-		}
-
-		// If a matching bracket is found, get its bounds and paint it!
-		int lastCaretBracketPos = bracketInfo==null ? -1 : bracketInfo.x;
-		bracketInfo = RSyntaxUtilities.getMatchingBracketPosition(this,
-				bracketInfo);
-		if (bracketInfo.y>-1 &&
-				(bracketInfo.y!=lastBracketMatchPos ||
-				 bracketInfo.x!=lastCaretBracketPos)) {
-			try {
-				match = SwingUtils.getBounds(this, bracketInfo.y);
-				if (match!=null) { // Happens if we're not yet visible
-					if (getPaintMatchedBracketPair()) {
-						dotRect = SwingUtils.getBounds(this, bracketInfo.x);
-					}
-					else {
-						dotRect = null;
-					}
-					if (getAnimateBracketMatching()) {
-						bracketRepaintTimer.restart();
-					}
-					repaint(match);
-					if (dotRect!=null) {
-						repaint(dotRect);
-					}
-
-					if (getShowMatchedBracketPopup()) {
-						Container parent = getParent();
-						if (parent instanceof JViewport) {
-							Rectangle visibleRect = this.getVisibleRect();
-							if (match.y + match.height < visibleRect.getY()) {
-								if (matchedBracketPopupTimer == null) {
-									matchedBracketPopupTimer =
-											new MatchedBracketPopupTimer();
-								}
-								matchedBracketPopupTimer.restart(bracketInfo.y);
-							}
-						}
-					}
-
-				}
-			} catch (BadLocationException ble) {
-				ble.printStackTrace(); // Shouldn't happen.
-			}
-		}
-		else if (bracketInfo.y==-1) {
-			// Set match to null so the old value isn't still repainted.
-			match = null;
-			dotRect = null;
-			bracketRepaintTimer.stop();
-		}
-		lastBracketMatchPos = bracketInfo.y;
-
+		bracketMatchingSupport.doBracketMatching();
 	}
 
 
@@ -989,8 +887,7 @@ public class RSyntaxTextArea extends RTextArea implements SyntaxConstants {
 	 * @param fold The fold that was collapsed or expanded.
 	 */
 	public void foldToggled(Fold fold) {
-		match = null; // TODO: Update the bracket rect rather than hide it
-		dotRect = null;
+		bracketMatchingSupport.hideMatch(); // TODO: Update the bracket rect rather than hide it
 		if (getLineWrap()) {
 			// NOTE: Without doing this later, the caret position is out of
 			// sync with the Element structure when word wrap is enabled, and
@@ -1053,7 +950,7 @@ public class RSyntaxTextArea extends RTextArea implements SyntaxConstants {
 	 * @see #setAnimateBracketMatching(boolean)
 	 */
 	public boolean getAnimateBracketMatching() {
-		return animateBracketMatching;
+		return bracketMatchingSupport.getAnimateBracketMatching();
 	}
 
 
@@ -1510,7 +1407,7 @@ public class RSyntaxTextArea extends RTextArea implements SyntaxConstants {
 	 * @see #getMatchedBracketBorderColor
 	 */
 	public Color getMatchedBracketBGColor() {
-		return matchedBracketBGColor;
+		return bracketMatchingSupport.getMatchedBracketBGColor();
 	}
 
 
@@ -1522,7 +1419,7 @@ public class RSyntaxTextArea extends RTextArea implements SyntaxConstants {
 	 * @see #getMatchedBracketBGColor
 	 */
 	public Color getMatchedBracketBorderColor() {
-		return matchedBracketBorderColor;
+		return bracketMatchingSupport.getMatchedBracketBorderColor();
 	}
 
 
@@ -1536,7 +1433,7 @@ public class RSyntaxTextArea extends RTextArea implements SyntaxConstants {
 	 * @see #getMatchRectangle()
 	 */
 	Rectangle getDotRectangle() {
-		return dotRect;
+		return bracketMatchingSupport.getDotRectangle();
 	}
 
 
@@ -1549,7 +1446,7 @@ public class RSyntaxTextArea extends RTextArea implements SyntaxConstants {
 	 * @see #getDotRectangle()
 	 */
 	Rectangle getMatchRectangle() {
-		return match;
+		return bracketMatchingSupport.getMatchRectangle();
 	}
 
 
@@ -1577,7 +1474,7 @@ public class RSyntaxTextArea extends RTextArea implements SyntaxConstants {
 	 * @see #setBracketMatchingEnabled(boolean)
 	 */
 	public boolean getPaintMatchedBracketPair() {
-		return paintMatchedBracketPair;
+		return bracketMatchingSupport.getPaintMatchedBracketPair();
 	}
 
 
@@ -1712,7 +1609,7 @@ public class RSyntaxTextArea extends RTextArea implements SyntaxConstants {
 	 * @see #setShowMatchedBracketPopup(boolean)
 	 */
 	public boolean getShowMatchedBracketPopup() {
-		return showMatchedBracketPopup;
+		return bracketMatchingSupport.getShowMatchedBracketPopup();
 	}
 
 
@@ -2071,6 +1968,7 @@ public class RSyntaxTextArea extends RTextArea implements SyntaxConstants {
 
 		tokenPainterFactory = new DefaultTokenPainterFactory();
 		tokenPainter = tokenPainterFactory.getTokenPainter(this);
+		bracketMatchingSupport = new BracketMatchingSupport(this);
 
 		// NOTE: Our actions are created here instead of in a static block
 		// so they are only created when the first RTextArea is instantiated,
@@ -2088,7 +1986,6 @@ public class RSyntaxTextArea extends RTextArea implements SyntaxConstants {
 		setMatchedBracketBorderColor(getDefaultBracketMatchBorderColor());
 		setBracketMatchingEnabled(true);
 		setAnimateBracketMatching(true);
-		lastBracketMatchPos = -1;
 		setSelectionColor(getDefaultSelectionColor());
 		setTabLineColor(null);
 		setMarkOccurrencesColor(MarkOccurrencesSupport.DEFAULT_COLOR);
@@ -2143,7 +2040,7 @@ public class RSyntaxTextArea extends RTextArea implements SyntaxConstants {
 	 * @see #setBracketMatchingEnabled
 	 */
 	public final boolean isBracketMatchingEnabled() {
-		return bracketMatchingEnabled;
+		return bracketMatchingSupport.isEnabled();
 	}
 
 
@@ -2382,14 +2279,7 @@ public class RSyntaxTextArea extends RTextArea implements SyntaxConstants {
 	 * @see #getAnimateBracketMatching()
 	 */
 	public void setAnimateBracketMatching(boolean animate) {
-		if (animate!=animateBracketMatching) {
-			animateBracketMatching = animate;
-			if (animate && bracketRepaintTimer==null) {
-				bracketRepaintTimer = new BracketMatchingTimer();
-			}
-			firePropertyChange(ANIMATE_BRACKET_MATCHING_PROPERTY,
-								!animate, animate);
-		}
+		bracketMatchingSupport.setAnimateBracketMatching(animate);
 	}
 
 
@@ -2449,11 +2339,7 @@ public class RSyntaxTextArea extends RTextArea implements SyntaxConstants {
 	 * @see #isBracketMatchingEnabled()
 	 */
 	public void setBracketMatchingEnabled(boolean enabled) {
-		if (enabled!=bracketMatchingEnabled) {
-			bracketMatchingEnabled = enabled;
-			repaint();
-			firePropertyChange(BRACKET_MATCHING_PROPERTY, !enabled, enabled);
-		}
+		bracketMatchingSupport.setEnabled(enabled);
 	}
 
 
@@ -2648,8 +2534,7 @@ public class RSyntaxTextArea extends RTextArea implements SyntaxConstants {
 			// though the caret's location hasn't changed.
 			forceCurrentLineHighlightRepaint();
 			// Update the "matched bracket", if any
-			lastBracketMatchPos = -1;
-			doBracketMatching();
+			bracketMatchingSupport.forceReMatch();
 			// Get line number border in text area to repaint again
 			// since line heights have updated.
 			firePropertyChange("font", old, font);
@@ -2906,10 +2791,7 @@ public class RSyntaxTextArea extends RTextArea implements SyntaxConstants {
 	 * @see #setPaintMarkOccurrencesBorder(boolean)
 	 */
 	public void setMatchedBracketBGColor(Color color) {
-		matchedBracketBGColor = color;
-		if (match!=null) {
-			repaint();
-		}
+		bracketMatchingSupport.setMatchedBracketBGColor(color);
 	}
 
 
@@ -2921,10 +2803,7 @@ public class RSyntaxTextArea extends RTextArea implements SyntaxConstants {
 	 * @see #setMatchedBracketBGColor
 	 */
 	public void setMatchedBracketBorderColor(Color color) {
-		matchedBracketBorderColor = color;
-		if (match!=null) {
-			repaint();
-		}
+		bracketMatchingSupport.setMatchedBracketBorderColor(color);
 	}
 
 
@@ -2959,13 +2838,7 @@ public class RSyntaxTextArea extends RTextArea implements SyntaxConstants {
 	 * @see #setBracketMatchingEnabled(boolean)
 	 */
 	public void setPaintMatchedBracketPair(boolean paintPair) {
-		if (paintPair!=paintMatchedBracketPair) {
-			paintMatchedBracketPair = paintPair;
-			doBracketMatching();
-			repaint();
-			firePropertyChange(PAINT_MATCHED_BRACKET_PAIR_PROPERTY,
-					!paintMatchedBracketPair, paintMatchedBracketPair);
-		}
+		bracketMatchingSupport.setPaintMatchedBracketPair(paintPair);
 	}
 
 
@@ -3061,7 +2934,7 @@ public class RSyntaxTextArea extends RTextArea implements SyntaxConstants {
 	 * @see #getShowMatchedBracketPopup()
 	 */
 	public void setShowMatchedBracketPopup(boolean show) {
-		showMatchedBracketPopup = show;
+		bracketMatchingSupport.setShowMatchedBracketPopup(show);
 	}
 
 
@@ -3134,8 +3007,7 @@ public class RSyntaxTextArea extends RTextArea implements SyntaxConstants {
 
 		// Updates the margin line and "matched bracket" highlight
 		updateMarginLineX();
-		lastBracketMatchPos = -1;
-		doBracketMatching();
+		bracketMatchingSupport.forceReMatch();
 
 		// Force the current line highlight to be repainted, even though
 		// the caret's location hasn't changed.
@@ -3379,136 +3251,6 @@ public class RSyntaxTextArea extends RTextArea implements SyntaxConstants {
 			refreshFontMetrics(getGraphics2D(graphics));
 		}
 	}
-
-	/**
-	 * Renders the text on the line containing the "matched bracket" after a
-	 * delay.
-	 */
-	private final class MatchedBracketPopupTimer extends Timer
-			implements ActionListener, CaretListener {
-
-		private MatchedBracketPopup popup;
-		private int origDot;
-		private int matchedBracketOffs;
-
-		private MatchedBracketPopupTimer() {
-			super(350, null);
-			addActionListener(this);
-			setRepeats(false);
-		}
-
-		@Override
-		public void actionPerformed(ActionEvent e) {
-
-			if (popup != null) {
-				popup.dispose();
-			}
-
-			if (RSyntaxTextArea.this.hasFocus()) {
-				Window window = SwingUtilities.getWindowAncestor(RSyntaxTextArea.this);
-				popup = new MatchedBracketPopup(window, RSyntaxTextArea.this, matchedBracketOffs);
-				popup.pack();
-				popup.setVisible(true);
-			}
-		}
-
-		@Override
-		public void caretUpdate(CaretEvent e) {
-			int dot = e.getDot();
-			if (dot != origDot) {
-				stop();
-				removeCaretListener(this);
-				if (popup != null) {
-					popup.dispose();
-				}
-			}
-		}
-
-		/**
-		 * Restarts this timer, and stores a new offset to paint.
-		 *
-		 * @param matchedBracketOffs The offset of the new matched bracket.
-		 */
-		public void restart(int matchedBracketOffs) {
-			this.origDot = getCaretPosition();
-			this.matchedBracketOffs = matchedBracketOffs;
-			this.restart();
-		}
-
-		@Override
-		public void start() {
-			super.start();
-			addCaretListener(this);
-		}
-
-	}
-
-
-	/**
-	 * A timer that animates the "bracket matching" animation.
-	 */
-	private class BracketMatchingTimer extends Timer implements ActionListener {
-
-		private int pulseCount;
-
-		BracketMatchingTimer() {
-			super(20, null);
-			addActionListener(this);
-			setCoalesce(false);
-		}
-
-		@Override
-		public void actionPerformed(ActionEvent e) {
-			if (isBracketMatchingEnabled()) {
-				if (match!=null) {
-					updateAndInvalidate(match);
-				}
-				if (dotRect!=null && getPaintMatchedBracketPair()) {
-					updateAndInvalidate(dotRect);
-				}
-				if (++pulseCount==8) {
-					pulseCount = 0;
-					stop();
-				}
-			}
-		}
-
-		private void init(Rectangle r) {
-			r.x += 3;
-			r.y += 3;
-			r.width -= 6;
-			r.height -= 6; // So animation can "grow" match
-		}
-
-		@Override
-		public void start() {
-			init(match);
-			if (dotRect!=null && getPaintMatchedBracketPair()) {
-				init(dotRect);
-			}
-			pulseCount = 0;
-			super.start();
-		}
-
-		private void updateAndInvalidate(Rectangle r) {
-			if (pulseCount<5) {
-				r.x--;
-				r.y--;
-				r.width += 2;
-				r.height += 2;
-				repaint(r.x,r.y, r.width,r.height);
-			}
-			else if (pulseCount<7) {
-				r.x++;
-				r.y++;
-				r.width -= 2;
-				r.height -= 2;
-				repaint(r.x-2,r.y-2, r.width+5,r.height+5);
-			}
-		}
-
-	}
-
 
 	/**
 	 * Handles hyperlinks.

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/BracketMatchingSupportTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/BracketMatchingSupportTest.java
@@ -1,0 +1,402 @@
+/*
+ * This library is distributed under a modified BSD license.  See the included
+ * LICENSE file for details.
+ */
+package org.fife.ui.rsyntaxtextarea;
+
+import org.fife.ui.SwingRunnerExtension;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import javax.swing.JFrame;
+import javax.swing.JViewport;
+import java.awt.Color;
+import java.awt.GraphicsEnvironment;
+import java.awt.Rectangle;
+
+
+/**
+ * Unit tests for the {@link BracketMatchingSupport} class.
+ *
+ * @author Robert Futrell
+ * @version 1.0
+ */
+@ExtendWith(SwingRunnerExtension.class)
+class BracketMatchingSupportTest extends AbstractRSyntaxTextAreaTest {
+
+	/** Offset just after the outer, opening curly brace in {@link #DEFAULT_CODE}. */
+	private static final int CARET_AFTER_OUTER_OPEN_BRACE = 1;
+
+	/** Offset just after the inner, opening curly brace in {@link #DEFAULT_CODE}. */
+	private static final int CARET_AFTER_INNER_OPEN_BRACE = 5;
+
+	/** Offset with no bracket immediately to either side, in {@link #DEFAULT_CODE}. */
+	private static final int CARET_WITH_NO_ADJACENT_BRACKET = 12;
+
+
+	@Test
+	void testConstructor_defaultState() {
+
+		RSyntaxTextArea textArea = createTextArea();
+		BracketMatchingSupport support = new BracketMatchingSupport(textArea);
+
+		Assertions.assertFalse(support.isEnabled());
+		Assertions.assertFalse(support.getAnimateBracketMatching());
+		Assertions.assertFalse(support.getPaintMatchedBracketPair());
+		Assertions.assertFalse(support.getShowMatchedBracketPopup());
+		Assertions.assertNull(support.getMatchRectangle());
+		Assertions.assertNull(support.getDotRectangle());
+		Assertions.assertNull(support.getMatchedBracketBGColor());
+		Assertions.assertNull(support.getMatchedBracketBorderColor());
+	}
+
+
+	@Test
+	void testSetEnabled() {
+
+		RSyntaxTextArea textArea = createTextArea();
+		BracketMatchingSupport support = new BracketMatchingSupport(textArea);
+		Object[] newValue = new Object[1];
+		textArea.addPropertyChangeListener(RSyntaxTextArea.BRACKET_MATCHING_PROPERTY,
+			e -> newValue[0] = e.getNewValue());
+
+		support.setEnabled(true);
+		Assertions.assertTrue(support.isEnabled());
+		Assertions.assertEquals(Boolean.TRUE, newValue[0]);
+
+		support.setEnabled(false);
+		Assertions.assertFalse(support.isEnabled());
+		Assertions.assertEquals(Boolean.FALSE, newValue[0]);
+	}
+
+
+	@Test
+	void testSetEnabled_calledWithExistingValue() {
+
+		RSyntaxTextArea textArea = createTextArea();
+		BracketMatchingSupport support = new BracketMatchingSupport(textArea);
+		Object[] newValue = new Object[1];
+		textArea.addPropertyChangeListener(RSyntaxTextArea.BRACKET_MATCHING_PROPERTY,
+			e -> newValue[0] = e.getNewValue());
+
+		// Default is already false, so this is a no-op
+		support.setEnabled(false);
+		Assertions.assertFalse(support.isEnabled());
+		Assertions.assertNull(newValue[0]);
+	}
+
+
+	@Test
+	void testSetAnimateBracketMatching() {
+
+		RSyntaxTextArea textArea = createTextArea();
+		BracketMatchingSupport support = new BracketMatchingSupport(textArea);
+		Object[] newValue = new Object[1];
+		textArea.addPropertyChangeListener(RSyntaxTextArea.ANIMATE_BRACKET_MATCHING_PROPERTY,
+			e -> newValue[0] = e.getNewValue());
+
+		support.setAnimateBracketMatching(true);
+		Assertions.assertTrue(support.getAnimateBracketMatching());
+		Assertions.assertEquals(Boolean.TRUE, newValue[0]);
+
+		support.setAnimateBracketMatching(false);
+		Assertions.assertFalse(support.getAnimateBracketMatching());
+		Assertions.assertEquals(Boolean.FALSE, newValue[0]);
+	}
+
+
+	@Test
+	void testSetAnimateBracketMatching_calledWithExistingValue() {
+
+		RSyntaxTextArea textArea = createTextArea();
+		BracketMatchingSupport support = new BracketMatchingSupport(textArea);
+		Object[] newValue = new Object[1];
+		textArea.addPropertyChangeListener(RSyntaxTextArea.ANIMATE_BRACKET_MATCHING_PROPERTY,
+			e -> newValue[0] = e.getNewValue());
+
+		// Default is already false, so this is a no-op
+		support.setAnimateBracketMatching(false);
+		Assertions.assertFalse(support.getAnimateBracketMatching());
+		Assertions.assertNull(newValue[0]);
+	}
+
+
+	@Test
+	void testGetSetMatchedBracketBGColor() {
+
+		RSyntaxTextArea textArea = createTextArea();
+		BracketMatchingSupport support = new BracketMatchingSupport(textArea);
+
+		support.setMatchedBracketBGColor(Color.pink);
+		Assertions.assertEquals(Color.pink, support.getMatchedBracketBGColor());
+
+		support.setMatchedBracketBGColor(null);
+		Assertions.assertNull(support.getMatchedBracketBGColor());
+	}
+
+
+	@Test
+	void testGetSetMatchedBracketBorderColor() {
+
+		RSyntaxTextArea textArea = createTextArea();
+		BracketMatchingSupport support = new BracketMatchingSupport(textArea);
+
+		support.setMatchedBracketBorderColor(Color.pink);
+		Assertions.assertEquals(Color.pink, support.getMatchedBracketBorderColor());
+
+		support.setMatchedBracketBorderColor(null);
+		Assertions.assertNull(support.getMatchedBracketBorderColor());
+	}
+
+
+	@Test
+	void testGetSetShowMatchedBracketPopup() {
+
+		RSyntaxTextArea textArea = createTextArea();
+		BracketMatchingSupport support = new BracketMatchingSupport(textArea);
+
+		Assertions.assertFalse(support.getShowMatchedBracketPopup());
+		support.setShowMatchedBracketPopup(true);
+		Assertions.assertTrue(support.getShowMatchedBracketPopup());
+		support.setShowMatchedBracketPopup(false);
+		Assertions.assertFalse(support.getShowMatchedBracketPopup());
+	}
+
+
+	@Test
+	void testSetPaintMatchedBracketPair() {
+
+		RSyntaxTextArea textArea = createTextArea();
+		BracketMatchingSupport support = new BracketMatchingSupport(textArea);
+		support.setAnimateBracketMatching(true);
+		Object[] newValue = new Object[1];
+		textArea.addPropertyChangeListener(RSyntaxTextArea.PAINT_MATCHED_BRACKET_PAIR_PROPERTY,
+			e -> newValue[0] = e.getNewValue());
+
+		support.setPaintMatchedBracketPair(true);
+		Assertions.assertTrue(support.getPaintMatchedBracketPair());
+		Assertions.assertEquals(Boolean.TRUE, newValue[0]);
+
+		support.setPaintMatchedBracketPair(false);
+		Assertions.assertFalse(support.getPaintMatchedBracketPair());
+		Assertions.assertEquals(Boolean.FALSE, newValue[0]);
+	}
+
+
+	@Test
+	void testSetPaintMatchedBracketPair_calledWithExistingValue() {
+
+		RSyntaxTextArea textArea = createTextArea();
+		BracketMatchingSupport support = new BracketMatchingSupport(textArea);
+		Object[] newValue = new Object[1];
+		textArea.addPropertyChangeListener(RSyntaxTextArea.PAINT_MATCHED_BRACKET_PAIR_PROPERTY,
+			e -> newValue[0] = e.getNewValue());
+
+		// Default is already false, so this is a no-op
+		support.setPaintMatchedBracketPair(false);
+		Assertions.assertFalse(support.getPaintMatchedBracketPair());
+		Assertions.assertNull(newValue[0]);
+	}
+
+
+	@Test
+	void testDoBracketMatching_singleBracketHighlighted() {
+
+		RSyntaxTextArea textArea = createTextArea();
+		textArea.setCaretPosition(CARET_AFTER_OUTER_OPEN_BRACE);
+		BracketMatchingSupport support = new BracketMatchingSupport(textArea);
+		support.setAnimateBracketMatching(true);
+
+		support.doBracketMatching();
+
+		Assertions.assertNotNull(support.getMatchRectangle());
+		Assertions.assertNull(support.getDotRectangle());
+	}
+
+
+	@Test
+	void testDoBracketMatching_bothBracketsHighlighted() {
+
+		RSyntaxTextArea textArea = createTextArea();
+		textArea.setCaretPosition(CARET_AFTER_OUTER_OPEN_BRACE);
+		BracketMatchingSupport support = new BracketMatchingSupport(textArea);
+		support.setAnimateBracketMatching(true);
+		support.setPaintMatchedBracketPair(true);
+
+		support.doBracketMatching();
+
+		Assertions.assertNotNull(support.getMatchRectangle());
+		Assertions.assertNotNull(support.getDotRectangle());
+	}
+
+
+	@Test
+	void testDoBracketMatching_matchesInnermostBracketPair() {
+
+		RSyntaxTextArea textArea = createTextArea();
+		textArea.setCaretPosition(CARET_AFTER_INNER_OPEN_BRACE);
+		BracketMatchingSupport support = new BracketMatchingSupport(textArea);
+		support.setAnimateBracketMatching(true);
+
+		support.doBracketMatching();
+
+		Assertions.assertNotNull(support.getMatchRectangle());
+	}
+
+
+	@Test
+	void testDoBracketMatching_noBracketAtCaretClearsPreviousMatch() {
+
+		RSyntaxTextArea textArea = createTextArea();
+		textArea.setCaretPosition(CARET_AFTER_OUTER_OPEN_BRACE);
+		BracketMatchingSupport support = new BracketMatchingSupport(textArea);
+		support.setAnimateBracketMatching(true);
+		support.setPaintMatchedBracketPair(true);
+		support.doBracketMatching();
+		Assertions.assertNotNull(support.getMatchRectangle());
+		Assertions.assertNotNull(support.getDotRectangle());
+
+		textArea.setCaretPosition(CARET_WITH_NO_ADJACENT_BRACKET);
+		support.doBracketMatching();
+
+		Assertions.assertNull(support.getMatchRectangle());
+		Assertions.assertNull(support.getDotRectangle());
+	}
+
+
+	@Test
+	void testDoBracketMatching_noBracketAtCaretFromTheStart() {
+
+		RSyntaxTextArea textArea = createTextArea();
+		textArea.setCaretPosition(CARET_WITH_NO_ADJACENT_BRACKET);
+		BracketMatchingSupport support = new BracketMatchingSupport(textArea);
+		support.setAnimateBracketMatching(true);
+
+		support.doBracketMatching();
+
+		Assertions.assertNull(support.getMatchRectangle());
+		Assertions.assertNull(support.getDotRectangle());
+	}
+
+
+	@Test
+	void testDoBracketMatching_repeatedCallsWithoutMovingCaretAreStable() {
+
+		RSyntaxTextArea textArea = createTextArea();
+		textArea.setCaretPosition(CARET_AFTER_OUTER_OPEN_BRACE);
+		BracketMatchingSupport support = new BracketMatchingSupport(textArea);
+		support.setAnimateBracketMatching(true);
+
+		support.doBracketMatching();
+		Rectangle firstMatch = support.getMatchRectangle();
+		Assertions.assertNotNull(firstMatch);
+
+		support.doBracketMatching();
+		Assertions.assertEquals(firstMatch, support.getMatchRectangle());
+	}
+
+
+	@Test
+	void testHideMatch() {
+
+		RSyntaxTextArea textArea = createTextArea();
+		textArea.setCaretPosition(CARET_AFTER_OUTER_OPEN_BRACE);
+		BracketMatchingSupport support = new BracketMatchingSupport(textArea);
+		support.setAnimateBracketMatching(true);
+		support.setPaintMatchedBracketPair(true);
+		support.doBracketMatching();
+		Assertions.assertNotNull(support.getMatchRectangle());
+		Assertions.assertNotNull(support.getDotRectangle());
+
+		support.hideMatch();
+
+		Assertions.assertNull(support.getMatchRectangle());
+		Assertions.assertNull(support.getDotRectangle());
+	}
+
+
+	@Test
+	void testHideMatch_doBracketMatchingWithoutMovingCaretStaysHidden() {
+
+		RSyntaxTextArea textArea = createTextArea();
+		textArea.setCaretPosition(CARET_AFTER_OUTER_OPEN_BRACE);
+		BracketMatchingSupport support = new BracketMatchingSupport(textArea);
+		support.setAnimateBracketMatching(true);
+		support.doBracketMatching();
+		Assertions.assertNotNull(support.getMatchRectangle());
+
+		support.hideMatch();
+		Assertions.assertNull(support.getMatchRectangle());
+
+		// Since the caret hasn't moved, the cached "last matched" state still
+		// matches the recomputed bracket position, so the match isn't redrawn.
+		support.doBracketMatching();
+		Assertions.assertNull(support.getMatchRectangle());
+	}
+
+
+	@Test
+	void testForceReMatch_recomputesMatchEvenWhenCaretHasNotMoved() {
+
+		RSyntaxTextArea textArea = createTextArea();
+		textArea.setCaretPosition(CARET_AFTER_OUTER_OPEN_BRACE);
+		BracketMatchingSupport support = new BracketMatchingSupport(textArea);
+		support.setAnimateBracketMatching(true);
+		support.doBracketMatching();
+		Assertions.assertNotNull(support.getMatchRectangle());
+
+		support.hideMatch();
+		Assertions.assertNull(support.getMatchRectangle());
+
+		support.forceReMatch();
+
+		Assertions.assertNotNull(support.getMatchRectangle());
+	}
+
+
+	@Test
+	void testDoBracketMatching_showMatchedBracketPopupWhenMatchScrolledOffscreen() {
+
+		Assumptions.assumeFalse(GraphicsEnvironment.isHeadless());
+
+		JFrame frame = new JFrame();
+		try {
+			RSyntaxTextArea textArea = createTextArea();
+			JViewport viewport = new JViewport();
+			viewport.setBounds(0, 0, 80, 20);
+			viewport.setView(textArea);
+			frame.add(viewport);
+			frame.setSize(100, 100);
+			frame.setVisible(true);
+
+			// Scroll down so the match (on line 0) is above the visible area.
+			viewport.setViewPosition(new java.awt.Point(0, 60));
+
+			textArea.setCaretPosition(CARET_AFTER_OUTER_OPEN_BRACE);
+			BracketMatchingSupport support = new BracketMatchingSupport(textArea);
+			support.setAnimateBracketMatching(true);
+			support.setShowMatchedBracketPopup(true);
+
+			Assertions.assertDoesNotThrow(support::doBracketMatching);
+		}
+		finally {
+			frame.dispose();
+		}
+	}
+
+
+	@Test
+	void testForceReMatch_doesNotThrowWhenNeverMatched() {
+
+		RSyntaxTextArea textArea = createTextArea();
+		textArea.setCaretPosition(CARET_WITH_NO_ADJACENT_BRACKET);
+		BracketMatchingSupport support = new BracketMatchingSupport(textArea);
+		support.setAnimateBracketMatching(true);
+
+		Assertions.assertDoesNotThrow(support::forceReMatch);
+		Assertions.assertNull(support.getMatchRectangle());
+	}
+
+}


### PR DESCRIPTION
Move the "bracket matching" logic out of `RSyntaxTextArea` and into a standalone `BracketMatchingSupport` class. Then RSTA proper will delegate to the bracket matching instance in a composable pattern. This refactor is mostly to reduce the LOC in `RSyntaxTextArea.java`, but also to prepare for more customizable bracket matching at the language level.

This PR is purely a refactor, there is no functional difference visible to the user.