### PR TITLE
refactor!: Replace OS_* int constants with an OS enum

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/FileTypeUtil.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/FileTypeUtil.java
@@ -113,7 +113,7 @@ public final class FileTypeUtil implements SyntaxConstants {
 	 */
 	public static Pattern fileFilterToPattern(String fileFilter) {
 		String pattern = fileFilterToPatternImpl(fileFilter);
-		int flags = RSyntaxUtilities.isOsCaseSensitive() ? 0 : (Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
+		int flags = OS.get().isCaseSensitive() ? 0 : (Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
 		return Pattern.compile(pattern, flags);
 	}
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/OS.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/OS.java
@@ -1,0 +1,88 @@
+/*
+ * This library is distributed under a modified BSD license.  See the included
+ * LICENSE file for details.
+ */
+package org.fife.ui.rsyntaxtextarea;
+
+
+/**
+ * The operating system the JVM is running on.
+ *
+ * @author Robert Futrell
+ * @version 1.0
+ */
+public enum OS {
+
+	/**
+	 * Any Windows variant.
+	 */
+	WINDOWS(false),
+
+	/**
+	 * Any version of OS X.
+	 */
+	MAC_OS_X(false),
+
+	/**
+	 * Any Linux variant.
+	 */
+	LINUX(true),
+
+	/**
+	 * Any Operating System that does not match any of the other values in
+	 * this enum, such as z/OS.
+	 */
+	OTHER(true);
+
+	private final boolean caseSensitive;
+
+	private static OS os;
+
+
+	OS(boolean caseSensitive) {
+		this.caseSensitive = caseSensitive;
+	}
+
+
+	/**
+	 * Returns the current OS.  This can be handy for special-case situations
+	 * such as Mac OS X (special application registration) or Windows (allow
+	 * mixed case, etc.).
+	 *
+	 * @return The OS we're running on.
+	 */
+	public static OS get() {
+		return os;
+	}
+
+
+	/**
+	 * Returns whether the OS is case-sensitive.
+	 *
+	 * @return Whether the OS is case-sensitive.
+	 */
+	public boolean isCaseSensitive() {
+		return caseSensitive;
+	}
+
+
+	static {
+		os = OTHER;
+		String osName = System.getProperty("os.name");
+		if (osName!=null) { // Should always be true.
+			osName = osName.toLowerCase();
+			if (osName.contains("windows")) {
+				os = WINDOWS;
+			}
+			else if (osName.contains("mac os x")) {
+				os = MAC_OS_X;
+			}
+			else if (osName.contains("linux")) {
+				os = LINUX;
+			}
+			else {
+				os = OTHER;
+			}
+		}
+	}
+}

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextArea.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextArea.java
@@ -1851,7 +1851,7 @@ public class RSyntaxTextArea extends RTextArea implements SyntaxConstants {
 		// repeat for some reason, so this method gets called every 1 second
 		// or so.  We short-circuit that since some ToolTipManagers may do
 		// expensive calculations (e.g. language supports).
-		if (RSyntaxUtilities.getOS()==RSyntaxUtilities.OS_MAC_OSX) {
+		if (OS.get() == OS.MAC_OS_X) {
 			Point newLoc = e.getPoint();
 			if (newLoc!=null && newLoc.equals(cachedTipLoc)) {
 				return cachedTip;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaDefaultInputMap.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaDefaultInputMap.java
@@ -51,8 +51,8 @@ public class RSyntaxTextAreaDefaultInputMap extends RTADefaultInputMap {
 		put(KeyStroke.getKeyStroke('`'),							RSyntaxTextAreaEditorKit.rstaBacktickAction);
 
 		put(KeyStroke.getKeyStroke('/'), 							RSyntaxTextAreaEditorKit.rstaCloseMarkupTagAction);
-		int os = RSyntaxUtilities.getOS();
-		if (os==RSyntaxUtilities.OS_WINDOWS || os==RSyntaxUtilities.OS_MAC_OSX) {
+		OS os = OS.get();
+		if (os == OS.WINDOWS || os == OS.MAC_OS_X) {
 			// *nix causes trouble with CloseMarkupTagAction and ToggleCommentAction.
 			// It triggers both KEY_PRESSED ctrl+'/' and KEY_TYPED '/' events when the
 			// user presses ctrl+'/', but Windows and OS X do not.  If we try to "move"

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxUtilities.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxUtilities.java
@@ -49,33 +49,10 @@ import org.fife.util.SwingUtils;
 public final class RSyntaxUtilities implements SwingConstants {
 
 	/**
-	 * Integer constant representing a Windows-variant OS.
-	 */
-	public static final int OS_WINDOWS			= 1;
-
-	/**
-	 * Integer constant representing Mac OS X.
-	 */
-	public static final int OS_MAC_OSX			= 2;
-
-	/**
-	 * Integer constant representing Linux.
-	 */
-	public static final int OS_LINUX			= 4;
-
-	/**
-	 * Integer constant representing an "unknown" OS.  99.99% of the
-	 * time, this means some UNIX variant (AIX, SunOS, etc.).
-	 */
-	public static final int OS_OTHER			= 8;
-
-	/**
 	 * Used for the color of hyperlinks when a LookAndFeel uses light text
 	 * against a dark background.
 	 */
 	private static final Color LIGHT_HYPERLINK_FG = new Color(0xd8ffff);
-
-	private static final int OS = getOSImpl();
 
 	//private static final int DIGIT_MASK			= 1;
 	private static final int LETTER_MASK			= 2;
@@ -757,48 +734,6 @@ public final class RSyntaxUtilities implements SwingConstants {
 
 
 	/**
-	 * Returns an integer constant representing the OS.  This can be handy for
-	 * special case situations such as Mac OS-X (special application
-	 * registration) or Windows (allow mixed case, etc.).
-	 *
-	 * @return An integer constant representing the OS.
-	 * @see #isOsCaseSensitive()
-	 */
-	public static int getOS() {
-		return OS;
-	}
-
-
-	/**
-	 * Returns an integer constant representing the OS.  This can be handy for
-	 * special case situations such as Mac OS-X (special application
-	 * registration) or Windows (allow mixed case, etc.).
-	 *
-	 * @return An integer constant representing the OS.
-	 */
-	private static int getOSImpl() {
-		int os = OS_OTHER;
-		String osName = System.getProperty("os.name");
-		if (osName!=null) { // Should always be true.
-			osName = osName.toLowerCase();
-			if (osName.contains("windows")) {
-				os = OS_WINDOWS;
-			}
-			else if (osName.contains("mac os x")) {
-				os = OS_MAC_OSX;
-			}
-			else if (osName.contains("linux")) {
-				os = OS_LINUX;
-			}
-			else {
-				os = OS_OTHER;
-			}
-		}
-		return os;
-	}
-
-
-	/**
 	 * Returns the flags necessary to create a {@link Pattern}.
 	 *
 	 * @param matchCase Whether the pattern should be case-sensitive.
@@ -1179,17 +1114,6 @@ return c.getLineStartOffset(line);
 	 */
 	public static boolean isNonWordChar(Token t) {
 		return t.length()==1 && !RSyntaxUtilities.isLetter(t.charAt(0));
-	}
-
-
-	/**
-	 * Returns whether the OS is case-sensitive.
-	 *
-	 * @return Whether the OS is case-sensitive.
-	 * @see #getOS()
-	 */
-	public static boolean isOsCaseSensitive() {
-		return OS != RSyntaxUtilities.OS_WINDOWS && OS != RSyntaxUtilities.OS_MAC_OSX;
 	}
 
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/FontUtil.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/FontUtil.java
@@ -4,7 +4,7 @@
  */
 package org.fife.ui.rtextarea;
 
-import org.fife.ui.rsyntaxtextarea.RSyntaxUtilities;
+import org.fife.ui.rsyntaxtextarea.OS;
 
 import javax.swing.text.StyleContext;
 import java.awt.*;
@@ -14,7 +14,8 @@ import java.util.Map;
 
 
 /**
- * Utility methods related to fonts.
+ * Utility methods related to fonts. Using these methods is preferred over the {@code new Font()} constructor as they
+ * ensure fallback fonts are properly configured for glyphs unsupported by the primary font.
  *
  * @author Robert Futrell
  * @version 1.0
@@ -95,15 +96,15 @@ public final class FontUtil {
 	 */
 	public static Font getDefaultMonospacedFont() {
 
-		int os = RSyntaxUtilities.getOS();
+		OS os = OS.get();
 
-		if (os == RSyntaxUtilities.OS_MAC_OSX) {
+		if (os == OS.MAC_OS_X) {
 			return getDefaultMonospaceFontMacOS();
 		}
-		else if (os == RSyntaxUtilities.OS_WINDOWS) {
+		else if (os == OS.WINDOWS) {
 			return getDefaultMonospaceFontWindows();
 		}
-		else if (os == RSyntaxUtilities.OS_LINUX) {
+		else if (os == OS.LINUX) {
 			return getDefaultMonospaceFontLinux();
 		}
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextArea.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextArea.java
@@ -1194,7 +1194,7 @@ public class RTextArea extends RTextAreaBase implements Printable {
 	/**
 	 * This method overrides <code>JTextComponent</code>'s
 	 * <code>replaceSelection</code>, so that if <code>textMode</code> is
-	 * {@link #OVERWRITE_MODE}, it actually overwrites.
+	 * {@code OVERWRITE_MODE}, it actually overwrites.
 	 *
 	 * @param text The content to replace the selection with.
 	 */
@@ -1415,7 +1415,7 @@ public class RTextArea extends RTextAreaBase implements Printable {
 	 * user toggles between insert and overwrite modes.
 	 *
 	 * @param caret The caret to use.
-	 * @see #setCaretStyle(int, CaretStyle)
+	 * @see #setCaretStyle(TextMode, CaretStyle)
 	 */
 	@Override
 	public void setCaret(Caret caret) {

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/OSTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/OSTest.java
@@ -1,0 +1,59 @@
+/*
+ * This library is distributed under a modified BSD license.  See the included
+ * LICENSE file for details.
+ */
+package org.fife.ui.rsyntaxtextarea;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+
+/**
+ * Unit tests for the {@code OS} enum.
+ */
+class OSTest {
+
+	@Test
+	void testGet_notNull() {
+		Assertions.assertNotNull(OS.get());
+	}
+
+	@Test
+	void testGet_matchesSystemProperty() {
+		String osName = System.getProperty("os.name");
+		OS expected = OS.OTHER;
+		if (osName != null) {
+			osName = osName.toLowerCase();
+			if (osName.contains("windows")) {
+				expected = OS.WINDOWS;
+			}
+			else if (osName.contains("mac os x")) {
+				expected = OS.MAC_OS_X;
+			}
+			else if (osName.contains("linux")) {
+				expected = OS.LINUX;
+			}
+		}
+		Assertions.assertEquals(expected, OS.get());
+	}
+
+	@Test
+	void testIsCaseSensitive_windows() {
+		Assertions.assertFalse(OS.WINDOWS.isCaseSensitive());
+	}
+
+	@Test
+	void testIsCaseSensitive_macOsX() {
+		Assertions.assertFalse(OS.MAC_OS_X.isCaseSensitive());
+	}
+
+	@Test
+	void testIsCaseSensitive_linux() {
+		Assertions.assertTrue(OS.LINUX.isCaseSensitive());
+	}
+
+	@Test
+	void testIsCaseSensitive_other() {
+		Assertions.assertTrue(OS.OTHER.isCaseSensitive());
+	}
+}

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxUtilitiesTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxUtilitiesTest.java
@@ -342,15 +342,6 @@ class RSyntaxUtilitiesTest extends AbstractRSyntaxTextAreaTest {
 
 
 	@Test
-	void testIsOSCaseSensitive() {
-		int os = RSyntaxUtilities.getOS();
-		boolean expected = !(os == RSyntaxUtilities.OS_MAC_OSX ||
-			os == RSyntaxUtilities.OS_WINDOWS);
-		Assertions.assertEquals(expected, RSyntaxUtilities.isOsCaseSensitive());
-	}
-
-
-	@Test
 	void testPossiblyRepaintGutter() {
 		RSyntaxTextArea textArea = createTextArea();
 		new RTextScrollPane(textArea);

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/FontUtilTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/FontUtilTest.java
@@ -5,7 +5,7 @@
 package org.fife.ui.rtextarea;
 
 import org.fife.ui.SwingRunnerExtension;
-import org.fife.ui.rsyntaxtextarea.RSyntaxUtilities;
+import org.fife.ui.rsyntaxtextarea.OS;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -83,8 +83,8 @@ class FontUtilTest {
 
 	@Test
 	void testGetDefaultMonospacedFont_linux() {
-		try (MockedStatic<RSyntaxUtilities> utils = Mockito.mockStatic(RSyntaxUtilities.class)) {
-			utils.when(RSyntaxUtilities::getOS).thenReturn(RSyntaxUtilities.OS_LINUX);
+		try (MockedStatic<OS> utils = Mockito.mockStatic(OS.class)) {
+			utils.when(OS::get).thenReturn(OS.LINUX);
 			// Can't verify too precisely since the test can run on any OS
 			Assertions.assertNotNull(FontUtil.getDefaultMonospacedFont());
 		}
@@ -93,8 +93,8 @@ class FontUtilTest {
 
 	@Test
 	void testGetDefaultMonospacedFont_macOS() {
-		try (MockedStatic<RSyntaxUtilities> utils = Mockito.mockStatic(RSyntaxUtilities.class)) {
-			utils.when(RSyntaxUtilities::getOS).thenReturn(RSyntaxUtilities.OS_MAC_OSX);
+		try (MockedStatic<OS> utils = Mockito.mockStatic(OS.class)) {
+			utils.when(OS::get).thenReturn(OS.MAC_OS_X);
 			// Can't verify too precisely since the test can run on any OS
 			Assertions.assertNotNull(FontUtil.getDefaultMonospacedFont());
 		}
@@ -103,8 +103,8 @@ class FontUtilTest {
 
 	@Test
 	void testGetDefaultMonospacedFont_other() {
-		try (MockedStatic<RSyntaxUtilities> utils = Mockito.mockStatic(RSyntaxUtilities.class)) {
-			utils.when(RSyntaxUtilities::getOS).thenReturn(RSyntaxUtilities.OS_OTHER);
+		try (MockedStatic<OS> utils = Mockito.mockStatic(OS.class)) {
+			utils.when(OS::get).thenReturn(OS.OTHER);
 			// Can't verify too precisely since the test can run on any OS
 			Assertions.assertNotNull(FontUtil.getDefaultMonospacedFont());
 		}
@@ -113,8 +113,8 @@ class FontUtilTest {
 
 	@Test
 	void testGetDefaultMonospacedFont_windows() {
-		try (MockedStatic<RSyntaxUtilities> utils = Mockito.mockStatic(RSyntaxUtilities.class)) {
-			utils.when(RSyntaxUtilities::getOS).thenReturn(RSyntaxUtilities.OS_WINDOWS);
+		try (MockedStatic<OS> utils = Mockito.mockStatic(OS.class)) {
+			utils.when(OS::get).thenReturn(OS.WINDOWS);
 			// Can't verify too precisely since the test can run on any OS
 			Assertions.assertNotNull(FontUtil.getDefaultMonospacedFont());
 		}


### PR DESCRIPTION
This PR introduces an `OS` enum (`WINDOWS`, `MAC_OS_X`, `LINUX`, `OTHER`) to replace the `public static final int OS_*` constants on `RSyntaxUtilities`. This is a mild refactoring to remove code from RSyntaxUtilities and migrate OS codes to an enum for static checking.
