### PR TITLE
fix: use YYINITIAL instead of TokenTypes.NULL for initial lexer state

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/ActionScriptTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/ActionScriptTokenMaker.flex
@@ -149,14 +149,14 @@ import org.fife.ui.rsyntaxtextarea.*;
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = TokenTypes.NULL;
+		int state = YYINITIAL;
 		switch (initialTokenType) {
 			case TokenTypes.COMMENT_MULTILINE:
 				state = MLC;
 				start = text.offset;
 				break;
 			default:
-				state = TokenTypes.NULL;
+				state = YYINITIAL;
 		}
 
 		s = text;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/ActionScriptTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/ActionScriptTokenMaker.java
@@ -1520,14 +1520,14 @@ public class ActionScriptTokenMaker extends AbstractJFlexCTokenMaker {
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = TokenTypes.NULL;
+		int state = YYINITIAL;
 		switch (initialTokenType) {
 			case TokenTypes.COMMENT_MULTILINE:
 				state = MLC;
 				start = text.offset;
 				break;
 			default:
-				state = TokenTypes.NULL;
+				state = YYINITIAL;
 		}
 
 		s = text;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/BBCodeTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/BBCodeTokenMaker.flex
@@ -170,14 +170,14 @@ import org.fife.ui.rsyntaxtextarea.*;
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = TokenTypes.NULL;
+		int state = YYINITIAL;
 		switch (initialTokenType) {
 			case INTERNAL_INTAG:
 				state = INTAG;
 				start = text.offset;
 				break;
 			default:
-				state = TokenTypes.NULL;
+				state = YYINITIAL;
 		}
 
 		s = text;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/BBCodeTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/BBCodeTokenMaker.java
@@ -371,14 +371,14 @@ public class BBCodeTokenMaker extends AbstractMarkupTokenMaker {
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = TokenTypes.NULL;
+		int state = YYINITIAL;
 		switch (initialTokenType) {
 			case INTERNAL_INTAG:
 				state = INTAG;
 				start = text.offset;
 				break;
 			default:
-				state = TokenTypes.NULL;
+				state = YYINITIAL;
 		}
 
 		s = text;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/CTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/CTokenMaker.flex
@@ -149,14 +149,14 @@ import org.fife.ui.rsyntaxtextarea.*;
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = TokenTypes.NULL;
+		int state = YYINITIAL;
 		switch (initialTokenType) {
 			case TokenTypes.COMMENT_MULTILINE:
 				state = MLC;
 				start = text.offset;
 				break;
 			default:
-				state = TokenTypes.NULL;
+				state = YYINITIAL;
 		}
 
 		s = text;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/CTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/CTokenMaker.java
@@ -1654,14 +1654,14 @@ public class CTokenMaker extends AbstractJFlexCTokenMaker {
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = TokenTypes.NULL;
+		int state = YYINITIAL;
 		switch (initialTokenType) {
 			case TokenTypes.COMMENT_MULTILINE:
 				state = MLC;
 				start = text.offset;
 				break;
 			default:
-				state = TokenTypes.NULL;
+				state = YYINITIAL;
 		}
 
 		s = text;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/ClojureTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/ClojureTokenMaker.flex
@@ -160,7 +160,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = TokenTypes.NULL;
+		int state = YYINITIAL;
 		switch (initialTokenType) {
 			/*case TokenTypes.COMMENT_MULTILINE:
 				state = MLC;
@@ -175,7 +175,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 				start = text.offset;
 				break;
 			default:
-				state = TokenTypes.NULL;
+				state = YYINITIAL;
 		}
 
 		s = text;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/ClojureTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/ClojureTokenMaker.java
@@ -1899,7 +1899,7 @@ public class ClojureTokenMaker extends AbstractJFlexTokenMaker {
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = TokenTypes.NULL;
+		int state = YYINITIAL;
 		switch (initialTokenType) {
 			/*case TokenTypes.COMMENT_MULTILINE:
 				state = MLC;
@@ -1914,7 +1914,7 @@ public class ClojureTokenMaker extends AbstractJFlexTokenMaker {
 				start = text.offset;
 				break;
 			default:
-				state = TokenTypes.NULL;
+				state = YYINITIAL;
 		}
 
 		s = text;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/DelphiTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/DelphiTokenMaker.flex
@@ -204,7 +204,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 				start = text.offset;
 				break;
 			default:
-				state = TokenTypes.NULL;
+				state = YYINITIAL;
 		}
 
 		s = text;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/DelphiTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/DelphiTokenMaker.java
@@ -1174,7 +1174,7 @@ public class DelphiTokenMaker extends AbstractJFlexTokenMaker {
 				start = text.offset;
 				break;
 			default:
-				state = TokenTypes.NULL;
+				state = YYINITIAL;
 		}
 
 		s = text;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/DockerTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/DockerTokenMaker.flex
@@ -153,7 +153,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = TokenTypes.NULL;
+		int state = YYINITIAL;
 
 		s = text;
 		try {

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/DockerTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/DockerTokenMaker.java
@@ -393,7 +393,7 @@ public class DockerTokenMaker extends AbstractJFlexTokenMaker {
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = TokenTypes.NULL;
+		int state = YYINITIAL;
 
 		s = text;
 		try {

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/FortranTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/FortranTokenMaker.flex
@@ -142,7 +142,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = TokenTypes.NULL;
+		int state = YYINITIAL;
 		switch (initialTokenType) {
 			case TokenTypes.LITERAL_STRING_DOUBLE_QUOTE:
 				state = STRING;
@@ -153,7 +153,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 				start = text.offset;
 				break;
 			default:
-				state = TokenTypes.NULL;
+				state = YYINITIAL;
 		}
 
 		s = text;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/FortranTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/FortranTokenMaker.java
@@ -605,7 +605,7 @@ public class FortranTokenMaker extends AbstractJFlexTokenMaker {
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = TokenTypes.NULL;
+		int state = YYINITIAL;
 		switch (initialTokenType) {
 			case TokenTypes.LITERAL_STRING_DOUBLE_QUOTE:
 				state = STRING;
@@ -616,7 +616,7 @@ public class FortranTokenMaker extends AbstractJFlexTokenMaker {
 				start = text.offset;
 				break;
 			default:
-				state = TokenTypes.NULL;
+				state = YYINITIAL;
 		}
 
 		s = text;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/GoTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/GoTokenMaker.flex
@@ -150,7 +150,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 				start = text.offset;
 				break;
 			default:
-				state = TokenTypes.NULL;
+				state = YYINITIAL;
 		}
 
 		s = text;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/GoTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/GoTokenMaker.java
@@ -1069,7 +1069,7 @@ public class GoTokenMaker extends AbstractJFlexCTokenMaker {
 				start = text.offset;
 				break;
 			default:
-				state = TokenTypes.NULL;
+				state = YYINITIAL;
 		}
 
 		s = text;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/GroovyTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/GroovyTokenMaker.flex
@@ -146,7 +146,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = TokenTypes.NULL;
+		int state = YYINITIAL;
 		switch (initialTokenType) {
 			case TokenTypes.LITERAL_STRING_DOUBLE_QUOTE:
 				state = MULTILINE_STRING_DOUBLE;
@@ -165,7 +165,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 				start = text.offset;
 				break;
 			default:
-				state = TokenTypes.NULL;
+				state = YYINITIAL;
 		}
 
 		s = text;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/GroovyTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/GroovyTokenMaker.java
@@ -4996,7 +4996,7 @@ public class GroovyTokenMaker extends AbstractJFlexCTokenMaker {
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = TokenTypes.NULL;
+		int state = YYINITIAL;
 		switch (initialTokenType) {
 			case TokenTypes.LITERAL_STRING_DOUBLE_QUOTE:
 				state = MULTILINE_STRING_DOUBLE;
@@ -5015,7 +5015,7 @@ public class GroovyTokenMaker extends AbstractJFlexCTokenMaker {
 				start = text.offset;
 				break;
 			default:
-				state = TokenTypes.NULL;
+				state = YYINITIAL;
 		}
 
 		s = text;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/HTMLTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/HTMLTokenMaker.flex
@@ -494,7 +494,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 					languageIndex = LANG_INDEX_CSS;
 				}
 				else {
-					state = TokenTypes.NULL;
+					state = YYINITIAL;
 				}
 				break;
 		}

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/HTMLTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/HTMLTokenMaker.java
@@ -2270,7 +2270,7 @@ public class HTMLTokenMaker extends AbstractMarkupTokenMaker {
 					languageIndex = LANG_INDEX_CSS;
 				}
 				else {
-					state = TokenTypes.NULL;
+					state = YYINITIAL;
 				}
 				break;
 		}

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/JSPTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/JSPTokenMaker.flex
@@ -546,7 +546,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 					}
 				}
 				else {
-					state = TokenTypes.NULL;
+					state = YYINITIAL;
 				}
 				break;
 		}

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/JSPTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/JSPTokenMaker.java
@@ -7054,7 +7054,7 @@ public class JSPTokenMaker extends AbstractMarkupTokenMaker {
 					}
 				}
 				else {
-					state = TokenTypes.NULL;
+					state = YYINITIAL;
 				}
 				break;
 		}

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/KotlinTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/KotlinTokenMaker.flex
@@ -145,7 +145,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = TokenTypes.NULL;
+		int state = YYINITIAL;
 		switch (initialTokenType) {
 			case TokenTypes.COMMENT_MULTILINE:
 				state = MLC;
@@ -156,7 +156,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 				start = text.offset;
 				break;
 			default:
-				state = TokenTypes.NULL;
+				state = YYINITIAL;
 		}
 
 		s = text;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/KotlinTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/KotlinTokenMaker.java
@@ -5186,7 +5186,7 @@ public class KotlinTokenMaker extends AbstractJFlexCTokenMaker {
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = TokenTypes.NULL;
+		int state = YYINITIAL;
 		switch (initialTokenType) {
 			case TokenTypes.COMMENT_MULTILINE:
 				state = MLC;
@@ -5197,7 +5197,7 @@ public class KotlinTokenMaker extends AbstractJFlexCTokenMaker {
 				start = text.offset;
 				break;
 			default:
-				state = TokenTypes.NULL;
+				state = YYINITIAL;
 		}
 
 		s = text;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/LatexTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/LatexTokenMaker.flex
@@ -159,7 +159,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = TokenTypes.NULL;
+		int state = YYINITIAL;
 
 		s = text;
 		try {

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/LatexTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/LatexTokenMaker.java
@@ -372,7 +372,7 @@ public class LatexTokenMaker extends AbstractJFlexTokenMaker {
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = TokenTypes.NULL;
+		int state = YYINITIAL;
 
 		s = text;
 		try {

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/LispTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/LispTokenMaker.flex
@@ -155,7 +155,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = TokenTypes.NULL;
+		int state = YYINITIAL;
 		switch (initialTokenType) {
 			case TokenTypes.COMMENT_MULTILINE:
 				state = MLC;
@@ -166,7 +166,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 				start = text.offset;
 				break;
 			default:
-				state = TokenTypes.NULL;
+				state = YYINITIAL;
 		}
 
 		s = text;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/LispTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/LispTokenMaker.java
@@ -892,7 +892,7 @@ public class LispTokenMaker extends AbstractJFlexTokenMaker {
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = TokenTypes.NULL;
+		int state = YYINITIAL;
 		switch (initialTokenType) {
 			case TokenTypes.COMMENT_MULTILINE:
 				state = MLC;
@@ -903,7 +903,7 @@ public class LispTokenMaker extends AbstractJFlexTokenMaker {
 				start = text.offset;
 				break;
 			default:
-				state = TokenTypes.NULL;
+				state = YYINITIAL;
 		}
 
 		s = text;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/LuaTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/LuaTokenMaker.flex
@@ -140,7 +140,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = TokenTypes.NULL;
+		int state = YYINITIAL;
 		switch (initialTokenType) {
 			case TokenTypes.COMMENT_MULTILINE:
 				state = MLC;
@@ -151,7 +151,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 				start = text.offset;
 				break;
 			default:
-				state = TokenTypes.NULL;
+				state = YYINITIAL;
 		}
 
 		s = text;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/LuaTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/LuaTokenMaker.java
@@ -556,7 +556,7 @@ public class LuaTokenMaker extends AbstractJFlexTokenMaker {
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = TokenTypes.NULL;
+		int state = YYINITIAL;
 		switch (initialTokenType) {
 			case TokenTypes.COMMENT_MULTILINE:
 				state = MLC;
@@ -567,7 +567,7 @@ public class LuaTokenMaker extends AbstractJFlexTokenMaker {
 				start = text.offset;
 				break;
 			default:
-				state = TokenTypes.NULL;
+				state = YYINITIAL;
 		}
 
 		s = text;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/MxmlTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/MxmlTokenMaker.flex
@@ -264,7 +264,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = TokenTypes.NULL;
+		int state = YYINITIAL;
 		switch (initialTokenType) {
 			case TokenTypes.MARKUP_COMMENT:
 				state = COMMENT;
@@ -315,7 +315,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 				start = text.offset;
 				break;
 			default:
-				state = TokenTypes.NULL;
+				state = YYINITIAL;
 		}
 
 		s = text;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/MxmlTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/MxmlTokenMaker.java
@@ -2058,7 +2058,7 @@ public class MxmlTokenMaker extends AbstractMarkupTokenMaker {
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = TokenTypes.NULL;
+		int state = YYINITIAL;
 		switch (initialTokenType) {
 			case TokenTypes.MARKUP_COMMENT:
 				state = COMMENT;
@@ -2109,7 +2109,7 @@ public class MxmlTokenMaker extends AbstractMarkupTokenMaker {
 				start = text.offset;
 				break;
 			default:
-				state = TokenTypes.NULL;
+				state = YYINITIAL;
 		}
 
 		s = text;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/PropertiesFileTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/PropertiesFileTokenMaker.flex
@@ -135,14 +135,14 @@ import org.fife.ui.rsyntaxtextarea.*;
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = TokenTypes.NULL;
+		int state = YYINITIAL;
 		switch (initialTokenType) {
 			case TokenTypes.LITERAL_STRING_DOUBLE_QUOTE:
 				state = VALUE;
 				start = text.offset;
 				break;
 			default:
-				state = TokenTypes.NULL;
+				state = YYINITIAL;
 		}
 
 		s = text;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/PropertiesFileTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/PropertiesFileTokenMaker.java
@@ -311,14 +311,14 @@ public class PropertiesFileTokenMaker extends AbstractJFlexTokenMaker {
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = TokenTypes.NULL;
+		int state = YYINITIAL;
 		switch (initialTokenType) {
 			case TokenTypes.LITERAL_STRING_DOUBLE_QUOTE:
 				state = VALUE;
 				start = text.offset;
 				break;
 			default:
-				state = TokenTypes.NULL;
+				state = YYINITIAL;
 		}
 
 		s = text;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/PythonTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/PythonTokenMaker.flex
@@ -123,7 +123,7 @@ import org.fife.ui.rsyntaxtextarea.TokenTypes;
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = TokenTypes.NULL;
+		int state = YYINITIAL;
 		switch (initialTokenType) {
 			case TokenTypes.LITERAL_STRING_DOUBLE_QUOTE:
 				state = LONG_STRING_2;
@@ -132,7 +132,7 @@ import org.fife.ui.rsyntaxtextarea.TokenTypes;
 				state = LONG_STRING_1;
 				break;
 			default:
-				state = TokenTypes.NULL;
+				state = YYINITIAL;
 		}
 
 		s = text;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/PythonTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/PythonTokenMaker.java
@@ -715,7 +715,7 @@ public class PythonTokenMaker extends AbstractJFlexTokenMaker {
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = TokenTypes.NULL;
+		int state = YYINITIAL;
 		switch (initialTokenType) {
 			case TokenTypes.LITERAL_STRING_DOUBLE_QUOTE:
 				state = LONG_STRING_2;
@@ -724,7 +724,7 @@ public class PythonTokenMaker extends AbstractJFlexTokenMaker {
 				state = LONG_STRING_1;
 				break;
 			default:
-				state = TokenTypes.NULL;
+				state = YYINITIAL;
 		}
 
 		s = text;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/TclTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/TclTokenMaker.flex
@@ -134,7 +134,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = TokenTypes.NULL;
+		int state = YYINITIAL;
 
 		s = text;
 		try {

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/TclTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/TclTokenMaker.java
@@ -713,7 +713,7 @@ public class TclTokenMaker extends AbstractJFlexCTokenMaker {
 		this.offsetShift = -text.offset + startOffset;
 
 		// Start off in the proper state.
-		int state = TokenTypes.NULL;
+		int state = YYINITIAL;
 
 		s = text;
 		try {

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/XMLTokenMaker.flex
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/XMLTokenMaker.flex
@@ -296,7 +296,7 @@ import org.fife.ui.rsyntaxtextarea.*;
 					prevState = -initialTokenType&0xff;
 				}
 				else { // Shouldn't happen
-					state = TokenTypes.NULL;
+					state = YYINITIAL;
 				}
 		}
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/XMLTokenMaker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/modes/XMLTokenMaker.java
@@ -527,7 +527,7 @@ public class XMLTokenMaker extends AbstractMarkupTokenMaker {
 					prevState = -initialTokenType&0xff;
 				}
 				else { // Shouldn't happen
-					state = TokenTypes.NULL;
+					state = YYINITIAL;
 				}
 		}
 


### PR DESCRIPTION
## Summary
- Every generated `TokenMaker`'s state-reset logic (used when re-tokenizing after edits) initialized the JFlex lexer state variable with `TokenTypes.NULL` — a token-type constant — instead of `YYINITIAL`, the JFlex-generated constant that actually represents the lexer's initial state.
- Both constants happen to be `0`, so there was no functional/behavioral change, but referencing the wrong constant was misleading and fragile (relying on both being defined as 0 by coincidence rather than by contract).
- Updated all affected `.flex` grammar sources and their generated `.java` `TokenMaker` counterparts (ActionScript, BBCode, C, Clojure, Delphi, Docker, Fortran, Go, Groovy, HTML, JSP, Kotlin, Latex, Lisp, Lua, Mxml, PropertiesFile, Python, Tcl, XML) to use `YYINITIAL`.

## Test plan
- [x] `./gradlew clean build` passes (checkstyle, spotbugs, full unit test suite all green)
- [x] No behavioral change expected since `TokenTypes.NULL == YYINITIAL == 0` in every affected lexer; this is a correctness/clarity fix, not a functional one

🤖 Generated with [Claude Code](https://claude.ai/claude-code)