### PR TITLE
feat: add RUndoManager#setEnabled to allow disabling undo tracking

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RUndoManager.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RUndoManager.java
@@ -43,6 +43,7 @@ public class RUndoManager extends UndoManager {
 	private int lastOffset;
 	private String cantUndoText;
 	private String cantRedoText;
+	private boolean enabled;
 
 	private int internalAtomicEditDepth;
 
@@ -56,6 +57,7 @@ public class RUndoManager extends UndoManager {
 	 */
 	public RUndoManager(RTextArea textArea) {
 		this.textArea = textArea;
+		this.enabled = true;
 		ResourceBundle msg = ResourceBundle.getBundle(MSG);
 		cantUndoText = msg.getString("Action.CantUndo.Name");
 		cantRedoText = msg.getString("Action.CantRedo.Name");
@@ -72,6 +74,9 @@ public class RUndoManager extends UndoManager {
 	 * @see #endInternalAtomicEdit()
 	 */
 	public void beginInternalAtomicEdit() {
+		if (!enabled) {
+			return;
+		}
 		if (++internalAtomicEditDepth==1) {
 			if (compoundEdit!=null) {
 				compoundEdit.end();
@@ -87,11 +92,56 @@ public class RUndoManager extends UndoManager {
 	 * @see #beginInternalAtomicEdit()
 	 */
 	public void endInternalAtomicEdit() {
+		if (!enabled) {
+			return;
+		}
 		if (internalAtomicEditDepth>0 && --internalAtomicEditDepth==0) {
 			addEdit(compoundEdit);
 			compoundEdit.end();
 			compoundEdit = null;
 			updateActions();	// Needed to show the new display name.
+		}
+	}
+
+
+	/**
+	 * Returns whether this undo manager is recording undoable edits.
+	 *
+	 * @return Whether this undo manager is enabled.
+	 * @see #setEnabled(boolean)
+	 */
+	public boolean isEnabled() {
+		return enabled;
+	}
+
+
+	/**
+	 * Sets whether this undo manager records undoable edits.  Applications
+	 * that perform their own large-scale, high-frequency document
+	 * modifications and have no need for undo/redo on a given text area
+	 * (e.g. a scrolling, read-only log console) should call
+	 * {@code setEnabled(false)} rather than relying on
+	 * {@link #setLimit(int)}.  Contrary to what one might expect,
+	 * {@code setLimit(0)} does <em>not</em> disable undo tracking; per the
+	 * contract of {@link UndoManager#setLimit(int)}, it instead makes the
+	 * edit history unbounded, which can quickly exhaust memory.
+	 * <p>
+	 * Disabling this undo manager discards any edits already being tracked,
+	 * since they can no longer be undone or redone in a meaningful way once
+	 * tracking stops.  Re-enabling it does not restore those edits; it
+	 * simply resumes recording edits from that point forward.
+	 *
+	 * @param enabled Whether this undo manager should record undoable
+	 *        edits.
+	 * @see #isEnabled()
+	 */
+	public void setEnabled(boolean enabled) {
+		if (enabled != this.enabled) {
+			this.enabled = enabled;
+			internalAtomicEditDepth = 0;
+			compoundEdit = null;
+			discardAllEdits();
+			updateActions();
 		}
 	}
 
@@ -166,6 +216,10 @@ public class RUndoManager extends UndoManager {
 
 	@Override
 	public void undoableEditHappened(UndoableEditEvent e) {
+
+		if (!enabled) {
+			return;
+		}
 
 		boolean newLineInsertion = internalAtomicEditDepth==0 &&
 			isSingleNewLineInsertion(e);

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/RUndoManagerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/RUndoManagerTest.java
@@ -153,4 +153,99 @@ class RUndoManagerTest {
 
 		Assertions.assertFalse(textArea.canUndo());
 	}
+
+
+	@Test
+	void testIsEnabled_defaultsToTrue() {
+		RTextArea textArea = new RTextArea();
+		Assertions.assertTrue(textArea.getUndoManager().isEnabled());
+	}
+
+
+	@Test
+	void testSetEnabled_false_noLongerRecordsEdits() throws BadLocationException {
+
+		RTextArea textArea = new RTextArea();
+		RUndoManager undoManager = textArea.getUndoManager();
+
+		undoManager.setEnabled(false);
+		Assertions.assertFalse(undoManager.isEnabled());
+
+		type(textArea, "foo");
+
+		Assertions.assertEquals("foo", textArea.getText());
+		Assertions.assertFalse(textArea.canUndo());
+	}
+
+
+	@Test
+	void testSetEnabled_false_discardsExistingEdits() throws BadLocationException {
+
+		RTextArea textArea = new RTextArea();
+		RUndoManager undoManager = textArea.getUndoManager();
+
+		type(textArea, "foo");
+		Assertions.assertTrue(textArea.canUndo());
+
+		undoManager.setEnabled(false);
+		Assertions.assertFalse(textArea.canUndo());
+	}
+
+
+	@Test
+	void testSetEnabled_false_endsInProgressAtomicEdit() throws BadLocationException {
+
+		RTextArea textArea = new RTextArea();
+		RUndoManager undoManager = textArea.getUndoManager();
+
+		textArea.beginAtomicEdit();
+		try {
+			type(textArea, "foo");
+			undoManager.setEnabled(false);
+		} finally {
+			// Should be a no-op since the manager is disabled, and must not
+			// throw despite the internal atomic edit depth being reset.
+			textArea.endAtomicEdit();
+		}
+
+		Assertions.assertFalse(textArea.canUndo());
+	}
+
+
+	@Test
+	void testSetEnabled_true_afterBeingDisabled_resumesRecordingEdits() throws BadLocationException {
+
+		RTextArea textArea = new RTextArea();
+		RUndoManager undoManager = textArea.getUndoManager();
+
+		undoManager.setEnabled(false);
+		type(textArea, "foo");
+
+		undoManager.setEnabled(true);
+		Assertions.assertTrue(undoManager.isEnabled());
+		type(textArea, "bar");
+
+		Assertions.assertEquals("foobar", textArea.getText());
+		Assertions.assertTrue(textArea.canUndo());
+
+		textArea.undoLastAction();
+		Assertions.assertEquals("foo", textArea.getText());
+	}
+
+
+	@Test
+	void testSetEnabled_sameValue_isNoOp() throws BadLocationException {
+
+		RTextArea textArea = new RTextArea();
+		RUndoManager undoManager = textArea.getUndoManager();
+
+		type(textArea, "foo");
+		Assertions.assertTrue(textArea.canUndo());
+
+		undoManager.setEnabled(true);
+
+		Assertions.assertTrue(textArea.canUndo());
+		textArea.undoLastAction();
+		Assertions.assertEquals("", textArea.getText());
+	}
 }


### PR DESCRIPTION
## Summary
- Fixes #99: applications with high-frequency programmatic document edits (e.g. a scrolling log console) have historically been told to call `getUndoManager().setLimit(0)` to disable undo tracking. Per `UndoManager`'s contract, a limit of `0` doesn't disable tracking — it makes the edit history *unbounded*, which can lead to an `OutOfMemoryError` as edits pile up forever.
- Adds `RUndoManager#setEnabled(boolean)` / `#isEnabled()`. Disabling stops the manager from recording new edits (`undoableEditHappened`, `beginInternalAtomicEdit`, `endInternalAtomicEdit` all become no-ops) and discards any edits already being tracked via `discardAllEdits()`.
- Intentionally does **not** add any new API surface to `RTextArea` — callers reach this via the existing `RTextArea#getUndoManager()` accessor.

## Test plan
- [x] `./gradlew clean build` passes (checkstyle, spotbugs, unit tests all green)
- [x] Added unit tests in `RUndoManagerTest` covering:
  - default enabled state
  - edits are not recorded while disabled
  - existing edits are discarded when disabled
  - an in-progress atomic edit is safely ended when disabled mid-edit
  - re-enabling resumes recording new edits
  - calling `setEnabled` with the current value is a no-op

🤖 Generated with [Claude Code](https://claude.ai/claude-code)