### PR TITLE
refactor: replace deprecated Color.* constants; perf improvements in SyntaxView and bracket matching

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,0 +1,50 @@
+# Create a Pull Request
+
+Create a branch (if needed), commit staged/unstaged changes, push, and open/update a PR.
+
+## Steps
+
+1. **Check branch status**: Run `git status` and `git branch --show-current`
+   - If on `master` or `main`, create a new branch:
+     - Analyze the changes to determine a descriptive branch name
+     - Use lower-kebab-case (e.g., `add-user-authentication`, `fix-login-bug`)
+     - Run `git checkout -b <branch-name>`
+   - If already on a feature branch, continue on that branch
+
+2. **Ensure JDK 25 is on the path**. This library requires JDK 25 or later to build.
+   Ensure that `java --version` shows `25` or later. If not, search for Java 25 in common
+   locaitons for the operating system. If you can't find it, exit early.
+
+3. **Build locally** by running `./gradlew clean build`. If there are any checkstyle
+   or spotbugs failure, or javac errors, fix them and rerun this check to verify your changes.
+   Don't worry about javac warnings currently - there are 3 that we need to address later,
+   but for now can be ignored.
+
+4. **Review changes**: Run `git status` and `git diff` to understand what will be committed
+
+5. **Stage and commit**:
+   - Stage relevant files (prefer specific files over `git add -A`)
+   - Determine the commit strategy:
+     - If the feature branch has no prior commits: create a new commit
+     - If the feature branch has a prior commit and a draft PR exists (`gh pr view --json isDraft`): amend the existing commit (`git commit --amend`)
+     - If the feature branch has a prior commit and no PR exists, or the PR is not in draft: create a new commit
+   - Write a commit message (or update the existing one if needed) using the [conventional commit style](https://www.conventionalcommits.org/en/v1.0.0/)
+     - Don't read the conventional commit site/URL if you already know the style
+     - Use "!" after the type to indicate a breaking change
+     - Use "build(deps)" for dependency bumps
+   - Include `Co-Authored-By: Claude <noreply@anthropic.com>` in the commit message
+
+6. **Push**:
+   - If the commit was amended: `git push --force-with-lease`
+   - Otherwise: `git push -u origin <branch-name>`
+
+7. **Create or update PR**:
+   - Check if a PR already exists for this branch with `gh pr view`
+   - If no PR exists: use `gh pr create --draft` with the title, body, and labels below
+   - If a PR exists: use `gh pr edit` to update the title, body, and labels
+   - Title: concise, matching the commit style
+   - Body: formatted using this repo's PR template (`.github/PULL_REQUEST_TEMPLATE.md`),
+     with an additional footer: `🤖 Generated with [Claude Code](https://claude.ai/claude-code)`
+   - Labels — add any that are relevant:
+     - `bug`, `build`, `ci/cd`, `code-folding`, dependencies`, `enhancement`, `refactor`, `sytax-highlighting`
+     - Only add a `tests` label if the PR is *only* adding test coverage

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextArea.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextArea.java
@@ -3099,7 +3099,7 @@ public class RSyntaxTextArea extends RTextArea implements SyntaxConstants {
 	public void setTabLineColor(Color c) {
 
 		if (c==null) {
-			c = Color.gray;
+			c = Color.GRAY;
 		}
 
 		if (!c.equals(tabLineColor)) {

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxUtilities.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxUtilities.java
@@ -211,7 +211,7 @@ public final class RSyntaxUtilities implements SwingConstants {
 
 	/**
 	 * Returns the color to use for hyperlink-style components.  This method
-	 * will return <code>Color.blue</code> unless it appears that the current
+	 * will return <code>Color.BLUE</code> unless it appears that the current
 	 * LookAndFeel uses light text on a dark background, in which case a
 	 * brighter alternative is returned.
 	 *
@@ -227,7 +227,7 @@ public final class RSyntaxUtilities implements SwingConstants {
 			fg = new JLabel().getForeground();
 		}
 
-		return isLightForeground(fg) ? LIGHT_HYPERLINK_FG : Color.blue;
+		return isLightForeground(fg) ? LIGHT_HYPERLINK_FG : Color.BLUE;
 
 	}
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxUtilities.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxUtilities.java
@@ -377,21 +377,23 @@ public final class RSyntaxUtilities implements SwingConstants {
 		}
 		input.setLocation(-1, -1);
 
+		RSyntaxDocument doc = (RSyntaxDocument)textArea.getDocument();
+		String bracketPairs = doc.getBracketPairs();
+		if (bracketPairs.isEmpty()) {
+			return input;
+		}
+
 		try {
 
 			// Actually position just BEFORE caret.
 			int caretPosition = textArea.getCaretPosition() - 1;
-			RSyntaxDocument doc = (RSyntaxDocument)textArea.getDocument();
 			char bracket = 0;
 
-			// If the caret was at offset 0, we can't check "to its left."
-			String bracketPairs = doc.getBracketPairs();
+			// Check "to the left" of the caret first, if possible.
+			// If that's not a bracket, check "to the right" if possible.
 			if (caretPosition>=0) {
 				bracket = doc.charAt(caretPosition);
 			}
-
-			// Try to match a bracket "to the right" of the caret if one
-			// was not found on the left.
 			int index = bracketPairs.indexOf(bracket);
 			if (index==-1 && caretPosition<doc.getLength()-1) {
 				bracket = doc.charAt(++caretPosition);

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/SyntaxScheme.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/SyntaxScheme.java
@@ -449,7 +449,7 @@ public class SyntaxScheme implements Cloneable, TokenTypes {
 		styles[COMMENT_MULTILINE]			= new Style(comment, null, commentFont);
 		styles[COMMENT_DOCUMENTATION]		= new Style(docComment, null, commentFont);
 		styles[COMMENT_KEYWORD]			= new Style(new Color(255,152,0), null, commentFont);
-		styles[COMMENT_MARKUP]			= new Style(Color.gray, null, commentFont);
+		styles[COMMENT_MARKUP]			= new Style(Color.GRAY, null, commentFont);
 		styles[RESERVED_WORD]				= new Style(keyword, null, keywordFont);
 		styles[RESERVED_WORD_2]			= new Style(keyword, null, keywordFont);
 		styles[FUNCTION]					= new Style(function);
@@ -463,9 +463,9 @@ public class SyntaxScheme implements Cloneable, TokenTypes {
 		styles[DATA_TYPE]				= new Style(dataType, null, keywordFont);
 		styles[VARIABLE]					= new Style(variable);
 		styles[REGEX]						= new Style(regex);
-		styles[ANNOTATION]				= new Style(Color.gray);
+		styles[ANNOTATION]				= new Style(Color.GRAY);
 		styles[IDENTIFIER]				= new Style(null);
-		styles[WHITESPACE]				= new Style(Color.gray);
+		styles[WHITESPACE]				= new Style(Color.GRAY);
 		styles[SEPARATOR]				= new Style(Color.RED);
 		styles[OPERATOR]					= new Style(operator);
 		styles[PREPROCESSOR]				= new Style(preprocessor);

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/SyntaxView.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/SyntaxView.java
@@ -752,8 +752,9 @@ public class SyntaxView extends View implements TabExpander,
 
 		TokenPainter painter = host.getTokenPainter();
 		int line = linesAbove;
+		int clipBottom = (int)(clip.getY() + clip.getHeight()) + ascent;
 		//int count = 0;
-		while (y<clip.getY()+clip.getHeight() +ascent && line<lineCount) {
+		while (y < clipBottom && line < lineCount) {
 
 			Fold fold = fm.getFoldForLine(line);
 			boolean isFoldCollapsed = fold != null && fold.isCollapsed();
@@ -1002,7 +1003,7 @@ public class SyntaxView extends View implements TabExpander,
 
 			Element map = doc.getDefaultRootElement();
 			lineHeight = host.getLineHeight();
-			int lineIndex = Math.abs((y - alloc.y) / lineHeight);//metrics.getHeight() );
+			int lineIndex = (y - alloc.y) / lineHeight;//metrics.getHeight() );
 			FoldManager fm = host.getFoldManager();
 			//System.out.print("--- " + lineIndex);
 			lineIndex += fm.getHiddenLineCountAbove(lineIndex, true);

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/parser/DefaultParserNotice.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/parser/DefaultParserNotice.java
@@ -35,7 +35,7 @@ public class DefaultParserNotice implements ParserNotice {
 	private static final Color[] DEFAULT_COLORS = {
 		new Color(255, 0, 128),		// Error
 		new Color(244, 200, 45),	// Warning
-		Color.gray,					// Info
+		Color.GRAY,					// Info
 	};
 
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/ConfigurableCaret.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/ConfigurableCaret.java
@@ -492,7 +492,7 @@ public class ConfigurableCaret extends DefaultCaret {
 					case BLOCK_STYLE:
 						Color textAreaBg = textArea.getBackground();
 						if (textAreaBg==null) {
-							textAreaBg = Color.white;
+							textAreaBg = Color.WHITE;
 						}
 						g.setXORMode(textAreaBg);
 						// fills x==r.x to x==(r.x+(r.width)-1), inclusive.
@@ -510,7 +510,7 @@ public class ConfigurableCaret extends DefaultCaret {
 					case UNDERLINE_STYLE:
 						textAreaBg = textArea.getBackground();
 						if (textAreaBg==null) {
-							textAreaBg = Color.white;
+							textAreaBg = Color.WHITE;
 						}
 						g2d.setXORMode(textAreaBg);
 						SwingUtils.drawLine(g2d, r.getX(), r.getY()+r.getHeight(),

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/BracketMatchingSupportTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/BracketMatchingSupportTest.java
@@ -129,8 +129,8 @@ class BracketMatchingSupportTest extends AbstractRSyntaxTextAreaTest {
 		RSyntaxTextArea textArea = createTextArea();
 		BracketMatchingSupport support = new BracketMatchingSupport(textArea);
 
-		support.setMatchedBracketBGColor(Color.pink);
-		Assertions.assertEquals(Color.pink, support.getMatchedBracketBGColor());
+		support.setMatchedBracketBGColor(Color.PINK);
+		Assertions.assertEquals(Color.PINK, support.getMatchedBracketBGColor());
 
 		support.setMatchedBracketBGColor(null);
 		Assertions.assertNull(support.getMatchedBracketBGColor());
@@ -143,8 +143,8 @@ class BracketMatchingSupportTest extends AbstractRSyntaxTextAreaTest {
 		RSyntaxTextArea textArea = createTextArea();
 		BracketMatchingSupport support = new BracketMatchingSupport(textArea);
 
-		support.setMatchedBracketBorderColor(Color.pink);
-		Assertions.assertEquals(Color.pink, support.getMatchedBracketBorderColor());
+		support.setMatchedBracketBorderColor(Color.PINK);
+		Assertions.assertEquals(Color.PINK, support.getMatchedBracketBorderColor());
 
 		support.setMatchedBracketBorderColor(null);
 		Assertions.assertNull(support.getMatchedBracketBorderColor());

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/HtmlUtilTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/HtmlUtilTest.java
@@ -86,12 +86,12 @@ class HtmlUtilTest {
 
 	@Test
 	void testGetHexString_allGreaterThan16() {
-		Assertions.assertEquals("#ffffff", HtmlUtil.getHexString(Color.white));
+		Assertions.assertEquals("#ffffff", HtmlUtil.getHexString(Color.WHITE));
 	}
 
 	@Test
 	void testGetHexString_allLessThan16() {
-		Assertions.assertEquals("#000000", HtmlUtil.getHexString(Color.black));
+		Assertions.assertEquals("#000000", HtmlUtil.getHexString(Color.BLACK));
 	}
 
 	@Test

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaTest.java
@@ -524,8 +524,8 @@ class RSyntaxTextAreaTest extends AbstractRSyntaxTextAreaTest {
 	@Test
 	void testHyperlinkForeground() {
 		RSyntaxTextArea textArea = new RSyntaxTextArea();
-		textArea.setHyperlinkForeground(Color.pink);
-		Assertions.assertEquals(Color.pink, textArea.getHyperlinkForeground());
+		textArea.setHyperlinkForeground(Color.PINK);
+		Assertions.assertEquals(Color.PINK, textArea.getHyperlinkForeground());
 	}
 
 
@@ -589,8 +589,8 @@ class RSyntaxTextAreaTest extends AbstractRSyntaxTextAreaTest {
 	void testMarkOccurrencesColor() {
 		RSyntaxTextArea textArea = new RSyntaxTextArea();
 		textArea.setMarkOccurrences(true);
-		textArea.setMarkOccurrencesColor(Color.pink);
-		Assertions.assertEquals(Color.pink, textArea.getMarkOccurrencesColor());
+		textArea.setMarkOccurrencesColor(Color.PINK);
+		Assertions.assertEquals(Color.PINK, textArea.getMarkOccurrencesColor());
 	}
 
 
@@ -623,16 +623,16 @@ class RSyntaxTextAreaTest extends AbstractRSyntaxTextAreaTest {
 	@Test
 	void testMatchedBracketBGColor() {
 		RSyntaxTextArea textArea = new RSyntaxTextArea();
-		textArea.setMatchedBracketBGColor(Color.pink);
-		Assertions.assertEquals(Color.pink, textArea.getMatchedBracketBGColor());
+		textArea.setMatchedBracketBGColor(Color.PINK);
+		Assertions.assertEquals(Color.PINK, textArea.getMatchedBracketBGColor());
 	}
 
 
 	@Test
 	void testMatchedBracketBorderColor() {
 		RSyntaxTextArea textArea = new RSyntaxTextArea();
-		textArea.setMatchedBracketBorderColor(Color.pink);
-		Assertions.assertEquals(Color.pink, textArea.getMatchedBracketBorderColor());
+		textArea.setMatchedBracketBorderColor(Color.PINK);
+		Assertions.assertEquals(Color.PINK, textArea.getMatchedBracketBorderColor());
 	}
 
 
@@ -821,8 +821,8 @@ class RSyntaxTextAreaTest extends AbstractRSyntaxTextAreaTest {
 	@Test
 	void testTabLineColor() {
 		RSyntaxTextArea textArea = createTextArea();
-		textArea.setTabLineColor(Color.blue);
-		Assertions.assertEquals(Color.blue, textArea.getTabLineColor());
+		textArea.setTabLineColor(Color.BLUE);
+		Assertions.assertEquals(Color.BLUE, textArea.getTabLineColor());
 	}
 
 

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RtfGeneratorTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RtfGeneratorTest.java
@@ -41,9 +41,9 @@ class RtfGeneratorTest {
 	@Test
 	void testHappyPath() {
 
-		RtfGenerator generator = new RtfGenerator(Color.white);
+		RtfGenerator generator = new RtfGenerator(Color.WHITE);
 		generator.appendToDoc(SIMPLE_TEXT.get(0), null, null, null);
-		generator.appendToDoc(SIMPLE_TEXT.get(1), null, Color.red, null);
+		generator.appendToDoc(SIMPLE_TEXT.get(1), null, Color.RED, null);
 		generator.appendToDoc(SIMPLE_TEXT.get(2), null, null, null);
 
 		// We can't do an exact string comparison due to differing default fonts on different OS's
@@ -52,7 +52,7 @@ class RtfGeneratorTest {
 
 	@Test
 	void testNon7BitAscii() {
-		RtfGenerator generator = new RtfGenerator(Color.white);
+		RtfGenerator generator = new RtfGenerator(Color.WHITE);
 		generator.appendToDoc("\u6c49", null, null, null);
 		String rtf = generator.getRtf();
 		int firstNewline = rtf.indexOf('\n');

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/ThemeTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/ThemeTest.java
@@ -85,40 +85,40 @@ class ThemeTest {
 	private void assertColorsMatchTheme1(RSyntaxTextArea textArea,
 			Gutter gutter) {
 
-		Assertions.assertEquals(Color.red, textArea.getBackground());
-		Assertions.assertEquals(Color.red, textArea.getCaretColor());
+		Assertions.assertEquals(Color.RED, textArea.getBackground());
+		Assertions.assertEquals(Color.RED, textArea.getCaretColor());
 		Assertions.assertFalse(textArea.getUseSelectedTextColor());
-		Assertions.assertEquals(Color.red, textArea.getSelectedTextColor());
-		Assertions.assertEquals(Color.red, textArea.getSelectionColor());
+		Assertions.assertEquals(Color.RED, textArea.getSelectedTextColor());
+		Assertions.assertEquals(Color.RED, textArea.getSelectionColor());
 		Assertions.assertTrue(textArea.getRoundedSelectionEdges());
-		Assertions.assertEquals(Color.red, textArea.getCurrentLineHighlightColor());
+		Assertions.assertEquals(Color.RED, textArea.getCurrentLineHighlightColor());
 		Assertions.assertTrue(textArea.getFadeCurrentLineHighlight());
-		Assertions.assertEquals(Color.red, textArea.getTabLineColor());
-		Assertions.assertEquals(Color.red, textArea.getMarginLineColor());
-		Assertions.assertEquals(Color.red, textArea.getMarkAllHighlightColor());
-		Assertions.assertEquals(Color.red, textArea.getMarkOccurrencesColor());
+		Assertions.assertEquals(Color.RED, textArea.getTabLineColor());
+		Assertions.assertEquals(Color.RED, textArea.getMarginLineColor());
+		Assertions.assertEquals(Color.RED, textArea.getMarkAllHighlightColor());
+		Assertions.assertEquals(Color.RED, textArea.getMarkOccurrencesColor());
 		Assertions.assertTrue(textArea.getPaintMarkOccurrencesBorder());
-		Assertions.assertEquals(Color.red, textArea.getMatchedBracketBGColor());
-		Assertions.assertEquals(Color.red, textArea.getMatchedBracketBorderColor());
+		Assertions.assertEquals(Color.RED, textArea.getMatchedBracketBGColor());
+		Assertions.assertEquals(Color.RED, textArea.getMatchedBracketBorderColor());
 		Assertions.assertTrue(textArea.getPaintMatchedBracketPair());
 		Assertions.assertTrue(textArea.getAnimateBracketMatching());
-		Assertions.assertEquals(Color.red, textArea.getHyperlinkForeground());
+		Assertions.assertEquals(Color.RED, textArea.getHyperlinkForeground());
 		for (int i=0; i<textArea.getSecondaryLanguageCount(); i++) {
-			Color expected = i==TokenTypes.IDENTIFIER ? Color.blue : Color.red;
+			Color expected = i==TokenTypes.IDENTIFIER ? Color.BLUE : Color.RED;
 			Assertions.assertEquals(expected, textArea.getSecondaryLanguageBackground(i+1));
 		}
 
-		Assertions.assertEquals(Color.red, gutter.getBackground());
-		Assertions.assertEquals(Color.red, gutter.getBorderColor());
-		Assertions.assertEquals(Color.red, gutter.getActiveLineRangeColor());
+		Assertions.assertEquals(Color.RED, gutter.getBackground());
+		Assertions.assertEquals(Color.RED, gutter.getBorderColor());
+		Assertions.assertEquals(Color.RED, gutter.getActiveLineRangeColor());
 		Assertions.assertTrue(gutter.getIconRowHeaderInheritsGutterBackground());
-		Assertions.assertEquals(Color.red, gutter.getLineNumberColor());
-		Assertions.assertEquals(Color.blue, gutter.getCurrentLineNumberColor());
+		Assertions.assertEquals(Color.RED, gutter.getLineNumberColor());
+		Assertions.assertEquals(Color.BLUE, gutter.getCurrentLineNumberColor());
 		//Assertions.assertEquals("Arial",  gutter.getLineNumberFont().getFamily()); // Arial not on CI build servers
 		Assertions.assertEquals(22,        gutter.getLineNumberFont().getSize());
-		Assertions.assertEquals(Color.red, gutter.getFoldIndicatorForeground());
-		Assertions.assertEquals(Color.red, gutter.getFoldBackground());
-		Assertions.assertEquals(Color.green, gutter.getArmedFoldBackground());
+		Assertions.assertEquals(Color.RED, gutter.getFoldIndicatorForeground());
+		Assertions.assertEquals(Color.RED, gutter.getFoldBackground());
+		Assertions.assertEquals(Color.GREEN, gutter.getArmedFoldBackground());
 
 	}
 
@@ -130,40 +130,40 @@ class ThemeTest {
 	private void assertColorsMatchTheme1_noLineNumbers_currentFG(
 			RSyntaxTextArea textArea, Gutter gutter) {
 
-		Assertions.assertEquals(Color.red, textArea.getBackground());
-		Assertions.assertEquals(Color.red, textArea.getCaretColor());
+		Assertions.assertEquals(Color.RED, textArea.getBackground());
+		Assertions.assertEquals(Color.RED, textArea.getCaretColor());
 		Assertions.assertFalse(textArea.getUseSelectedTextColor());
-		Assertions.assertEquals(Color.red, textArea.getSelectedTextColor());
-		Assertions.assertEquals(Color.red, textArea.getSelectionColor());
+		Assertions.assertEquals(Color.RED, textArea.getSelectedTextColor());
+		Assertions.assertEquals(Color.RED, textArea.getSelectionColor());
 		Assertions.assertTrue(textArea.getRoundedSelectionEdges());
-		Assertions.assertEquals(Color.red, textArea.getCurrentLineHighlightColor());
+		Assertions.assertEquals(Color.RED, textArea.getCurrentLineHighlightColor());
 		Assertions.assertTrue(textArea.getFadeCurrentLineHighlight());
-		Assertions.assertEquals(Color.red, textArea.getTabLineColor());
-		Assertions.assertEquals(Color.red, textArea.getMarginLineColor());
-		Assertions.assertEquals(Color.red, textArea.getMarkAllHighlightColor());
-		Assertions.assertEquals(Color.red, textArea.getMarkOccurrencesColor());
+		Assertions.assertEquals(Color.RED, textArea.getTabLineColor());
+		Assertions.assertEquals(Color.RED, textArea.getMarginLineColor());
+		Assertions.assertEquals(Color.RED, textArea.getMarkAllHighlightColor());
+		Assertions.assertEquals(Color.RED, textArea.getMarkOccurrencesColor());
 		Assertions.assertTrue(textArea.getPaintMarkOccurrencesBorder());
-		Assertions.assertEquals(Color.red, textArea.getMatchedBracketBGColor());
-		Assertions.assertEquals(Color.red, textArea.getMatchedBracketBorderColor());
+		Assertions.assertEquals(Color.RED, textArea.getMatchedBracketBGColor());
+		Assertions.assertEquals(Color.RED, textArea.getMatchedBracketBorderColor());
 		Assertions.assertTrue(textArea.getPaintMatchedBracketPair());
 		Assertions.assertTrue(textArea.getAnimateBracketMatching());
-		Assertions.assertEquals(Color.red, textArea.getHyperlinkForeground());
+		Assertions.assertEquals(Color.RED, textArea.getHyperlinkForeground());
 		for (int i=0; i<textArea.getSecondaryLanguageCount(); i++) {
-			Color expected = i==TokenTypes.IDENTIFIER ? Color.blue : Color.red;
+			Color expected = i==TokenTypes.IDENTIFIER ? Color.BLUE : Color.RED;
 			Assertions.assertEquals(expected, textArea.getSecondaryLanguageBackground(i+1));
 		}
 
-		Assertions.assertEquals(Color.red, gutter.getBackground());
-		Assertions.assertEquals(Color.red, gutter.getBorderColor());
-		Assertions.assertEquals(Color.red, gutter.getActiveLineRangeColor());
+		Assertions.assertEquals(Color.RED, gutter.getBackground());
+		Assertions.assertEquals(Color.RED, gutter.getBorderColor());
+		Assertions.assertEquals(Color.RED, gutter.getActiveLineRangeColor());
 		Assertions.assertTrue(gutter.getIconRowHeaderInheritsGutterBackground());
-		Assertions.assertEquals(Color.red, gutter.getLineNumberColor());
+		Assertions.assertEquals(Color.RED, gutter.getLineNumberColor());
 		Assertions.assertNull(gutter.getCurrentLineNumberColor());
 		//Assertions.assertEquals("Arial",  gutter.getLineNumberFont().getFamily()); // Arial not on CI build servers
 		Assertions.assertEquals(22,        gutter.getLineNumberFont().getSize());
-		Assertions.assertEquals(Color.red, gutter.getFoldIndicatorForeground());
-		Assertions.assertEquals(Color.red, gutter.getFoldBackground());
-		Assertions.assertEquals(Color.green, gutter.getArmedFoldBackground());
+		Assertions.assertEquals(Color.RED, gutter.getFoldIndicatorForeground());
+		Assertions.assertEquals(Color.RED, gutter.getFoldBackground());
+		Assertions.assertEquals(Color.GREEN, gutter.getArmedFoldBackground());
 
 	}
 
@@ -175,39 +175,39 @@ class ThemeTest {
 	private void assertColorsMatchTheme1_noArmedBG(RSyntaxTextArea textArea,
 										 Gutter gutter) {
 
-		Assertions.assertEquals(Color.red, textArea.getBackground());
-		Assertions.assertEquals(Color.red, textArea.getCaretColor());
+		Assertions.assertEquals(Color.RED, textArea.getBackground());
+		Assertions.assertEquals(Color.RED, textArea.getCaretColor());
 		Assertions.assertFalse(textArea.getUseSelectedTextColor());
-		Assertions.assertEquals(Color.red, textArea.getSelectedTextColor());
-		Assertions.assertEquals(Color.red, textArea.getSelectionColor());
+		Assertions.assertEquals(Color.RED, textArea.getSelectedTextColor());
+		Assertions.assertEquals(Color.RED, textArea.getSelectionColor());
 		Assertions.assertTrue(textArea.getRoundedSelectionEdges());
-		Assertions.assertEquals(Color.red, textArea.getCurrentLineHighlightColor());
+		Assertions.assertEquals(Color.RED, textArea.getCurrentLineHighlightColor());
 		Assertions.assertTrue(textArea.getFadeCurrentLineHighlight());
-		Assertions.assertEquals(Color.red, textArea.getTabLineColor());
-		Assertions.assertEquals(Color.red, textArea.getMarginLineColor());
-		Assertions.assertEquals(Color.red, textArea.getMarkAllHighlightColor());
-		Assertions.assertEquals(Color.red, textArea.getMarkOccurrencesColor());
+		Assertions.assertEquals(Color.RED, textArea.getTabLineColor());
+		Assertions.assertEquals(Color.RED, textArea.getMarginLineColor());
+		Assertions.assertEquals(Color.RED, textArea.getMarkAllHighlightColor());
+		Assertions.assertEquals(Color.RED, textArea.getMarkOccurrencesColor());
 		Assertions.assertTrue(textArea.getPaintMarkOccurrencesBorder());
-		Assertions.assertEquals(Color.red, textArea.getMatchedBracketBGColor());
-		Assertions.assertEquals(Color.red, textArea.getMatchedBracketBorderColor());
+		Assertions.assertEquals(Color.RED, textArea.getMatchedBracketBGColor());
+		Assertions.assertEquals(Color.RED, textArea.getMatchedBracketBorderColor());
 		Assertions.assertTrue(textArea.getPaintMatchedBracketPair());
 		Assertions.assertTrue(textArea.getAnimateBracketMatching());
-		Assertions.assertEquals(Color.red, textArea.getHyperlinkForeground());
+		Assertions.assertEquals(Color.RED, textArea.getHyperlinkForeground());
 		for (int i=0; i<textArea.getSecondaryLanguageCount(); i++) {
-			Color expected = i==TokenTypes.IDENTIFIER ? Color.blue : Color.red;
+			Color expected = i==TokenTypes.IDENTIFIER ? Color.BLUE : Color.RED;
 			Assertions.assertEquals(expected, textArea.getSecondaryLanguageBackground(i+1));
 		}
 
-		Assertions.assertEquals(Color.red, gutter.getBackground());
-		Assertions.assertEquals(Color.red, gutter.getBorderColor());
-		Assertions.assertEquals(Color.red, gutter.getActiveLineRangeColor());
+		Assertions.assertEquals(Color.RED, gutter.getBackground());
+		Assertions.assertEquals(Color.RED, gutter.getBorderColor());
+		Assertions.assertEquals(Color.RED, gutter.getActiveLineRangeColor());
 		Assertions.assertTrue(gutter.getIconRowHeaderInheritsGutterBackground());
-		Assertions.assertEquals(Color.red, gutter.getLineNumberColor());
-		Assertions.assertEquals(Color.blue, gutter.getCurrentLineNumberColor());
+		Assertions.assertEquals(Color.RED, gutter.getLineNumberColor());
+		Assertions.assertEquals(Color.BLUE, gutter.getCurrentLineNumberColor());
 		//Assertions.assertEquals("Arial",  gutter.getLineNumberFont().getFamily()); // Arial not on CI build servers
 		Assertions.assertEquals(22,        gutter.getLineNumberFont().getSize());
-		Assertions.assertEquals(Color.red, gutter.getFoldIndicatorForeground());
-		Assertions.assertEquals(Color.red, gutter.getFoldBackground());
+		Assertions.assertEquals(Color.RED, gutter.getFoldIndicatorForeground());
+		Assertions.assertEquals(Color.RED, gutter.getFoldBackground());
 		// Armed fold BG defaults to regular fold BG
 		Assertions.assertEquals(gutter.getFoldBackground(), gutter.getArmedFoldBackground());
 
@@ -298,40 +298,40 @@ class ThemeTest {
 
 		Font font = new Font(Font.DIALOG, Font.PLAIN, 13);
 		textArea.setFont(font);
-		textArea.setSyntaxScheme(createSyntaxScheme(font, Color.orange));
-		textArea.setBackground(Color.orange);
-		textArea.setCaretColor(Color.orange);
+		textArea.setSyntaxScheme(createSyntaxScheme(font, Color.ORANGE));
+		textArea.setBackground(Color.ORANGE);
+		textArea.setCaretColor(Color.ORANGE);
 		textArea.setUseSelectedTextColor(true);
-		textArea.setSelectedTextColor(Color.orange);
-		textArea.setSelectionColor(Color.orange);
+		textArea.setSelectedTextColor(Color.ORANGE);
+		textArea.setSelectionColor(Color.ORANGE);
 		textArea.setRoundedSelectionEdges(true);
-		textArea.setCurrentLineHighlightColor(Color.orange);
+		textArea.setCurrentLineHighlightColor(Color.ORANGE);
 		textArea.setFadeCurrentLineHighlight(true);
-		textArea.setTabLineColor(Color.orange);
-		textArea.setMarginLineColor(Color.orange);
-		textArea.setMarkAllHighlightColor(Color.pink); // orange is the default (!)
-		textArea.setMarkOccurrencesColor(Color.orange);
+		textArea.setTabLineColor(Color.ORANGE);
+		textArea.setMarginLineColor(Color.ORANGE);
+		textArea.setMarkAllHighlightColor(Color.PINK); // orange is the default (!)
+		textArea.setMarkOccurrencesColor(Color.ORANGE);
 		textArea.setPaintMarkOccurrencesBorder(!textArea.getPaintMarkOccurrencesBorder());
-		textArea.setMatchedBracketBGColor(Color.orange);
-		textArea.setMatchedBracketBorderColor(Color.orange);
+		textArea.setMatchedBracketBGColor(Color.ORANGE);
+		textArea.setMatchedBracketBorderColor(Color.ORANGE);
 		textArea.setPaintMatchedBracketPair(!textArea.getPaintMatchedBracketPair());
 		textArea.setAnimateBracketMatching(!textArea.getAnimateBracketMatching());
-		textArea.setHyperlinkForeground(Color.orange);
+		textArea.setHyperlinkForeground(Color.ORANGE);
 		for (int i=0; i<textArea.getSecondaryLanguageCount(); i++) {
-			textArea.setSecondaryLanguageBackground(i+1, Color.orange);
+			textArea.setSecondaryLanguageBackground(i+1, Color.ORANGE);
 		}
 
-		gutter.setBackground(Color.orange);
-		gutter.setBorderColor(Color.orange);
-		gutter.setActiveLineRangeColor(Color.orange);
+		gutter.setBackground(Color.ORANGE);
+		gutter.setBorderColor(Color.ORANGE);
+		gutter.setActiveLineRangeColor(Color.ORANGE);
 		gutter.setIconRowHeaderInheritsGutterBackground(!gutter.getIconRowHeaderInheritsGutterBackground());
-		gutter.setLineNumberColor(Color.orange);
-		gutter.setCurrentLineNumberColor(Color.orange);
+		gutter.setLineNumberColor(Color.ORANGE);
+		gutter.setCurrentLineNumberColor(Color.ORANGE);
 		gutter.setLineNumberFont(font);
-		gutter.setFoldIndicatorArmedForeground(Color.orange);
-		gutter.setFoldIndicatorForeground(Color.orange);
-		gutter.setFoldBackground(Color.orange);
-		gutter.setArmedFoldBackground(Color.orange);
+		gutter.setFoldIndicatorArmedForeground(Color.ORANGE);
+		gutter.setFoldIndicatorForeground(Color.ORANGE);
+		gutter.setFoldBackground(Color.ORANGE);
+		gutter.setArmedFoldBackground(Color.ORANGE);
 
 	}
 

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/parser/DefaultParserNoticeTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/parser/DefaultParserNoticeTest.java
@@ -186,10 +186,10 @@ class DefaultParserNoticeTest {
 	@Test
 	void testGetColor() {
 		notice = new DefaultParserNotice(parser, "Foo", 5);
-		notice.setColor(Color.yellow);
-		Assertions.assertEquals(Color.yellow, notice.getColor());
-		notice.setColor(Color.orange);
-		Assertions.assertEquals(Color.orange, notice.getColor());
+		notice.setColor(Color.YELLOW);
+		Assertions.assertEquals(Color.YELLOW, notice.getColor());
+		notice.setColor(Color.ORANGE);
+		Assertions.assertEquals(Color.ORANGE, notice.getColor());
 	}
 
 
@@ -295,10 +295,10 @@ class DefaultParserNoticeTest {
 	@Test
 	void testSetColor() {
 		notice = new DefaultParserNotice(parser, "Foo", 5);
-		notice.setColor(Color.yellow);
-		Assertions.assertEquals(Color.yellow, notice.getColor());
-		notice.setColor(Color.orange);
-		Assertions.assertEquals(Color.orange, notice.getColor());
+		notice.setColor(Color.YELLOW);
+		Assertions.assertEquals(Color.YELLOW, notice.getColor());
+		notice.setColor(Color.ORANGE);
+		Assertions.assertEquals(Color.ORANGE, notice.getColor());
 	}
 
 

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/FoldIndicatorTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/FoldIndicatorTest.java
@@ -107,15 +107,15 @@ class FoldIndicatorTest extends AbstractRSyntaxTextAreaTest {
 		RSyntaxTextArea textArea = createTextArea();
 		FoldIndicator fi = new FoldIndicator(textArea);
 
-		Color color = Color.red;
+		Color color = Color.RED;
 		fi.setArmedForeground(color);
 		Assertions.assertEquals(color, fi.getArmedForeground());
 
-		color = Color.green;
+		color = Color.GREEN;
 		fi.setArmedForeground(color);
 		Assertions.assertEquals(color, fi.getArmedForeground());
 
-		// Sets to default - not a public value, but also not Color.green.
+		// Sets to default - not a public value, but also not Color.GREEN.
 		fi.setArmedForeground(null);
 		Assertions.assertNotNull(fi.getArmedForeground());
 		Assertions.assertNotEquals(color, fi.getArmedForeground());

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/GutterTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/GutterTest.java
@@ -173,11 +173,11 @@ class GutterTest extends AbstractRTextAreaTest {
 		RTextArea textArea = new RTextArea(PLAIN_TEXT);
 		Gutter gutter = new Gutter(textArea);
 
-		Color color = Color.blue;
+		Color color = Color.BLUE;
 		gutter.setActiveLineRangeColor(color);
 		Assertions.assertEquals(color, gutter.getActiveLineRangeColor());
 
-		color = Color.red;
+		color = Color.RED;
 		gutter.setActiveLineRangeColor(color);
 		Assertions.assertEquals(color, gutter.getActiveLineRangeColor());
 
@@ -255,11 +255,11 @@ class GutterTest extends AbstractRTextAreaTest {
 		RTextArea textArea = new RTextArea(PLAIN_TEXT);
 		Gutter gutter = new Gutter(textArea);
 
-		Color color = Color.red;
+		Color color = Color.RED;
 		gutter.setBorderColor(color);
 		Assertions.assertEquals(color, gutter.getBorderColor());
 
-		color = Color.green;
+		color = Color.GREEN;
 		gutter.setBorderColor(color);
 		Assertions.assertEquals(color, gutter.getBorderColor());
 
@@ -274,7 +274,7 @@ class GutterTest extends AbstractRTextAreaTest {
 
 		Assertions.assertNull(gutter.getCurrentLineNumberColor());
 
-		Color color = Color.red;
+		Color color = Color.RED;
 		gutter.setCurrentLineNumberColor(color);
 		Assertions.assertEquals(color, gutter.getCurrentLineNumberColor());
 
@@ -297,15 +297,15 @@ class GutterTest extends AbstractRTextAreaTest {
 		RTextArea textArea = new RTextArea(PLAIN_TEXT);
 		Gutter gutter = new Gutter(textArea);
 
-		Color color = Color.red;
+		Color color = Color.RED;
 		gutter.setFoldBackground(color);
 		Assertions.assertEquals(color, gutter.getFoldBackground());
 
-		color = Color.green;
+		color = Color.GREEN;
 		gutter.setFoldBackground(color);
 		Assertions.assertEquals(color, gutter.getFoldBackground());
 
-		// Sets to default - not a public value, but also not Color.green.
+		// Sets to default - not a public value, but also not Color.GREEN.
 		gutter.setFoldBackground(null);
 		Assertions.assertNotNull(gutter.getFoldBackground());
 		Assertions.assertNotEquals(color, gutter.getFoldBackground());
@@ -319,15 +319,15 @@ class GutterTest extends AbstractRTextAreaTest {
 		RTextArea textArea = new RTextArea(PLAIN_TEXT);
 		Gutter gutter = new Gutter(textArea);
 
-		Color color = Color.red;
+		Color color = Color.RED;
 		gutter.setFoldIndicatorArmedForeground(color);
 		Assertions.assertEquals(color, gutter.getFoldIndicatorArmedForeground());
 
-		color = Color.green;
+		color = Color.GREEN;
 		gutter.setFoldIndicatorArmedForeground(color);
 		Assertions.assertEquals(color, gutter.getFoldIndicatorArmedForeground());
 
-		// Sets to default - not a public value, but also not Color.green.
+		// Sets to default - not a public value, but also not Color.GREEN.
 		gutter.setFoldIndicatorArmedForeground(null);
 		Assertions.assertNotNull(gutter.getFoldIndicatorArmedForeground());
 		Assertions.assertNotEquals(color, gutter.getFoldIndicatorArmedForeground());
@@ -341,15 +341,15 @@ class GutterTest extends AbstractRTextAreaTest {
 		RTextArea textArea = new RTextArea(PLAIN_TEXT);
 		Gutter gutter = new Gutter(textArea);
 
-		Color color = Color.red;
+		Color color = Color.RED;
 		gutter.setFoldIndicatorForeground(color);
 		Assertions.assertEquals(color, gutter.getFoldIndicatorForeground());
 
-		color = Color.green;
+		color = Color.GREEN;
 		gutter.setFoldIndicatorForeground(color);
 		Assertions.assertEquals(color, gutter.getFoldIndicatorForeground());
 
-		// Sets to default - not a public value, but also not Color.green.
+		// Sets to default - not a public value, but also not Color.GREEN.
 		gutter.setFoldIndicatorForeground(null);
 		Assertions.assertNotNull(gutter.getFoldIndicatorForeground());
 		Assertions.assertNotEquals(color, gutter.getFoldIndicatorForeground());
@@ -376,11 +376,11 @@ class GutterTest extends AbstractRTextAreaTest {
 		RTextArea textArea = new RTextArea(PLAIN_TEXT);
 		Gutter gutter = new Gutter(textArea);
 
-		Color color = Color.red;
+		Color color = Color.RED;
 		gutter.setLineNumberColor(color);
 		Assertions.assertEquals(color, gutter.getLineNumberColor());
 
-		color = Color.green;
+		color = Color.GREEN;
 		gutter.setLineNumberColor(color);
 		Assertions.assertEquals(color, gutter.getLineNumberColor());
 

--- a/RSyntaxTextAreaDemo/src/main/java/org/fife/ui/rsyntaxtextarea/demo/DemoRootPane.java
+++ b/RSyntaxTextAreaDemo/src/main/java/org/fife/ui/rsyntaxtextarea/demo/DemoRootPane.java
@@ -53,7 +53,7 @@ public class DemoRootPane extends JRootPane implements HyperlinkListener,
 		gutter.setBookmarkIcon(new ImageIcon(url));
 		getContentPane().add(scrollPane);
 		ErrorStrip errorStrip = new ErrorStrip(textArea);
-		//errorStrip.setBackground(java.awt.Color.blue);
+		//errorStrip.setBackground(java.awt.Color.BLUE);
 		getContentPane().add(errorStrip, BorderLayout.LINE_END);
 		setJMenuBar(createMenuBar());
 		getContentPane().add(createFontControls(), BorderLayout.SOUTH);

--- a/RSyntaxTextAreaDemo/src/main/java/org/fife/ui/rsyntaxtextarea/demo/SyntaxSchemeDemo.java
+++ b/RSyntaxTextAreaDemo/src/main/java/org/fife/ui/rsyntaxtextarea/demo/SyntaxSchemeDemo.java
@@ -93,8 +93,8 @@ public final class SyntaxSchemeDemo extends JFrame implements ActionListener {
 
       // Change a few things here and there.
       SyntaxScheme scheme = textArea.getSyntaxScheme();
-      scheme.getStyle(TokenTypes.RESERVED_WORD).background = Color.pink;
-      scheme.getStyle(TokenTypes.DATA_TYPE).foreground = Color.blue;
+      scheme.getStyle(TokenTypes.RESERVED_WORD).background = Color.PINK;
+      scheme.getStyle(TokenTypes.DATA_TYPE).foreground = Color.BLUE;
       scheme.getStyle(TokenTypes.LITERAL_STRING_DOUBLE_QUOTE).underline = true;
       scheme.getStyle(TokenTypes.COMMENT_EOL).font = new Font("Georgia",
             Font.ITALIC, 18);


### PR DESCRIPTION
## Summary

- Replace all usages of deprecated lowercase `Color` field constants (`Color.gray`, `Color.blue`, `Color.white`, etc.) with their uppercase equivalents (`Color.GRAY`, `Color.BLUE`, `Color.WHITE`, etc.) across production and test sources — eliminates deprecation warnings from IDEs and static analysis tools.
- Early-exit in `RSyntaxUtilities.getMatchingBracketPosition()` when the document has an empty bracket-pair set, avoiding a full document scan for languages/configs with no pairs configured.
- Pre-compute the paint-loop termination bound in `SyntaxView.paint()` so `clip.getY() + clip.getHeight() + ascent` is not recomputed on every line iteration.
- Remove an unreachable `Math.abs()` call in `SyntaxView.viewToModel()` — the prior `y >= alloc.y` guard already ensures the expression is non-negative.

## Files changed

| Area | Change |
|------|--------|
| `RSyntaxTextArea.java`, `RSyntaxUtilities.java`, `SyntaxScheme.java`, `ConfigurableCaret.java`, `DefaultParserNotice.java` | `Color.*` constant capitalisation |
| `RSyntaxUtilities.java` | Early-exit bracket matching |
| `SyntaxView.java` | Pre-computed loop bound; remove `Math.abs()` |
| Test sources | `Color.*` constant capitalisation to match |

## Test plan

- [x] `./gradlew clean build` passes with no checkstyle, spotbugs, or compiler errors
- [x] Bracket matching still works normally for languages with configured pairs (e.g. Java)
- [x] No visible change in rendering behaviour

🤖 Generated with [Claude Code](https://claude.ai/claude-code)