### PR TITLE
refactor!: Replace INSERT_MODE/OVERWRITE_MODE int constants with a TextMode enum

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextArea.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextArea.java
@@ -361,10 +361,9 @@ public class RSyntaxTextArea extends RTextArea implements SyntaxConstants {
 	/**
 	 * Creates a new <code>RSyntaxTextArea</code>.
 	 *
-	 * @param textMode Either <code>INSERT_MODE</code> or
-	 *        <code>OVERWRITE_MODE</code>.
+	 * @param textMode The text mode.
 	 */
-	public RSyntaxTextArea(int textMode) {
+	public RSyntaxTextArea(TextMode textMode) {
 		super(textMode);
 	}
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaEditorKit.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaEditorKit.java
@@ -37,6 +37,7 @@ import org.fife.ui.rtextarea.IconRowHeader;
 import org.fife.ui.rtextarea.RTextArea;
 import org.fife.ui.rtextarea.RTextAreaEditorKit;
 import org.fife.ui.rtextarea.RecordableTextAction;
+import org.fife.ui.rtextarea.TextMode;
 
 
 /**
@@ -1778,7 +1779,7 @@ public class RSyntaxTextAreaEditorKit extends RTextAreaEditorKit {
 
 			if (!rsta.getInsertPairedCharacters() ||
 				textArea.getSelectionStart() != textArea.getSelectionEnd() ||
-				textArea.getTextMode() == RTextArea.OVERWRITE_MODE) {
+				textArea.getTextMode() == TextMode.OVERWRITE) {
 				super.actionPerformedImpl(e, textArea);
 				return;
 			}

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TextEditorPane.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TextEditorPane.java
@@ -24,6 +24,7 @@ import javax.swing.text.Document;
 import org.fife.io.UnicodeReader;
 import org.fife.io.UnicodeWriter;
 import org.fife.ui.rtextarea.RTextAreaEditorKit;
+import org.fife.ui.rtextarea.TextMode;
 
 /**
  * An extension of {@link org.fife.ui.rsyntaxtextarea.RSyntaxTextArea}
@@ -131,17 +132,16 @@ public class TextEditorPane extends RSyntaxTextArea implements
 	 * Constructor.  The file will be given a default name.
 	 */
 	public TextEditorPane() {
-		this(INSERT_MODE);
+		this(TextMode.INSERT);
 	}
 
 
 	/**
 	 * Constructor.  The file will be given a default name.
 	 *
-	 * @param textMode Either <code>INSERT_MODE</code> or
-	 *        <code>OVERWRITE_MODE</code>.
+	 * @param textMode The text mode.
 	 */
-	public TextEditorPane(int textMode) {
+	public TextEditorPane(TextMode textMode) {
 		this(textMode, false);
 	}
 
@@ -150,11 +150,10 @@ public class TextEditorPane extends RSyntaxTextArea implements
 	 * Creates a new <code>TextEditorPane</code>.  The file will be given
 	 * a default name.
 	 *
-	 * @param textMode Either <code>INSERT_MODE</code> or
-	 *        <code>OVERWRITE_MODE</code>.
+	 * @param textMode The text mode.
 	 * @param wordWrapEnabled Whether to use word wrap in this pane.
 	 */
-	public TextEditorPane(int textMode, boolean wordWrapEnabled) {
+	public TextEditorPane(TextMode textMode, boolean wordWrapEnabled) {
 		super(textMode);
 		setLineWrap(wordWrapEnabled);
 		try {
@@ -168,8 +167,7 @@ public class TextEditorPane extends RSyntaxTextArea implements
 	/**
 	 * Creates a new <code>TextEditorPane</code>.
 	 *
-	 * @param textMode Either <code>INSERT_MODE</code> or
-	 *        <code>OVERWRITE_MODE</code>.
+	 * @param textMode The text mode.
 	 * @param wordWrapEnabled Whether to use word wrap in this pane.
 	 * @param loc The location of the text file being edited.  If this value
 	 *        is <code>null</code>, a file named "Untitled.txt" in the current
@@ -178,7 +176,7 @@ public class TextEditorPane extends RSyntaxTextArea implements
 	 *         <code>loc</code>.  This of course won't happen if
 	 *         <code>loc</code> is <code>null</code>.
 	 */
-	public TextEditorPane(int textMode, boolean wordWrapEnabled,
+	public TextEditorPane(TextMode textMode, boolean wordWrapEnabled,
 							FileLocation loc) throws IOException {
 		this(textMode, wordWrapEnabled, loc, null);
 	}
@@ -187,8 +185,7 @@ public class TextEditorPane extends RSyntaxTextArea implements
 	/**
 	 * Creates a new <code>TextEditorPane</code>.
 	 *
-	 * @param textMode Either <code>INSERT_MODE</code> or
-	 *        <code>OVERWRITE_MODE</code>.
+	 * @param textMode The text mode.
 	 * @param wordWrapEnabled Whether to use word wrap in this pane.
 	 * @param loc The location of the text file being edited.  If this value
 	 *        is <code>null</code>, a file named "Untitled.txt" in the current
@@ -201,7 +198,7 @@ public class TextEditorPane extends RSyntaxTextArea implements
 	 *         <code>loc</code>.  This of course won't happen if
 	 *         <code>loc</code> is <code>null</code>.
 	 */
-	public TextEditorPane(int textMode, boolean wordWrapEnabled,
+	public TextEditorPane(TextMode textMode, boolean wordWrapEnabled,
 				FileLocation loc, String defaultEnc) throws IOException {
 		super(textMode);
 		setLineWrap(wordWrapEnabled);

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TokenMakerBase.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TokenMakerBase.java
@@ -159,8 +159,6 @@ public abstract class TokenMakerBase implements TokenMaker {
 	}
 
 
-
-
 	/**
 	 * Returns whether no tokens have been identified yet.  Should only be
 	 * called by subclasses that need to identify tokens depending on whether
@@ -180,8 +178,6 @@ public abstract class TokenMakerBase implements TokenMaker {
 		}
 		return occurrenceMarker;
 	}
-
-
 
 
 	/**

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextArea.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextArea.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Reader;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
@@ -65,20 +66,6 @@ import org.fife.ui.rtextarea.Macro.MacroRecord;
 public class RTextArea extends RTextAreaBase implements Printable {
 
 	/**
-	 * Constant representing insert mode.
-	 *
-	 * @see #setCaretStyle(int, CaretStyle)
-	 */
-	public static final int INSERT_MODE = 0;
-
-	/**
-	 * Constant representing overwrite mode.
-	 *
-	 * @see #setCaretStyle(int, CaretStyle)
-	 */
-	public static final int OVERWRITE_MODE = 1;
-
-	/**
 	 * The property fired when the "mark all" color changes.
 	 */
 	public static final String MARK_ALL_COLOR_PROPERTY = "RTA.markAllColor";
@@ -110,10 +97,7 @@ public class RTextArea extends RTextAreaBase implements Printable {
 
 	private static final Color DEFAULT_MARK_ALL_COLOR = new Color(0xffc800);
 
-	/**
-	 * The current text mode ({@link #INSERT_MODE} or {@link #OVERWRITE_MODE}).
-	 */
-	private int textMode;
+	private TextMode textMode;
 
 	// All macros are shared across all RTextAreas.
 	private static boolean recordingMacro;		// Whether we're recording a macro.
@@ -166,7 +150,7 @@ public class RTextArea extends RTextAreaBase implements Printable {
 
 	private boolean markAllOnOccurrenceSearches;
 
-	private CaretStyle[] carets; // Index 0=>insert caret, 1=>overwrite.
+	private EnumMap<TextMode, CaretStyle> carets;
 
 	private static final String MSG	= "org.fife.ui.rtextarea.RTextArea";
 
@@ -243,10 +227,9 @@ public class RTextArea extends RTextAreaBase implements Printable {
 	/**
 	 * Creates a new <code>RTextArea</code>.
 	 *
-	 * @param textMode Either <code>INSERT_MODE</code> or
-	 *        <code>OVERWRITE_MODE</code>.
+	 * @param textMode The text mode.
 	 */
-	public RTextArea(int textMode) {
+	public RTextArea(TextMode textMode) {
 		setTextMode(textMode);
 	}
 
@@ -819,10 +802,10 @@ public class RTextArea extends RTextAreaBase implements Printable {
 	/**
 	 * Returns the text mode this editor pane is currently in.
 	 *
-	 * @return Either {@link #INSERT_MODE} or {@link #OVERWRITE_MODE}.
-	 * @see #setTextMode(int)
+	 * @return The text mode.
+	 * @see #setTextMode(TextMode)
 	 */
-	public final int getTextMode() {
+	public final TextMode getTextMode() {
 		return textMode;
 	}
 
@@ -898,12 +881,12 @@ public class RTextArea extends RTextAreaBase implements Printable {
 		markAllHighlightPainter = new SmartHighlightPainter(
 										markAllHighlightColor);
 		setMarkAllHighlightColor(markAllHighlightColor);
-		carets = new CaretStyle[2];
-		setCaretStyle(INSERT_MODE, CaretStyle.THICK_VERTICAL_LINE_STYLE);
-		setCaretStyle(OVERWRITE_MODE, CaretStyle.BLOCK_STYLE);
+		carets = new EnumMap<>(TextMode.class);
+		setCaretStyle(TextMode.INSERT, CaretStyle.THICK_VERTICAL_LINE_STYLE);
+		setCaretStyle(TextMode.OVERWRITE, CaretStyle.BLOCK_STYLE);
 		setDragEnabled(!GraphicsEnvironment.isHeadless());
 
-		setTextMode(INSERT_MODE); // Carets array must be created first!
+		setTextMode(TextMode.INSERT); // Carets map must be populated first!
 		setMarkAllOnOccurrenceSearches(true);
 
 		// Fix the odd "Ctrl+H <=> Backspace" Java behavior.
@@ -1237,7 +1220,7 @@ public class RTextArea extends RTextAreaBase implements Printable {
 		}
 
 		// If the user wants to overwrite text...
-		if (textMode==OVERWRITE_MODE && !"\n".equals(text)) {
+		if (textMode==TextMode.OVERWRITE && !"\n".equals(text)) {
 
 			Caret caret = getCaret();
 			int caretPos = caret.getDot();
@@ -1267,7 +1250,7 @@ public class RTextArea extends RTextAreaBase implements Printable {
 				ble.printStackTrace();
 			}
 
-		} // End of if (textMode==OVERWRITE_MODE).
+		} // End of if (textMode==TextMode.OVERWRITE).
 
 		// Now, actually do the inserting/replacing.  Our undoManager will
 		// take care of remembering the remove/insert as atomic if we are in
@@ -1439,7 +1422,7 @@ public class RTextArea extends RTextAreaBase implements Printable {
 		super.setCaret(caret);
 		if (carets!=null && // Called by setUI() before carets is initialized
 				caret instanceof ConfigurableCaret) {
-			((ConfigurableCaret)caret).setStyle(carets[getTextMode()]);
+			((ConfigurableCaret)caret).setStyle(carets.get(getTextMode()));
 		}
 	}
 
@@ -1447,15 +1430,15 @@ public class RTextArea extends RTextAreaBase implements Printable {
 	/**
 	 * Sets the style of caret used when in insert or overwrite mode.
 	 *
-	 * @param mode Either {@link #INSERT_MODE} or {@link #OVERWRITE_MODE}.
+	 * @param mode The text mode.
 	 * @param style The style for the caret.
 	 * @see ConfigurableCaret
 	 */
-	public void setCaretStyle(int mode, CaretStyle style) {
+	public void setCaretStyle(TextMode mode, CaretStyle style) {
 		if (style==null) {
 			style = CaretStyle.THICK_VERTICAL_LINE_STYLE;
 		}
-		carets[mode] = style;
+		carets.put(mode, style);
 		if (mode==getTextMode() && getCaret() instanceof ConfigurableCaret) {
 			// Will repaint the caret if necessary.
 			((ConfigurableCaret)getCaret()).setStyle(style);
@@ -1618,19 +1601,15 @@ public class RTextArea extends RTextAreaBase implements Printable {
 	 * automatically updated to render itself appropriately for the new text
 	 * mode.
 	 *
-	 * @param mode Either {@link #INSERT_MODE} or {@link #OVERWRITE_MODE}.
+	 * @param mode The text mode.
 	 * @see #getTextMode()
 	 */
-	public void setTextMode(int mode) {
-
-		if (mode!=INSERT_MODE && mode!=OVERWRITE_MODE) {
-			mode = INSERT_MODE;
-		}
+	public void setTextMode(TextMode mode) {
 
 		if (textMode != mode) {
 			Caret caret = getCaret();
 			if (caret instanceof ConfigurableCaret) {
-				((ConfigurableCaret)caret).setStyle(carets[mode]);
+				((ConfigurableCaret)caret).setStyle(carets.get(mode));
 			}
 			textMode = mode;
 			// Prevent the caret from blinking while e.g. holding down the

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextAreaEditorKit.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextAreaEditorKit.java
@@ -2645,12 +2645,11 @@ public class RTextAreaEditorKit extends DefaultEditorKit {
 
 		@Override
 		public void actionPerformedImpl(ActionEvent e, RTextArea textArea) {
-			int textMode = textArea.getTextMode();
-			if (textMode==RTextArea.INSERT_MODE) {
-				textArea.setTextMode(RTextArea.OVERWRITE_MODE);
+			if (textArea.getTextMode() == TextMode.INSERT) {
+				textArea.setTextMode(TextMode.OVERWRITE);
 			}
 			else {
-				textArea.setTextMode(RTextArea.INSERT_MODE);
+				textArea.setTextMode(TextMode.INSERT);
 			}
 		}
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/TextMode.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/TextMode.java
@@ -1,0 +1,23 @@
+/*
+ * This library is distributed under a modified BSD license.  See the included
+ * LICENSE file for details.
+ */
+package org.fife.ui.rtextarea;
+
+
+/**
+ * The text entry mode for an {@link RTextArea}.
+ *
+ * @author Robert Futrell
+ * @version 1.0
+ * @see RTextArea#getTextMode()
+ * @see RTextArea#setTextMode(TextMode)
+ */
+public enum TextMode {
+
+	/** Characters typed are inserted at the caret position. */
+	INSERT,
+
+	/** Characters typed overwrite the character at the caret position. */
+	OVERWRITE,
+}

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaEditorKitInsertQuoteActionTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaEditorKitInsertQuoteActionTest.java
@@ -6,6 +6,7 @@ package org.fife.ui.rsyntaxtextarea;
 
 import org.fife.ui.SwingRunnerExtension;
 import org.fife.ui.rtextarea.RecordableTextAction;
+import org.fife.ui.rtextarea.TextMode;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -111,7 +112,7 @@ class RSyntaxTextAreaEditorKitInsertQuoteActionTest extends AbstractRSyntaxTextA
 		String origContent = "one word here";
 
 		RSyntaxTextArea textArea = createTextArea(SyntaxConstants.SYNTAX_STYLE_JAVA, origContent);
-		textArea.setTextMode(RSyntaxTextArea.OVERWRITE_MODE);
+		textArea.setTextMode(TextMode.OVERWRITE);
 		textArea.setCaretPosition(origContent.indexOf("word"));
 
 		RecordableTextAction a = new RSyntaxTextAreaEditorKit.InsertQuoteAction("test",

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/TextEditorPaneTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/TextEditorPaneTest.java
@@ -11,6 +11,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnsupportedCharsetException;
 
 import org.fife.ui.SwingRunnerExtension;
+import org.fife.ui.rtextarea.TextMode;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,15 +31,15 @@ class TextEditorPaneTest {
 	@Test
 	void testConstructor_zeroArg() {
 		TextEditorPane textArea = new TextEditorPane();
-		Assertions.assertEquals(TextEditorPane.INSERT_MODE, textArea.getTextMode());
+		Assertions.assertEquals(TextMode.INSERT, textArea.getTextMode());
 		Assertions.assertFalse(textArea.getLineWrap());
 	}
 
 
 	@Test
 	void testConstructor_oneArg() {
-		TextEditorPane textArea = new TextEditorPane(TextEditorPane.OVERWRITE_MODE);
-		Assertions.assertEquals(TextEditorPane.OVERWRITE_MODE, textArea.getTextMode());
+		TextEditorPane textArea = new TextEditorPane(TextMode.OVERWRITE);
+		Assertions.assertEquals(TextMode.OVERWRITE, textArea.getTextMode());
 		Assertions.assertFalse(textArea.getLineWrap());
 	}
 
@@ -47,7 +48,7 @@ class TextEditorPaneTest {
 	void testGetFileName_localFile() throws IOException {
 		File file = createTempFile();
 		FileLocation loc = FileLocation.create(file);
-		TextEditorPane textArea = new TextEditorPane(TextEditorPane.INSERT_MODE, false, loc);
+		TextEditorPane textArea = new TextEditorPane(TextMode.INSERT, false, loc);
 		Assertions.assertEquals(file.getName(), textArea.getFileName());
 	}
 
@@ -58,7 +59,7 @@ class TextEditorPaneTest {
 		FileLocation spyLoc = Mockito.spy(loc);
 		InputStream testInputStream = new ByteArrayInputStream(new byte[0]);
 		Mockito.doReturn(testInputStream).when(spyLoc).getInputStream();
-		TextEditorPane textArea = new TextEditorPane(TextEditorPane.INSERT_MODE, false, spyLoc);
+		TextEditorPane textArea = new TextEditorPane(TextMode.INSERT, false, spyLoc);
 		Assertions.assertEquals(loc.getFileFullPath(), textArea.getFileFullPath());
 	}
 
@@ -67,7 +68,7 @@ class TextEditorPaneTest {
 	void testGetLastSaveOrLoadTime_localFileThatExists() throws IOException {
 		File tempFile = createTempFile();
 		FileLocation loc = FileLocation.create(tempFile);
-		TextEditorPane textArea = new TextEditorPane(TextEditorPane.INSERT_MODE, false, loc);
+		TextEditorPane textArea = new TextEditorPane(TextMode.INSERT, false, loc);
 		Assertions.assertEquals(tempFile.lastModified(), textArea.getLastSaveOrLoadTime());
 	}
 
@@ -84,7 +85,7 @@ class TextEditorPaneTest {
 		FileLocation spyLoc = Mockito.spy(loc);
 		InputStream testInputStream = new ByteArrayInputStream(new byte[0]);
 		Mockito.doReturn(testInputStream).when(spyLoc).getInputStream();
-		TextEditorPane textArea = new TextEditorPane(TextEditorPane.INSERT_MODE, false, spyLoc);
+		TextEditorPane textArea = new TextEditorPane(TextMode.INSERT, false, spyLoc);
 		Assertions.assertEquals(TextEditorPane.LAST_MODIFIED_UNKNOWN, textArea.getLastSaveOrLoadTime());
 	}
 
@@ -137,7 +138,7 @@ class TextEditorPaneTest {
 	void testIsLocalAndExists() throws IOException {
 		File file = createTempFile();
 		FileLocation loc = FileLocation.create(file);
-		TextEditorPane textArea = new TextEditorPane(TextEditorPane.INSERT_MODE, false, loc);
+		TextEditorPane textArea = new TextEditorPane(TextMode.INSERT, false, loc);
 		Assertions.assertTrue(textArea.isLocalAndExists());
 		Assertions.assertTrue(file.delete());
 		Assertions.assertFalse(textArea.isLocalAndExists());
@@ -154,7 +155,7 @@ class TextEditorPaneTest {
 		// Simulate the file's "last modified" timestamp changing
 		Mockito.doReturn(100L, 150L).when(spyLoc).getActualLastModified();
 
-		TextEditorPane textArea = new TextEditorPane(TextEditorPane.INSERT_MODE, false, loc);
+		TextEditorPane textArea = new TextEditorPane(TextMode.INSERT, false, loc);
 		Assertions.assertFalse(textArea.isModifiedOutsideEditor());
 
 		try (PrintWriter w = new PrintWriter(file)) {
@@ -346,7 +347,7 @@ class TextEditorPaneTest {
 		InputStream testInputStream = new ByteArrayInputStream("Hello world".getBytes(StandardCharsets.UTF_8));
 		Mockito.doReturn(testInputStream).when(spyLoc).getInputStream();
 
-		TextEditorPane textArea = new TextEditorPane(TextEditorPane.INSERT_MODE, false, spyLoc);
+		TextEditorPane textArea = new TextEditorPane(TextMode.INSERT, false, spyLoc);
 		Assertions.assertEquals("Hello world", textArea.getText());
 
 		// Modify the text area's contents, then reload

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/RTextAreaEditorKitToggleTextModeActionTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/RTextAreaEditorKitToggleTextModeActionTest.java
@@ -26,16 +26,16 @@ class RTextAreaEditorKitToggleTextModeActionTest {
 	void testActionPerformedImpl() {
 
 		RTextArea textArea = new RTextArea("line 1\nline 2\nline 3");
-		Assertions.assertEquals(RTextArea.INSERT_MODE, textArea.getTextMode());
+		Assertions.assertEquals(TextMode.INSERT, textArea.getTextMode());
 
 		// Toggle to overwrite
 		ActionEvent e = new ActionEvent(textArea, 0, "command");
 		new RTextAreaEditorKit.ToggleTextModeAction().actionPerformedImpl(e, textArea);
-		Assertions.assertEquals(RTextArea.OVERWRITE_MODE, textArea.getTextMode());
+		Assertions.assertEquals(TextMode.OVERWRITE, textArea.getTextMode());
 
 		// And back to insert
 		new RTextAreaEditorKit.ToggleTextModeAction().actionPerformedImpl(e, textArea);
-		Assertions.assertEquals(RTextArea.INSERT_MODE, textArea.getTextMode());
+		Assertions.assertEquals(TextMode.INSERT, textArea.getTextMode());
 	}
 
 

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/RTextAreaTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/RTextAreaTest.java
@@ -319,7 +319,7 @@ class RTextAreaTest {
 	void testReplaceSelection_tabsEmulatedWithWhiteSpace_overwriteMode() {
 		RTextArea textArea = new RTextArea("line 1\nline 2");
 		textArea.setTabsEmulated(true);
-		textArea.setTextMode(RTextArea.OVERWRITE_MODE);
+		textArea.setTextMode(TextMode.OVERWRITE);
 		textArea.setTabSize(4);
 		textArea.setCaretPosition(0);
 		textArea.replaceSelection("\t");
@@ -351,7 +351,7 @@ class RTextAreaTest {
 	@Test
 	void testSetCaretStyle_nullDoesntThrowException() {
 		RTextArea textArea = new RTextArea();
-		textArea.setCaretStyle(RTextArea.INSERT_MODE, null);
+		textArea.setCaretStyle(TextMode.INSERT, null);
 	}
 
 
@@ -373,11 +373,4 @@ class RTextAreaTest {
 	}
 
 
-	@Test
-	void setTextMode_invalidMode() {
-		RTextArea textArea = new RTextArea();
-		Assertions.assertEquals(RTextArea.INSERT_MODE, textArea.getTextMode());
-		textArea.setTextMode(-7);
-		Assertions.assertEquals(RTextArea.INSERT_MODE, textArea.getTextMode());
-	}
 }


### PR DESCRIPTION
## Summary

- Introduces `TextMode` enum (`INSERT`, `OVERWRITE`) in the `org.fife.ui.rtextarea` package, replacing the `public static final int INSERT_MODE = 0` and `OVERWRITE_MODE = 1` constants on `RTextArea`
- `RTextArea.getTextMode()` now returns `TextMode`; `setTextMode()` and `setCaretStyle()` now accept `TextMode` — the invalid-value guard in `setTextMode(int)` is removed since the enum makes it impossible to pass a bad value
- The internal `CaretStyle[]` array indexed on those int values is replaced with `EnumMap<TextMode, CaretStyle>`, removing the implicit coupling between the enum ordinal and the array position
- `RSyntaxTextArea`, `TextEditorPane`, `RTextAreaEditorKit`, and `RSyntaxTextAreaEditorKit` updated throughout; all tests updated accordingly

## Notes

This is a **breaking API change** for any consumers that reference `RTextArea.INSERT_MODE` / `RTextArea.OVERWRITE_MODE` as `int` literals, or that call `setTextMode(int)` / `setCaretStyle(int, CaretStyle)`. The migration is mechanical: replace `RTextArea.INSERT_MODE` → `TextMode.INSERT` and `RTextArea.OVERWRITE_MODE` → `TextMode.OVERWRITE`.

## Test plan

- [x] `./gradlew :RSyntaxTextArea:test` passes
- [x] Toggle insert/overwrite mode via the Insert key works as before
- [x] Caret style changes correctly when switching modes