### PR TITLE
perf: consolidate Style lookup in token painters

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/DefaultTokenPainter.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/DefaultTokenPainter.java
@@ -9,6 +9,7 @@
 package org.fife.ui.rsyntaxtextarea;
 
 import java.awt.Color;
+import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Graphics2D;
 import java.awt.geom.Rectangle2D;
@@ -134,8 +135,11 @@ public class DefaultTokenPainter implements TokenPainter {
 		Color fg = useSTC ? host.getSelectedTextColor() :
 			host.getForegroundForToken(token);
 		Color bg = selected ? null : host.getBackgroundForToken(token);
-		g.setFont(host.getFontForToken(token));
-		FontMetrics fm = host.getFontMetricsForToken(token);
+		Style style = host.getSyntaxScheme().getStyle(token.getType());
+		Font font = style.font != null ? style.font : host.getFont();
+		FontMetrics fm = style.fontMetrics != null ? style.fontMetrics :
+				host.getFontMetricsForTokenType(token.getType());
+		g.setFont(font);
 
 		for (int i=textOffs; i<end; i++) {
 			switch (text[i]) {

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/VisibleWhitespaceTokenPainter.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/VisibleWhitespaceTokenPainter.java
@@ -12,6 +12,7 @@ package org.fife.ui.rsyntaxtextarea;
 import org.fife.util.SwingUtils;
 
 import java.awt.Color;
+import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Graphics2D;
 import javax.swing.text.TabExpander;
@@ -66,8 +67,11 @@ public class VisibleWhitespaceTokenPainter extends DefaultTokenPainter {
 		Color fg = useSTC ? host.getSelectedTextColor() :
 			host.getForegroundForToken(token);
 		Color bg = selected ? null : host.getBackgroundForToken(token);
-		g.setFont(host.getFontForToken(token));
-		FontMetrics fm = host.getFontMetricsForToken(token);
+		Style style = host.getSyntaxScheme().getStyle(token.getType());
+		Font font = style.font != null ? style.font : host.getFont();
+		FontMetrics fm = style.fontMetrics != null ? style.fontMetrics :
+				host.getFontMetricsForTokenType(token.getType());
+		g.setFont(font);
 
 		int ascent = fm.getAscent();
 		int height = fm.getHeight();


### PR DESCRIPTION
## Description

In `DefaultTokenPainter.paintImpl()` and `VisibleWhitespaceTokenPainter.paintImpl()`, the token font and font metrics were fetched via two separate host methods:

```java
g.setFont(host.getFontForToken(token));
FontMetrics fm = host.getFontMetricsForToken(token);
```

Each dispatched through `RSyntaxTextArea` to `syntaxScheme.getStyle(token.getType())` independently — two array lookups for the same `Style` object, on every token in every painted line.

This PR consolidates them into a single `getStyle()` call, reading `style.font` and `style.fontMetrics` directly, with the existing fallback behaviour preserved for the case where a `Style` has no cached `fontMetrics` yet:

```java
Style style = host.getSyntaxScheme().getStyle(token.getType());
Font font = style.font != null ? style.font : host.getFont();
FontMetrics fm = style.fontMetrics != null ? style.fontMetrics :
        host.getFontMetricsForTokenType(token.getType());
g.setFont(font);
```

## Testing

- [x] Existing test suite passes (`./gradlew clean build`)
- [x] Checkstyle and SpotBugs clean
- [x] Built with JDK 25

🤖 Generated with [Claude Code](https://claude.ai/claude-code)