### PR TITLE
Support customizing the EOL marker

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextArea.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextArea.java
@@ -126,6 +126,7 @@ public class RSyntaxTextArea extends RTextArea implements SyntaxConstants {
 	public static final String CLOSE_CURLY_BRACES_PROPERTY				= "RSTA.closeCurlyBraces";
 	public static final String CLOSE_MARKUP_TAGS_PROPERTY				= "RSTA.closeMarkupTags";
 	public static final String CODE_FOLDING_PROPERTY					= "RSTA.codeFolding";
+	public static final String EOL_MARKER_PROPERTY						= "RSTA.eolMarker";
 	public static final String EOL_VISIBLE_PROPERTY						= "RSTA.eolMarkersVisible";
 	public static final String FOCUSABLE_TIPS_PROPERTY					= "RSTA.focusableTips";
 	public static final String FRACTIONAL_FONTMETRICS_PROPERTY			= "RSTA.fractionalFontMetrics";
@@ -200,6 +201,9 @@ public class RSyntaxTextArea extends RTextArea implements SyntaxConstants {
 
 	/** Whether EOL markers should be visible at the end of each line. */
 	private boolean eolMarkersVisible;
+
+	/** The marker rendered at the end of each line when EOL markers are visible. */
+	private String eolMarker = "\u21b2";
 
 	/** Whether tab lines are enabled. */
 	private boolean paintTabLines;
@@ -1093,6 +1097,19 @@ public class RSyntaxTextArea extends RTextArea implements SyntaxConstants {
 	 */
 	public boolean getEOLMarkersVisible() {
 		return eolMarkersVisible;
+	}
+
+
+	/**
+	 * Returns the marker rendered at the end of each line when EOL markers
+	 * are visible.  The default value is {@code "\u21b2"}.
+	 *
+	 * @return The EOL marker.
+	 * @see #setEOLMarker(String)
+	 * @see #getEOLMarkersVisible()
+	 */
+	public String getEOLMarker() {
+		return eolMarker;
 	}
 
 
@@ -2487,6 +2504,29 @@ public class RSyntaxTextArea extends RTextArea implements SyntaxConstants {
 			eolMarkersVisible = visible;
 			repaint();
 			firePropertyChange(EOL_VISIBLE_PROPERTY, !visible, visible);
+		}
+	}
+
+
+	/**
+	 * Sets the marker rendered at the end of each line when EOL markers are
+	 * visible.  This method fires a property change of type
+	 * {@link #EOL_MARKER_PROPERTY}.
+	 *
+	 * @param marker The new EOL marker.  This cannot be {@code null} or
+	 *        empty.
+	 * @see #getEOLMarker()
+	 * @see #setEOLMarkersVisible(boolean)
+	 */
+	public void setEOLMarker(String marker) {
+		if (marker == null || marker.isEmpty()) {
+			throw new IllegalArgumentException("marker cannot be null or empty");
+		}
+		if (!marker.equals(eolMarker)) {
+			String old = eolMarker;
+			eolMarker = marker;
+			repaint();
+			firePropertyChange(EOL_MARKER_PROPERTY, old, marker);
 		}
 	}
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/SyntaxView.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/SyntaxView.java
@@ -80,11 +80,6 @@ public class SyntaxView extends View implements TabExpander,
 	 */
 	private TokenImpl tempToken;
 
-	/**
-	 * Used as the default rendered EOL marker.
-	 */
-	static final String EOL_MARKER = "\u00B6";
-
 
 	/**
 	 * Constructs a new <code>SyntaxView</code> wrapped around an element.
@@ -176,7 +171,7 @@ public class SyntaxView extends View implements TabExpander,
 	static void drawEOLMarker(RSyntaxTextArea textArea, Graphics2D g, float x, float y) {
 		g.setColor(textArea.getForegroundForTokenType(TokenTypes.WHITESPACE));
 		g.setFont(textArea.getFontForTokenType(TokenTypes.WHITESPACE));
-		g.drawString(EOL_MARKER, x, y);
+		g.drawString(textArea.getEOLMarker(), x, y);
 	}
 
 
@@ -342,7 +337,7 @@ public class SyntaxView extends View implements TabExpander,
 	 * @return The width of the EOL marker.
 	 */
 	private float getEOLMarkerWidth(RSyntaxTextArea textArea) {
-		return metrics.stringWidth(EOL_MARKER);
+		return metrics.stringWidth(textArea.getEOLMarker());
 	}
 
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/WrappedSyntaxView.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/WrappedSyntaxView.java
@@ -40,8 +40,6 @@ import org.fife.ui.rsyntaxtextarea.folding.FoldManager;
 import org.fife.ui.rtextarea.Gutter;
 import org.fife.util.SwingUtils;
 
-import static org.fife.ui.rsyntaxtextarea.SyntaxView.EOL_MARKER;
-
 
 /**
  * The view used by {@link RSyntaxTextArea} when word wrap is enabled.
@@ -492,7 +490,10 @@ public class WrappedSyntaxView extends BoxView implements TabExpander,
 	 * @return The width of the EOL marker.
 	 */
 	private float getEOLMarkerWidth(RSyntaxTextArea textArea) {
-		return metrics.stringWidth(EOL_MARKER);
+		if (textArea == null) {
+			textArea = (RSyntaxTextArea)getContainer();
+		}
+		return metrics.stringWidth(textArea.getEOLMarker());
 	}
 
 

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaTest.java
@@ -372,6 +372,37 @@ class RSyntaxTextAreaTest extends AbstractRSyntaxTextAreaTest {
 
 
 	@Test
+	void testGetEOLMarker_default() {
+		RSyntaxTextArea textArea = new RSyntaxTextArea();
+		Assertions.assertEquals("\u21b2", textArea.getEOLMarker());
+	}
+
+
+	@Test
+	void testSetEOLMarker() {
+		RSyntaxTextArea textArea = new RSyntaxTextArea();
+		textArea.setEOLMarker("\u263a");
+		Assertions.assertEquals("\u263a", textArea.getEOLMarker());
+	}
+
+
+	@Test
+	void testSetEOLMarker_null() {
+		RSyntaxTextArea textArea = new RSyntaxTextArea();
+		Assertions.assertThrows(IllegalArgumentException.class,
+			() -> textArea.setEOLMarker(null));
+	}
+
+
+	@Test
+	void testSetEOLMarker_empty() {
+		RSyntaxTextArea textArea = new RSyntaxTextArea();
+		Assertions.assertThrows(IllegalArgumentException.class,
+			() -> textArea.setEOLMarker(""));
+	}
+
+
+	@Test
 	void testGetSetRightHandSideCorrection() {
 		RSyntaxTextArea textArea = createTextArea();
 		Assertions.assertEquals(0, textArea.getRightHandSideCorrection());


### PR DESCRIPTION
## Summary
- Adds `RSyntaxTextArea.getEOLMarker()` / `setEOLMarker(String)`, backed by a new `EOL_MARKER_PROPERTY` property-change event, following the same pattern as the existing `eolMarkersVisible` property.
- Removes the hardcoded pilcrow constant (`SyntaxView.EOL_MARKER`) from `SyntaxView` and `WrappedSyntaxView`; both now read the marker from the `RSyntaxTextArea` instance being rendered.
- Default marker is now `"↲"`.

Closes #704

## Screenshots

| Default | Customized |
| --- | --- |
| <img width="542" height="510" alt="image" src="https://github.com/user-attachments/assets/366850df-d55a-46a4-8728-557df5afca8e" /> | <img width="580" height="478" alt="image" src="https://github.com/user-attachments/assets/1c5374d7-bd72-4982-afa6-23d2b465dcd7" /> |

## Test plan
- [x] `./gradlew :RSyntaxTextArea:test` — full suite passes
- [x] `./gradlew :RSyntaxTextArea:check -x test` — checkstyle/other checks pass
- [x] Added unit tests: default value, setting a custom marker, and rejection of `null`/empty markers

🤖 Generated with [Claude Code](https://claude.com/claude-code)