### PR TITLE
fix: Make default monospaced font overridable

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/FontUtil.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/FontUtil.java
@@ -6,6 +6,7 @@ package org.fife.ui.rtextarea;
 
 import org.fife.ui.rsyntaxtextarea.OS;
 
+import javax.swing.*;
 import javax.swing.text.StyleContext;
 import java.awt.*;
 import java.awt.font.TextAttribute;
@@ -21,6 +22,15 @@ import java.util.Map;
  * @version 1.0
  */
 public final class FontUtil {
+
+	/**
+	 * If a KV pair with this key is defined in the UI defaults as a Font,
+	 * that font will be returned by {@link #getDefaultMonospacedFont()}. Note
+	 * that if you use this method, you should consider using {@link #createFont(String, int, int)}
+	 * to ensure it has a fallback for glyphs it doesn't support.
+	 */
+	public static final String DEFAULT_FONT_KEY = "org.fife.ui.rtextarea.defaultFont";
+
 
 	/**
 	 * Private constructor to prevent instantiation.
@@ -95,6 +105,11 @@ public final class FontUtil {
 	 * @return The default font.
 	 */
 	public static Font getDefaultMonospacedFont() {
+
+		Font font = UIManager.getFont(DEFAULT_FONT_KEY);
+		if (font != null) {
+			return font;
+		}
 
 		OS os = OS.get();
 

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/FontUtilTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/FontUtilTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import javax.swing.*;
 import java.awt.*;
 
 
@@ -108,6 +109,14 @@ class FontUtilTest {
 			// Can't verify too precisely since the test can run on any OS
 			Assertions.assertNotNull(FontUtil.getDefaultMonospacedFont());
 		}
+	}
+
+
+	@Test
+	void testGetDefaultMonospacedFont_overriddenDefault() {
+		Font font = new Font(Font.SERIF, Font.ITALIC, 5);
+		UIManager.put(FontUtil.DEFAULT_FONT_KEY, font);
+		Assertions.assertEquals(font, FontUtil.getDefaultMonospacedFont());
 	}
 
 


### PR DESCRIPTION
Fixes #392.

Make the default monospaced font used by `RTextArea` and subclasses, as well as the gutter, etc., overridable with a property defined in `UIManager`. This can be used in those rare cases where there is high latency loading fonts (as discussed in the ticket above), or if you just want to not have to call `setFont()` everywhre to override the default.