### PR TITLE
feat: start a new undo edit on newline insertion

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextArea.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextArea.java
@@ -845,6 +845,17 @@ public class RTextArea extends RTextAreaBase implements Printable {
 
 
 	/**
+	 * Returns the undo manager used by this text area.
+	 *
+	 * @return The undo manager.
+	 * @see #createUndoManager()
+	 */
+	public RUndoManager getUndoManager() {
+		return undoManager;
+	}
+
+
+	/**
 	 * Does the actual dirty-work of replacing the selected text in this
 	 * text area (i.e., in its document).  This method provides a hook for
 	 * subclasses to handle this in a different way.

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RUndoManager.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RUndoManager.java
@@ -12,7 +12,9 @@ import java.util.ResourceBundle;
 
 import javax.swing.Action;
 import javax.swing.UIManager;
+import javax.swing.event.DocumentEvent;
 import javax.swing.event.UndoableEditEvent;
+import javax.swing.text.BadLocationException;
 import javax.swing.undo.CompoundEdit;
 import javax.swing.undo.UndoManager;
 import javax.swing.undo.UndoableEdit;
@@ -25,6 +27,11 @@ import javax.swing.undo.UndoableEdit;
  * recognizes "replace" actions (i.e., text is selected, then the user
  * types), and treats it as a single action, instead of a remove/insert
  * action pair.
+ * <p>
+ * Pressing Enter to insert a newline ends the current compound edit and
+ * starts a new one, so that undoing after typing on a new line won't also
+ * remove the newline and any text typed before it.  This matches the
+ * behavior of editors such as IntelliJ and VS Code.
  *
  * @author Robert Futrell
  * @version 1.0
@@ -111,6 +118,29 @@ public class RUndoManager extends UndoManager {
 	}
 
 
+	/**
+	 * Returns whether the undoable edit represents the insertion of a
+	 * single newline character.
+	 *
+	 * @param e The event to check.
+	 * @return Whether the event represents a single newline insertion.
+	 */
+	private boolean isSingleNewLineInsertion(UndoableEditEvent e) {
+		UndoableEdit edit = e.getEdit();
+		if (edit instanceof DocumentEvent) {
+			DocumentEvent de = (DocumentEvent)edit;
+			if (de.getType() == DocumentEvent.EventType.INSERT && de.getLength() == 1) {
+				try {
+					return "\n".equals(textArea.getText(de.getOffset(), 1));
+				} catch (BadLocationException ble) {
+					// Shouldn't happen
+				}
+			}
+		}
+		return false;
+	}
+
+
 	@Override
 	public void redo() {
 		super.redo();
@@ -137,16 +167,36 @@ public class RUndoManager extends UndoManager {
 	@Override
 	public void undoableEditHappened(UndoableEditEvent e) {
 
+		boolean newLineInsertion = internalAtomicEditDepth==0 &&
+			isSingleNewLineInsertion(e);
+
 		// This happens when the first undoable edit occurs, and
 		// just after an undo.  So, we need to update our actions.
 		if (compoundEdit==null) {
 			compoundEdit = startCompoundEdit(e.getEdit());
 			updateActions();
+			// A newline should be undone by itself, separately from
+			// whatever gets typed after it.
+			if (newLineInsertion) {
+				compoundEdit.end();
+				compoundEdit = null;
+			}
 			return;
 		}
 
 		else if (internalAtomicEditDepth>0) {
 			compoundEdit.addEdit(e.getEdit());
+			return;
+		}
+
+		// A newline ends whatever compound edit was in progress, and starts
+		// (and immediately ends) a new one containing only the newline, so
+		// undoing it doesn't also undo text typed before or after it.
+		if (newLineInsertion) {
+			compoundEdit.end();
+			compoundEdit = startCompoundEdit(e.getEdit());
+			compoundEdit.end();
+			compoundEdit = null;
 			return;
 		}
 

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/RTextAreaTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/RTextAreaTest.java
@@ -178,6 +178,20 @@ class RTextAreaTest {
 
 
 	@Test
+	void testGetUndoManager() {
+		final RUndoManager[] undoManager = new RUndoManager[1];
+		RTextArea textArea = new RTextArea() {
+			@Override
+			protected RUndoManager createUndoManager() {
+				RUndoManager um = new RUndoManager(this);
+				return undoManager[0] = um;
+			}
+		};
+		Assertions.assertEquals(undoManager[0], textArea.getUndoManager());
+	}
+
+
+	@Test
 	void testMarkAllOnOccurrenceSearches() {
 		RTextArea textArea = new RTextArea();
 		Assertions.assertTrue(textArea.getMarkAllOnOccurrenceSearches());

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/RUndoManagerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/RUndoManagerTest.java
@@ -1,0 +1,156 @@
+/*
+ * This library is distributed under a modified BSD license.  See the included
+ * LICENSE file for details.
+ */
+package org.fife.ui.rtextarea;
+
+import org.fife.ui.SwingRunnerExtension;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import javax.swing.text.BadLocationException;
+
+
+/**
+ * Unit tests for the {@link RUndoManager} class.
+ *
+ * @author Robert Futrell
+ * @version 1.0
+ */
+@ExtendWith(SwingRunnerExtension.class)
+class RUndoManagerTest {
+
+
+	/**
+	 * Simulates the user typing {@code str} one character at a time at the
+	 * end of {@code textArea}, since {@code append()} does not necessarily
+	 * move the caret the way real key presses would.
+	 */
+	private static void type(RTextArea textArea, String str) throws BadLocationException {
+		for (int i = 0; i < str.length(); i++) {
+			int end = textArea.getDocument().getLength();
+			textArea.getDocument().insertString(end, String.valueOf(str.charAt(i)), null);
+			textArea.setCaretPosition(end + 1);
+		}
+	}
+
+
+	@Test
+	void testUndoableEditHappened_newLineStartsNewCompoundEdit() throws BadLocationException {
+
+		RTextArea textArea = new RTextArea();
+
+		type(textArea, "foo");
+		type(textArea, "\n");
+		type(textArea, "bar");
+
+		Assertions.assertEquals("foo\nbar", textArea.getText());
+
+		// "bar" is undone as its own edit.
+		textArea.undoLastAction();
+		Assertions.assertEquals("foo\n", textArea.getText());
+
+		// The newline is undone separately from the text before or after it.
+		textArea.undoLastAction();
+		Assertions.assertEquals("foo", textArea.getText());
+
+		// "foo" is undone as its own edit.
+		textArea.undoLastAction();
+		Assertions.assertEquals("", textArea.getText());
+
+		Assertions.assertFalse(textArea.canUndo());
+	}
+
+
+	/**
+	 * Simulates pasting {@code str} at the end of {@code textArea} as a
+	 * single edit, the way {@code JTextComponent.paste()} would, rather
+	 * than one character at a time like {@link #type(RTextArea, String)}.
+	 */
+	private static void paste(RTextArea textArea, String str) throws BadLocationException {
+		int end = textArea.getDocument().getLength();
+		textArea.getDocument().insertString(end, str, null);
+		textArea.setCaretPosition(end + str.length());
+	}
+
+
+	@Test
+	void testUndoableEditHappened_pastedTextWithNewlineIsUndoneAsOneEdit() throws BadLocationException {
+
+		RTextArea textArea = new RTextArea();
+
+		type(textArea, "foo");
+		paste(textArea, "one\ntwo");
+
+		Assertions.assertEquals("fooone\ntwo", textArea.getText());
+
+		// The entire pasted blob, newline included, is undone as one edit.
+		textArea.undoLastAction();
+		Assertions.assertEquals("foo", textArea.getText());
+
+		// "foo" is undone as its own edit.
+		textArea.undoLastAction();
+		Assertions.assertEquals("", textArea.getText());
+
+		Assertions.assertFalse(textArea.canUndo());
+	}
+
+
+	@Test
+	void testUndoableEditHappened_atomicNewLineStartsNewCompoundEdit() throws BadLocationException {
+
+		RTextArea textArea = new RTextArea();
+
+		type(textArea, "foo");
+
+		// Simulates a newline insertion wrapped in an atomic edit, the way
+		// RSyntaxTextAreaEditorKit.InsertBreakAction wraps a newline plus
+		// auto-indent whitespace in beginAtomicEdit()/endAtomicEdit().
+		textArea.beginAtomicEdit();
+		try {
+			type(textArea, "\n");
+		} finally {
+			textArea.endAtomicEdit();
+		}
+
+		type(textArea, "bar");
+
+		Assertions.assertEquals("foo\nbar", textArea.getText());
+
+		// "bar" is undone as its own edit.
+		textArea.undoLastAction();
+		Assertions.assertEquals("foo\n", textArea.getText());
+
+		// The atomically-inserted newline is undone separately, just like a
+		// plain (non-atomic) newline insertion would be.
+		textArea.undoLastAction();
+		Assertions.assertEquals("foo", textArea.getText());
+
+		// "foo" is undone as its own edit.
+		textArea.undoLastAction();
+		Assertions.assertEquals("", textArea.getText());
+
+		Assertions.assertFalse(textArea.canUndo());
+	}
+
+
+	@Test
+	void testUndoableEditHappened_multipleNewLinesAreSeparateEdits() throws BadLocationException {
+
+		RTextArea textArea = new RTextArea();
+
+		type(textArea, "\n");
+		type(textArea, "\n");
+
+		Assertions.assertEquals("\n\n", textArea.getText());
+
+		textArea.undoLastAction();
+		Assertions.assertEquals("\n", textArea.getText());
+
+		textArea.undoLastAction();
+		Assertions.assertEquals("", textArea.getText());
+
+		Assertions.assertFalse(textArea.canUndo());
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #372.

- `RUndoManager` now ends the current compound undo edit whenever a newline is inserted (e.g. pressing Enter), so undoing after typing on a new line doesn't also undo the newline and text typed before it. This matches the behavior of editors like IntelliJ and VS Code.
- This also correctly isolates newlines inserted as part of an atomic edit (e.g. `RSyntaxTextAreaEditorKit.InsertBreakAction`'s newline + auto-indent whitespace, wrapped in `beginAtomicEdit()`/`endAtomicEdit()`), consistent with how a plain newline insertion is treated.
- Added `RTextArea#getUndoManager()` so callers can access the active `RUndoManager` instance (previously only settable via overriding `createUndoManager()`, with no way to retrieve it afterward).

This is unconditional -- no opt-out toggle. An earlier version of this PR included a `setBreakUndoOnNewLine(boolean)` escape hatch, but since 4.0.0 is a major version bump where API breakage is acceptable, and no one had asked for the old grouping behavior back, we cut it to keep the change simple. It roughly halved the diff (removed a stateful flag, the logic to preserve it across `discardAllEdits()`, and the deferred atomic-edit merge/isolate decision needed to honor it).

Note: only newline *insertion* is special-cased; deleting a newline (e.g. backspacing at the start of a line) is not, since the Swing `UndoableEditEvent`/`DocumentEvent` for a removal fires after the text is already gone from the document, so there's no straightforward way to inspect what was removed without deeper plumbing. Happy to follow up on that separately if desired.

## Test plan

- [x] `RUndoManagerTest` covers: a plain newline starts a new compound edit, an atomic (auto-indent-wrapped) newline does too, multiple consecutive newlines are separate edits, and pasted text containing a newline is undone as a single blob.
- [x] `./gradlew clean build` passes locally (checkstyle, spotbugs, all unit tests).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)