### PR TITLE
chore: remove deprecated DataFlavor.plainTextFlavor from StyledTextTransferable

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/StyledTextTransferable.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/StyledTextTransferable.java
@@ -13,7 +13,6 @@ import java.awt.datatransfer.Transferable;
 import java.awt.datatransfer.UnsupportedFlavorException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.StringReader;
 
 
 /**
@@ -50,8 +49,7 @@ class StyledTextTransferable implements Transferable {
 	private static final DataFlavor[] FLAVORS = {
 		DataFlavor.fragmentHtmlFlavor,
 		new DataFlavor("text/rtf", "RTF"),
-		DataFlavor.stringFlavor,
-		DataFlavor.plainTextFlavor // deprecated
+		DataFlavor.stringFlavor
 	};
 
 
@@ -82,10 +80,6 @@ class StyledTextTransferable implements Transferable {
 
 		else if (flavor.equals(FLAVORS[2])) { // stringFlavor
 			return plain;
-		}
-
-		else if (flavor.equals(FLAVORS[3])) { // plainTextFlavor (deprecated)
-			return new StringReader(plain);
 		}
 
 		throw new UnsupportedFlavorException(flavor);

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/StyledTextTransferableTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/StyledTextTransferableTest.java
@@ -23,7 +23,7 @@ class StyledTextTransferableTest {
 	void testGetDataFlavors() {
 		byte[] rtfBytes = {};
 		StyledTextTransferable t = new StyledTextTransferable("", "foo", rtfBytes);
-		Assertions.assertEquals(4, t.getTransferDataFlavors().length);
+		Assertions.assertEquals(3, t.getTransferDataFlavors().length);
 	}
 
 


### PR DESCRIPTION
## Summary
- Removes `DataFlavor.plainTextFlavor` from `StyledTextTransferable`'s advertised flavors, eliminating a javac deprecation warning during compile.
- `DataFlavor.stringFlavor` (already offered) is sufficient for native text/plain clipboard/DnD interop — the JDK's `SystemFlavorMap` translates `stringFlavor` to native `text/plain`-style clipboard formats automatically, which is why `plainTextFlavor` was deprecated in the first place.
- `StyledTextTransferable` is package-private, so this is not a public API change.

## Test plan
- [x] `./gradlew clean build` passes (checkstyle, spotbugs, tests all green)
- [x] Updated `StyledTextTransferableTest#testGetDataFlavors` to expect 3 flavors instead of 4

🤖 Generated with [Claude Code](https://claude.ai/claude-code)