### PR TITLE
refactor!: Replace HtmlFoldParser LANGUAGE_* int constants with a Language enum

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/FoldParserManager.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/FoldParserManager.java
@@ -82,12 +82,12 @@ public final class FoldParserManager implements SyntaxConstants {
 		map.put(SYNTAX_STYLE_GO,				new CurlyFoldParser());
 		map.put(SYNTAX_STYLE_GROOVY,			new CurlyFoldParser());
 		map.put(SYNTAX_STYLE_HTACCESS,			new XmlFoldParser());
-		map.put(SYNTAX_STYLE_HTML,				new HtmlFoldParser(HtmlFoldParser.LANGUAGE_HTML));
+		map.put(SYNTAX_STYLE_HTML,				new HtmlFoldParser(HtmlFoldParser.Language.HTML));
 		map.put(SYNTAX_STYLE_JAVA,				new CurlyFoldParser(true, true));
 		map.put(SYNTAX_STYLE_JAVASCRIPT,		new CurlyFoldParser());
 		map.put(SYNTAX_STYLE_JSON,				new JsonFoldParser());
 		map.put(SYNTAX_STYLE_JSON_WITH_COMMENTS,new JsonFoldParser());
-		map.put(SYNTAX_STYLE_JSP,				new HtmlFoldParser(HtmlFoldParser.LANGUAGE_JSP));
+		map.put(SYNTAX_STYLE_JSP,				new HtmlFoldParser(HtmlFoldParser.Language.JSP));
 		map.put(SYNTAX_STYLE_KOTLIN,			new CurlyFoldParser(true, true));
 		map.put(SYNTAX_STYLE_LATEX,				new LatexFoldParser());
 		map.put(SYNTAX_STYLE_LESS,				new CurlyFoldParser());
@@ -95,7 +95,7 @@ public final class FoldParserManager implements SyntaxConstants {
 		map.put(SYNTAX_STYLE_MXML,				new XmlFoldParser());
 		map.put(SYNTAX_STYLE_NSIS,				new NsisFoldParser());
 		map.put(SYNTAX_STYLE_PERL,				new CurlyFoldParser());
-		map.put(SYNTAX_STYLE_PHP,				new HtmlFoldParser(HtmlFoldParser.LANGUAGE_PHP));
+		map.put(SYNTAX_STYLE_PHP,				new HtmlFoldParser(HtmlFoldParser.Language.PHP));
 		map.put(SYNTAX_STYLE_PROTO,				new CurlyFoldParser());
 		map.put(SYNTAX_STYLE_PYTHON,			new PythonFoldParser());
 		map.put(SYNTAX_STYLE_RUST,				new CurlyFoldParser());

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/HtmlFoldParser.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/HtmlFoldParser.java
@@ -34,24 +34,28 @@ import org.fife.ui.rsyntaxtextarea.TokenTypes;
 public class HtmlFoldParser implements FoldParser {
 
 	/**
-	 * Constant denoting we're folding HTML.
+	 * The markup language being folded.
 	 */
-	public static final int LANGUAGE_HTML	= -1;
+	public enum Language {
 
-	/**
-	 * Constant denoting we're folding PHP.
-	 */
-	public static final int LANGUAGE_PHP	= 0;
+		HTML(null, null),
+		PHP("<?".toCharArray(), "?>".toCharArray()),
+		JSP("<%".toCharArray(), "%>".toCharArray());
 
-	/**
-	 * Constant denoting we're folding JSP.
-	 */
-	public static final int LANGUAGE_JSP	= 1;
+		final char[] regionStart;
+		final char[] regionEnd;
+
+		Language(char[] regionStart, char[] regionEnd) {
+			this.regionStart = regionStart;
+			this.regionEnd = regionEnd;
+		}
+
+	}
 
 	/**
 	 * The language we're folding.
 	 */
-	private final int language;
+	private final Language language;
 
 	/**
 	 * The set of tags we allow to be folded.  These are tags that must have
@@ -63,16 +67,6 @@ public class HtmlFoldParser implements FoldParser {
 	//private static final char[] MARKUP_SHORT_TAG_END = "/>".toCharArray();
 	private static final char[] MLC_START = "<!--".toCharArray();
 	private static final char[] MLC_END   = "-->".toCharArray();
-
-	private static final char[] PHP_START = "<?".toCharArray(); // <? and <?php
-	private static final char[] PHP_END = "?>".toCharArray();
-
-	// Scriptlets, declarations, and expressions all start the same way.
-	private static final char[] JSP_START = "<%".toCharArray();
-	private static final char[] JSP_END = "%>".toCharArray();
-
-	private static final char[][] LANG_START = { PHP_START, JSP_START };
-	private static final char[][] LANG_END   = { PHP_END, JSP_END };
 
 	private static final char[] JSP_COMMENT_START = "<%--".toCharArray();
 	private static final char[] JSP_COMMENT_END   = "--%>".toCharArray();
@@ -102,12 +96,9 @@ public class HtmlFoldParser implements FoldParser {
 	/**
 	 * Constructor.
 	 *
-	 * @param language The language to fold, such as {@link #LANGUAGE_PHP}.
+	 * @param language The language to fold, such as {@link Language#PHP}.
 	 */
-	public HtmlFoldParser(int language) {
-		if (language<LANGUAGE_HTML || language>LANGUAGE_JSP) {
-			throw new IllegalArgumentException("Invalid language: " + language);
-		}
+	public HtmlFoldParser(Language language) {
 		this.language = language;
 	}
 
@@ -134,10 +125,10 @@ public class HtmlFoldParser implements FoldParser {
 
 					// If we're folding PHP.  Note that PHP folding can only be
 					// "one level deep," so our logic here is simple.
-					if (language>=0 && t.getType()==TokenTypes.MARKUP_TAG_DELIMITER) {
+					if (language != Language.HTML && t.getType()==TokenTypes.MARKUP_TAG_DELIMITER) {
 
 						// <?, <?php, <%, <%!, ...
-						if (t.startsWith(LANG_START[language])) {
+						if (t.startsWith(language.regionStart)) {
 							if (currentFold==null) {
 								currentFold = new Fold(FoldType.CODE, textArea, t.getOffset());
 								folds.add(currentFold);
@@ -149,7 +140,7 @@ public class HtmlFoldParser implements FoldParser {
 						}
 
 						// ?> or %>
-						else if (t.startsWith(LANG_END[language]) && currentFold != null) {
+						else if (t.startsWith(language.regionEnd) && currentFold != null) {
 							int phpEnd = t.getEndOffset() - 1;
 							currentFold.setEndOffset(phpEnd);
 							Fold parentFold = currentFold.getParent();
@@ -218,7 +209,7 @@ public class HtmlFoldParser implements FoldParser {
 							}
 
 							// Starting a JSP comment that ends on a later line...
-							else if (language==LANGUAGE_JSP &&
+							else if (language == Language.JSP &&
 									t.startsWith(JSP_COMMENT_START) &&
 									!t.endsWith(JSP_COMMENT_END)) {
 								if (currentFold==null) {

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/folding/HtmlFoldParserTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/folding/HtmlFoldParserTest.java
@@ -9,7 +9,7 @@ import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.util.List;
 
@@ -22,24 +22,12 @@ import java.util.List;
  */
 class HtmlFoldParserTest {
 
-	private static final String[] SUPPORTED_LANGUAGES = {
-		SyntaxConstants.SYNTAX_STYLE_HTML,
-		SyntaxConstants.SYNTAX_STYLE_PHP,
-		SyntaxConstants.SYNTAX_STYLE_JSP,
-	};
-
-	@Test
-	void testConstructor_invalidLanguageIndex_tooSmall() {
-		Assertions.assertThrows(IllegalArgumentException.class, () ->
-			new HtmlFoldParser(-42)
-		);
-	}
-
-	@Test
-	void testConstructor_invalidLanguageIndex_tooLarge() {
-		Assertions.assertThrows(IllegalArgumentException.class, () ->
-			new HtmlFoldParser(42)
-		);
+	private static String syntaxStyle(HtmlFoldParser.Language language) {
+		return switch (language) {
+			case HTML -> SyntaxConstants.SYNTAX_STYLE_HTML;
+			case PHP -> SyntaxConstants.SYNTAX_STYLE_PHP;
+			case JSP -> SyntaxConstants.SYNTAX_STYLE_JSP;
+		};
 	}
 
 	@Test
@@ -52,7 +40,7 @@ class HtmlFoldParserTest {
 		RSyntaxTextArea textArea = new RSyntaxTextArea(code);
 		textArea.setSyntaxEditingStyle(language);
 
-		HtmlFoldParser parser = new HtmlFoldParser(HtmlFoldParser.LANGUAGE_PHP);
+		HtmlFoldParser parser = new HtmlFoldParser(HtmlFoldParser.Language.PHP);
 		List<Fold> folds = parser.getFolds(textArea);
 
 		Assertions.assertEquals(1, folds.size());
@@ -75,7 +63,7 @@ class HtmlFoldParserTest {
 		RSyntaxTextArea textArea = new RSyntaxTextArea(code);
 		textArea.setSyntaxEditingStyle(language);
 
-		HtmlFoldParser parser = new HtmlFoldParser(HtmlFoldParser.LANGUAGE_PHP);
+		HtmlFoldParser parser = new HtmlFoldParser(HtmlFoldParser.Language.PHP);
 		List<Fold> folds = parser.getFolds(textArea);
 
 		Assertions.assertEquals(1, folds.size());
@@ -96,7 +84,7 @@ class HtmlFoldParserTest {
 		RSyntaxTextArea textArea = new RSyntaxTextArea(code);
 		textArea.setSyntaxEditingStyle(language);
 
-		HtmlFoldParser parser = new HtmlFoldParser(HtmlFoldParser.LANGUAGE_PHP);
+		HtmlFoldParser parser = new HtmlFoldParser(HtmlFoldParser.Language.PHP);
 		List<Fold> folds = parser.getFolds(textArea);
 		Assertions.assertEquals(0, folds.size());
 	}
@@ -111,7 +99,7 @@ class HtmlFoldParserTest {
 		RSyntaxTextArea textArea = new RSyntaxTextArea(code);
 		textArea.setSyntaxEditingStyle(language);
 
-		HtmlFoldParser parser = new HtmlFoldParser(HtmlFoldParser.LANGUAGE_JSP);
+		HtmlFoldParser parser = new HtmlFoldParser(HtmlFoldParser.Language.JSP);
 		List<Fold> folds = parser.getFolds(textArea);
 
 		Assertions.assertEquals(1, folds.size());
@@ -132,28 +120,23 @@ class HtmlFoldParserTest {
 		RSyntaxTextArea textArea = new RSyntaxTextArea(code);
 		textArea.setSyntaxEditingStyle(language);
 
-		HtmlFoldParser parser = new HtmlFoldParser(HtmlFoldParser.LANGUAGE_JSP);
+		HtmlFoldParser parser = new HtmlFoldParser(HtmlFoldParser.Language.JSP);
 		List<Fold> folds = parser.getFolds(textArea);
 
 		Assertions.assertEquals(0, folds.size());
 	}
 
 	@ParameterizedTest
-	@ValueSource(ints = {
-		HtmlFoldParser.LANGUAGE_HTML,
-		HtmlFoldParser.LANGUAGE_PHP,
-		HtmlFoldParser.LANGUAGE_JSP
-	})
-	void testGetFolds_comments_oneLine(int languageIndex) {
+	@EnumSource(HtmlFoldParser.Language.class)
+	void testGetFolds_comments_oneLine(HtmlFoldParser.Language language) {
 
 		String code = "<!-- start\n" +
 			"end -->\n";
 
-		String language = SUPPORTED_LANGUAGES[languageIndex + 1];
 		RSyntaxTextArea textArea = new RSyntaxTextArea(code);
-		textArea.setSyntaxEditingStyle(language);
+		textArea.setSyntaxEditingStyle(syntaxStyle(language));
 
-		HtmlFoldParser parser = new HtmlFoldParser(languageIndex);
+		HtmlFoldParser parser = new HtmlFoldParser(language);
 		List<Fold> folds = parser.getFolds(textArea);
 
 		Assertions.assertEquals(1, folds.size());
@@ -166,22 +149,17 @@ class HtmlFoldParserTest {
 	}
 
 	@ParameterizedTest
-	@ValueSource(ints = {
-		HtmlFoldParser.LANGUAGE_HTML,
-		HtmlFoldParser.LANGUAGE_PHP,
-		HtmlFoldParser.LANGUAGE_JSP
-	})
-	void testGetFolds_comments_twoLines(int languageIndex) {
+	@EnumSource(HtmlFoldParser.Language.class)
+	void testGetFolds_comments_twoLines(HtmlFoldParser.Language language) {
 
 		String code = "<!-- start\n" +
 			"a second line\n" +
 			"end -->\n";
 
-		String language = SUPPORTED_LANGUAGES[languageIndex + 1];
 		RSyntaxTextArea textArea = new RSyntaxTextArea(code);
-		textArea.setSyntaxEditingStyle(language);
+		textArea.setSyntaxEditingStyle(syntaxStyle(language));
 
-		HtmlFoldParser parser = new HtmlFoldParser(languageIndex);
+		HtmlFoldParser parser = new HtmlFoldParser(language);
 		List<Fold> folds = parser.getFolds(textArea);
 
 		Assertions.assertEquals(1, folds.size());
@@ -194,40 +172,30 @@ class HtmlFoldParserTest {
 	}
 
 	@ParameterizedTest
-	@ValueSource(ints = {
-		HtmlFoldParser.LANGUAGE_HTML,
-		HtmlFoldParser.LANGUAGE_PHP,
-		HtmlFoldParser.LANGUAGE_JSP
-	})
-	void testGetFolds_comments_onOneLineIsNotAFold(int languageIndex) {
+	@EnumSource(HtmlFoldParser.Language.class)
+	void testGetFolds_comments_onOneLineIsNotAFold(HtmlFoldParser.Language language) {
 
 		String code = "<!-- all on one line -->\n";
 
-		String language = SUPPORTED_LANGUAGES[languageIndex + 1];
 		RSyntaxTextArea textArea = new RSyntaxTextArea(code);
-		textArea.setSyntaxEditingStyle(language);
+		textArea.setSyntaxEditingStyle(syntaxStyle(language));
 
-		HtmlFoldParser parser = new HtmlFoldParser(languageIndex);
+		HtmlFoldParser parser = new HtmlFoldParser(language);
 		List<Fold> folds = parser.getFolds(textArea);
 		Assertions.assertEquals(0, folds.size());
 	}
 
 	@ParameterizedTest
-	@ValueSource(ints = {
-		HtmlFoldParser.LANGUAGE_HTML,
-		HtmlFoldParser.LANGUAGE_PHP,
-		HtmlFoldParser.LANGUAGE_JSP
-	})
-	void testGetFolds_tags_oneLine(int languageIndex) {
+	@EnumSource(HtmlFoldParser.Language.class)
+	void testGetFolds_tags_oneLine(HtmlFoldParser.Language language) {
 
 		String code = "<body>\n" +
 			"</body>\n";
 
-		String language = SUPPORTED_LANGUAGES[languageIndex + 1];
 		RSyntaxTextArea textArea = new RSyntaxTextArea(code);
-		textArea.setSyntaxEditingStyle(language);
+		textArea.setSyntaxEditingStyle(syntaxStyle(language));
 
-		HtmlFoldParser parser = new HtmlFoldParser(languageIndex);
+		HtmlFoldParser parser = new HtmlFoldParser(language);
 		List<Fold> folds = parser.getFolds(textArea);
 
 		Assertions.assertEquals(1, folds.size());
@@ -240,22 +208,17 @@ class HtmlFoldParserTest {
 	}
 
 	@ParameterizedTest
-	@ValueSource(ints = {
-		HtmlFoldParser.LANGUAGE_HTML,
-		HtmlFoldParser.LANGUAGE_PHP,
-		HtmlFoldParser.LANGUAGE_JSP
-	})
-	void testGetFolds_tags_twoLines(int languageIndex) {
+	@EnumSource(HtmlFoldParser.Language.class)
+	void testGetFolds_tags_twoLines(HtmlFoldParser.Language language) {
 
 		String code = "<body>\n" +
 			"this is content\n" +
 			"</body>\n";
 
-		String language = SUPPORTED_LANGUAGES[languageIndex + 1];
 		RSyntaxTextArea textArea = new RSyntaxTextArea(code);
-		textArea.setSyntaxEditingStyle(language);
+		textArea.setSyntaxEditingStyle(syntaxStyle(language));
 
-		HtmlFoldParser parser = new HtmlFoldParser(languageIndex);
+		HtmlFoldParser parser = new HtmlFoldParser(language);
 		List<Fold> folds = parser.getFolds(textArea);
 
 		Assertions.assertEquals(1, folds.size());
@@ -268,20 +231,15 @@ class HtmlFoldParserTest {
 	}
 
 	@ParameterizedTest
-	@ValueSource(ints = {
-		HtmlFoldParser.LANGUAGE_HTML,
-		HtmlFoldParser.LANGUAGE_PHP,
-		HtmlFoldParser.LANGUAGE_JSP
-	})
-	void testGetFolds_tags_onOneLineIsNotAFold(int languageIndex) {
+	@EnumSource(HtmlFoldParser.Language.class)
+	void testGetFolds_tags_onOneLineIsNotAFold(HtmlFoldParser.Language language) {
 
 		String code = "<body>foo</body>\n";
 
-		String language = SUPPORTED_LANGUAGES[languageIndex + 1];
 		RSyntaxTextArea textArea = new RSyntaxTextArea(code);
-		textArea.setSyntaxEditingStyle(language);
+		textArea.setSyntaxEditingStyle(syntaxStyle(language));
 
-		HtmlFoldParser parser = new HtmlFoldParser(languageIndex);
+		HtmlFoldParser parser = new HtmlFoldParser(language);
 		List<Fold> folds = parser.getFolds(textArea);
 		Assertions.assertEquals(0, folds.size());
 	}


### PR DESCRIPTION
As part of our continuing effort to modernize the codebase for the 4.0 release, this PR replaces the three `LANGUAGE_HTML`/`LANGUAGE_PHP`/`LANGUAGE_JSP` int constants in `HtmlFoldParser` with a nested `Language` enum whose `PHP` and `JSP` members carry their own region-start/end char arrays.
