### PR TITLE
refactor: Promote stateless TokenMaker methods to interface defaults

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxUtilities.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxUtilities.java
@@ -1171,7 +1171,7 @@ return c.getLineStartOffset(line);
 	 * Returns whether the specified token is a single non-word char (e.g. not
 	 * in <code>[A-Za-z]</code>).  This is a HACK to work around the fact that
 	 * many standard token makers return things like semicolons and periods as
-	 * {@link Token#IDENTIFIER}s just to make the syntax highlighting coloring
+	 * {@link TokenTypes#IDENTIFIER}s just to make the syntax highlighting coloring
 	 * look a little better.
 	 *
 	 * @param t The token to check.  This cannot be <code>null</code>.

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TokenMaker.java
@@ -55,9 +55,12 @@ public interface TokenMaker {
 	 *
 	 * @param type The token type.
 	 * @return The closest "standard" token type.  If a mapping is not defined
-	 *         for this language, then <code>type</code> is returned.
+	 *         for this language, then <code>type</code> is returned. The default
+	 *         implementation returns <code>type</code> always.
 	 */
-	int getClosestStandardTokenTypeForInternalType(int type);
+	default int getClosestStandardTokenTypeForInternalType(int type) {
+		return type;
+	}
 
 
 	/**
@@ -68,28 +71,37 @@ public interface TokenMaker {
 	 *        Since some <code>TokenMaker</code>s effectively have nested
 	 *        languages (such as JavaScript in HTML), this parameter tells the
 	 *        <code>TokenMaker</code> what sub-language to look at.
-	 * @return Whether curly braces denote code blocks.
+	 * @return Whether curly braces denote code blocks. The default
+	 *         implementation returns <code>false</code>.
 	 */
-	boolean getCurlyBracesDenoteCodeBlocks(int languageIndex);
+	default boolean getCurlyBracesDenoteCodeBlocks(int languageIndex) {
+		return false;
+	}
 
 
 	/**
 	 * Returns the last token on this line's type if the token is "unfinished",
-	 * or {@link Token#NULL} if it was finished.  For example, if C-style
+	 * or {@link TokenTypes#NULL} if it was finished.  For example, if C-style
 	 * syntax highlighting is being implemented, and <code>text</code>
 	 * contained a line of code that contained the beginning of a comment but
 	 * no end-comment marker ("*\/"), then this method would return
-	 * {@link Token#COMMENT_MULTILINE} for that line.  This is useful
+	 * {@link TokenTypes#COMMENT_MULTILINE} for that line.  This is useful
 	 * for doing syntax highlighting.
 	 *
 	 * @param text The line of tokens to examine.
 	 * @param initialTokenType The token type to start with (i.e., the value
 	 *        of <code>getLastTokenTypeOnLine</code> for the line before
 	 *        <code>text</code>).
-	 * @return The last token on this line's type, or {@link Token#NULL}
+	 * @return The last token on this line's type, or {@link TokenTypes#NULL}
 	 *         if the line was completed.
 	 */
-	int getLastTokenTypeOnLine(Segment text, int initialTokenType);
+	default int getLastTokenTypeOnLine(Segment text, int initialTokenType) {
+		Token t = getTokenList(text, initialTokenType, 0);
+		while (t.getNextToken() != null) {
+			t = t.getNextToken();
+		}
+		return t.getType();
+	}
 
 
 	/**
@@ -104,18 +116,23 @@ public interface TokenMaker {
 	 *         it out.  A <code>null</code> value for either means there
 	 *         is no string to add for that part.  A value of
 	 *         <code>null</code> for the array means this language
-	 *         does not support commenting/uncommenting lines.
+	 *         does not support commenting/uncommenting lines. The default
+	 *         implementation returns <code>null</code>.
 	 */
-	String[] getLineCommentStartAndEnd(int languageIndex);
+	default String[] getLineCommentStartAndEnd(int languageIndex) {
+		return null;
+	}
 
 
 	/**
 	 * Returns an action to handle "insert break" key presses (i.e. Enter).
 	 *
 	 * @return The action, or <code>null</code> if the default action should
-	 *         be used.
+	 *         be used. The default implementation returns <code>null</code>.
 	 */
-	Action getInsertBreakAction();
+	default Action getInsertBreakAction() {
+		return null;
+	}
 
 
 	/**
@@ -124,9 +141,12 @@ public interface TokenMaker {
 	 *
 	 * @param type The token type.
 	 * @return Whether tokens of this type should have "mark occurrences"
-	 *         enabled.
+	 *         enabled. The default implementation returns true only if
+	 *         the token type is <code>TokenTypes.IDENTIFIER</code>.
 	 */
-	boolean getMarkOccurrencesOfTokenType(int type);
+	default boolean getMarkOccurrencesOfTokenType(int type) {
+		return type == TokenTypes.IDENTIFIER;
+	}
 
 
 	/**
@@ -136,7 +156,7 @@ public interface TokenMaker {
 	 * is used.
 	 *
 	 * @return The occurrence marker for this language, or <code>null</code>
-	 *         for none.
+	 *         for none. The default implementation returns <code>null</code>.
 	 */
 	OccurrenceMarker getOccurrenceMarker();
 
@@ -146,9 +166,12 @@ public interface TokenMaker {
 	 * a new line inserted after that line should be indented.
 	 *
 	 * @param token The token the previous line ends with.
-	 * @return Whether the next line should be indented.
+	 * @return Whether the next line should be indented. The default implementation
+	 *         returns {@code false}.
 	 */
-	boolean getShouldIndentNextLineAfter(Token token);
+	default boolean getShouldIndentNextLineAfter(Token token) {
+		return false;
+	}
 
 
 	/**
@@ -176,7 +199,9 @@ public interface TokenMaker {
 	 * @param ch The character.
 	 * @return Whether the character could be part of an "identifier" token.
 	 */
-	boolean isIdentifierChar(int languageIndex, char ch);
+	default boolean isIdentifierChar(int languageIndex, char ch) {
+		return Character.isLetterOrDigit(ch) || ch == '_' || ch == '$';
+	}
 
 
 	/**
@@ -202,9 +227,12 @@ public interface TokenMaker {
 	/**
 	 * Returns whether this language is a markup language.
 	 *
-	 * @return Whether this language is markup.
+	 * @return Whether this language is markup. The default implementation
+	 *         returns {@code false}.
 	 */
-	boolean isMarkupLanguage();
+	default boolean isMarkupLanguage() {
+		return false;
+	}
 
 
 }

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TokenMakerBase.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TokenMakerBase.java
@@ -8,7 +8,6 @@
  */
 package org.fife.ui.rsyntaxtextarea;
 
-import javax.swing.Action;
 import javax.swing.text.Segment;
 
 
@@ -150,55 +149,6 @@ public abstract class TokenMakerBase implements TokenMaker {
 
 
 	/**
-	 * Returns the closest {@link TokenTypes "standard" token type} for a given
-	 * "internal" token type (e.g. one whose value is <code>&lt; 0</code>).<p>
-	 *
-	 * The default implementation returns <code>type</code> always, which
-	 * denotes that a mapping from internal token types to standard token types
-	 * is not defined; subclasses can override.
-	 *
-	 * @param type The token type.
-	 * @return The closest "standard" token type.
-	 */
-	@Override
-	public int getClosestStandardTokenTypeForInternalType(int type) {
-		return type;
-	}
-
-
-	/**
-	 * Returns whether this programming language uses curly braces
-	 * ('<code>{</code>' and '<code>}</code>') to denote code blocks.
-	 *
-	 * The default implementation returns <code>false</code>; subclasses can
-	 * override this method if necessary.
-	 *
-	 * @param languageIndex The language index at the offset in question.
-	 *        Since some <code>TokenMaker</code>s effectively have nested
-	 *        languages (such as JavaScript in HTML), this parameter tells the
-	 *        <code>TokenMaker</code> what sub-language to look at.
-	 * @return Whether curly braces denote code blocks.
-	 */
-	@Override
-	public boolean getCurlyBracesDenoteCodeBlocks(int languageIndex) {
-		return false;
-	}
-
-
-	/**
-	 * Returns an action to handle "insert break" key presses (i.e. Enter).
-	 * The default implementation returns <code>null</code>.  Subclasses
-	 * can override.
-	 *
-	 * @return The default implementation always returns <code>null</code>.
-	 */
-	@Override
-	public Action getInsertBreakAction() {
-		return null;
-	}
-
-
-	/**
 	 * Returns the current language index.
 	 *
 	 * @return The current language index.
@@ -209,42 +159,6 @@ public abstract class TokenMakerBase implements TokenMaker {
 	}
 
 
-	@Override
-	public int getLastTokenTypeOnLine(Segment text, int initialTokenType) {
-
-		// Last parameter doesn't matter if we're not painting.
-		Token t = getTokenList(text, initialTokenType, 0);
-
-		while (t.getNextToken()!=null) {
-			t = t.getNextToken();
-		}
-
-		return t.getType();
-
-	}
-
-
-	@Override
-	public String[] getLineCommentStartAndEnd(int languageIndex) {
-		return null;
-	}
-
-
-	/**
-	 * Returns whether tokens of the specified type should have "mark
-	 * occurrences" enabled for the current programming language.  The default
-	 * implementation returns true if <tt>type</tt> is
-	 * {@link TokenTypes#IDENTIFIER}. Subclasses can override this method to
-	 * support other token types, such as {@link TokenTypes#VARIABLE}.
-	 *
-	 * @param type The token type.
-	 * @return Whether tokens of this type should have "mark occurrences"
-	 *         enabled.
-	 */
-	@Override
-	public boolean getMarkOccurrencesOfTokenType(int type) {
-		return type==TokenTypes.IDENTIFIER;
-	}
 
 
 	/**
@@ -268,41 +182,6 @@ public abstract class TokenMakerBase implements TokenMaker {
 	}
 
 
-	/**
-	 * The default implementation returns <code>false</code> always.  Languages
-	 * that wish to better support auto-indentation can override this method.
-	 *
-	 * @param token The token the previous line ends with.
-	 * @return Whether the next line should be indented.
-	 */
-	@Override
-	public boolean getShouldIndentNextLineAfter(Token token) {
-		return false;
-	}
-
-
-	/**
-	 * Returns whether a character could be part of an "identifier" token
-	 * in a specific language.  The default implementation returns
-	 * <code>true</code> for letters, numbers, and certain symbols.
-	 */
-	@Override
-	public boolean isIdentifierChar(int languageIndex, char ch) {
-		return Character.isLetterOrDigit(ch) || ch=='_' || ch=='$';
-	}
-
-
-	/**
-	 * The default implementation returns <code>false</code> always.
-	 * Subclasses that are highlighting a markup language should override this
-	 * method to return <code>true</code>.
-	 *
-	 * @return <code>false</code> always.
-	 */
-	@Override
-	public boolean isMarkupLanguage() {
-		return false;
-	}
 
 
 	/**

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/CurlyFoldParser.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/CurlyFoldParser.java
@@ -28,7 +28,7 @@ import org.fife.ui.rsyntaxtextarea.TokenTypes;
  * This parser knows nothing about language semantics; it uses
  * <code>RSyntaxTextArea</code>'s syntax highlighting tokens to identify
  * curly braces.  By default, it looks for single-char tokens of type
- * {@link Token#SEPARATOR}, with lexemes '<code>{</code>' or '<code>}</code>'.
+ * {@link TokenTypes#SEPARATOR}, with lexemes '<code>{</code>' or '<code>}</code>'.
  * If your {@link org.fife.ui.rsyntaxtextarea.TokenMaker} uses a different token
  * type for curly braces, you should override the {@link #isLeftCurly(Token)} and
  * {@link #isRightCurly(Token)} methods with your own definitions.  In theory,


### PR DESCRIPTION
## Summary

- Nine methods in `TokenMakerBase` that returned constant or trivially-derived values (`false`, `null`, pass-through, etc.) and depended on no instance state have been moved to `default` implementations directly on the `TokenMaker` interface, following the precedent set by `getBracketPairs()`.
- `getLastTokenTypeOnLine()` is also moved: its implementation only calls `getTokenList()`, which is itself declared on `TokenMaker`, so no instance state is needed.
- The now-redundant overrides are removed from `TokenMakerBase`, along with the unused `javax.swing.Action` import.
- Javadoc `@link` cross-references corrected from `Token#CONSTANT` to `TokenTypes#CONSTANT` in `TokenMaker`, `RSyntaxUtilities`, and `CurlyFoldParser`.

## Motivation

Any class that wants to implement `TokenMaker` directly (without extending `TokenMakerBase`) previously had to re-implement all of these trivial no-ops itself. With this change, only the genuinely stateful methods (`addNullToken`, `addToken`, `getOccurrenceMarker`, `resetTokenList`, etc.) remain in `TokenMakerBase` as the right place to implement them.

## Test plan

- [x] Existing test suite passes unchanged (no behavioral change — only where the default implementation lives)
- [x] Verify a custom `TokenMaker` implementation that does not extend `TokenMakerBase` compiles and runs correctly without implementing the moved methods