### PR TITLE
build(deps): bump gradle, spotbugs, checkstyle, and junit-bom

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/io/UnicodeWriter.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/io/UnicodeWriter.java
@@ -259,6 +259,18 @@ public class UnicodeWriter extends Writer {
 
 
 	/**
+	 * Writes a single character.
+	 *
+	 * @param c An integer specifying the character to write.
+	 * @throws IOException If an IO error occurs.
+	 */
+	@Override
+	public void write(int c) throws IOException {
+		internalOut.write(c);
+	}
+
+
+	/**
 	 * Writes a portion of an array of characters.
 	 *
 	 * @param cbuf The buffer of characters.
@@ -269,18 +281,6 @@ public class UnicodeWriter extends Writer {
 	@Override
 	public void write(char[] cbuf, int off, int len) throws IOException {
 		internalOut.write(cbuf, off, len);
-	}
-
-
-	/**
-	 * Writes a single character.
-	 *
-	 * @param c An integer specifying the character to write.
-	 * @throws IOException If an IO error occurs.
-	 */
-	@Override
-	public void write(int c) throws IOException {
-		internalOut.write(c);
 	}
 
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextArea.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextArea.java
@@ -592,34 +592,6 @@ public class RSyntaxTextArea extends RTextArea implements SyntaxConstants {
 
 
 	/**
-	 * Copies the currently selected text to the system clipboard, with style
-	 * information from the specified theme.  Does nothing for {@code null} or
-	 * empty selections.
-	 *
-	 * @param theme The theme to use for the color and font information.
-	 *        This may be {@code null}, in which case this text area's
-	 *        current styles are used.
-	 * @see #copyAsStyledText()
-	 */
-	public void copyAsStyledText(Theme theme) {
-
-		// It's more performant to call the no-arg overload
-		if (theme == null) {
-			copyAsStyledText();
-			return;
-		}
-
-		Theme origTheme = new Theme(this);
-
-		theme.apply(this);
-		try {
-			copyAsStyledText();
-		} finally {
-			origTheme.apply(this);
-		}
-	}
-
-	/**
 	 * Copies the currently selected text to the system clipboard, with
 	 * any necessary style information (font, foreground color and background
 	 * color).  Does nothing for {@code null} or empty selections.
@@ -651,6 +623,35 @@ public class RSyntaxTextArea extends RTextArea implements SyntaxConstants {
 			ClipboardHistory.get().add(plainText);
 		} catch (IllegalStateException ise) {
 			UIManager.getLookAndFeel().provideErrorFeedback(null);
+		}
+	}
+
+
+	/**
+	 * Copies the currently selected text to the system clipboard, with style
+	 * information from the specified theme.  Does nothing for {@code null} or
+	 * empty selections.
+	 *
+	 * @param theme The theme to use for the color and font information.
+	 *        This may be {@code null}, in which case this text area's
+	 *        current styles are used.
+	 * @see #copyAsStyledText()
+	 */
+	public void copyAsStyledText(Theme theme) {
+
+		// It's more performant to call the no-arg overload
+		if (theme == null) {
+			copyAsStyledText();
+			return;
+		}
+
+		Theme origTheme = new Theme(this);
+
+		theme.apply(this);
+		try {
+			copyAsStyledText();
+		} finally {
+			origTheme.apply(this);
 		}
 	}
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxUtilities.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxUtilities.java
@@ -902,25 +902,6 @@ return c.getLineStartOffset(line);
 
 
 	/**
-	 * Returns the token at the specified offset. If the offset
-	 * is at the very end of a line, the "last" token in that line is returned
-	 * instead (which may be {@code null} if the line is empty).
-	 *
-	 * @param textArea The text area.
-	 * @param offset The offset at which to get the token.
-	 * @return The token at <code>offset</code>, or <code>null</code> if
-	 *         the offset is invalid or there is no token at that offset.
-	 * @see #getTokenAtOffset(RSyntaxTextArea, int)
-	 * @see #getTokenAtOffset(RSyntaxDocument, int)
-	 * @see #getTokenAtOffset(Token, int)
-	 */
-	public static Token getTokenAtOffsetOrLastTokenIfEndOfLine(RSyntaxTextArea textArea, int offset) {
-		RSyntaxDocument doc = (RSyntaxDocument)textArea.getDocument();
-		return RSyntaxUtilities.getTokenAtOffsetOrLastTokenIfEndOfLine(doc, offset);
-	}
-
-
-	/**
 	 * Returns the token at the specified offset.
 	 *
 	 * @param doc The document.
@@ -935,25 +916,6 @@ return c.getLineStartOffset(line);
 		int lineIndex = root.getElementIndex(offset);
 		Token t = doc.getTokenListForLine(lineIndex);
 		return RSyntaxUtilities.getTokenAtOffset(t, offset);
-	}
-
-
-	/**
-	 * Returns the token at the specified offset.
-	 *
-	 * @param doc The document.
-	 * @param offset The offset of the token.
-	 * @return The token, or <code>null</code> if the offset is not valid or
-	 *         there is no token at that offset.
-	 * @see #getTokenAtOffset(RSyntaxTextArea, int)
-	 * @see #getTokenAtOffset(RSyntaxDocument, int)
-	 * @see #getTokenAtOffset(Token, int)
-	 */
-	public static Token getTokenAtOffsetOrLastTokenIfEndOfLine(RSyntaxDocument doc, int offset) {
-		Element root = doc.getDefaultRootElement();
-		int lineIndex = root.getElementIndex(offset);
-		Token t = doc.getTokenListForLine(lineIndex);
-		return RSyntaxUtilities.getTokenAtOffsetOrLastTokenIfEndOfLine(t, offset);
 	}
 
 
@@ -978,6 +940,44 @@ return c.getLineStartOffset(line);
 			}
 		}
 		return null;
+	}
+
+
+	/**
+	 * Returns the token at the specified offset. If the offset
+	 * is at the very end of a line, the "last" token in that line is returned
+	 * instead (which may be {@code null} if the line is empty).
+	 *
+	 * @param textArea The text area.
+	 * @param offset The offset at which to get the token.
+	 * @return The token at <code>offset</code>, or <code>null</code> if
+	 *         the offset is invalid or there is no token at that offset.
+	 * @see #getTokenAtOffset(RSyntaxTextArea, int)
+	 * @see #getTokenAtOffset(RSyntaxDocument, int)
+	 * @see #getTokenAtOffset(Token, int)
+	 */
+	public static Token getTokenAtOffsetOrLastTokenIfEndOfLine(RSyntaxTextArea textArea, int offset) {
+		RSyntaxDocument doc = (RSyntaxDocument)textArea.getDocument();
+		return RSyntaxUtilities.getTokenAtOffsetOrLastTokenIfEndOfLine(doc, offset);
+	}
+
+
+	/**
+	 * Returns the token at the specified offset.
+	 *
+	 * @param doc The document.
+	 * @param offset The offset of the token.
+	 * @return The token, or <code>null</code> if the offset is not valid or
+	 *         there is no token at that offset.
+	 * @see #getTokenAtOffset(RSyntaxTextArea, int)
+	 * @see #getTokenAtOffset(RSyntaxDocument, int)
+	 * @see #getTokenAtOffset(Token, int)
+	 */
+	public static Token getTokenAtOffsetOrLastTokenIfEndOfLine(RSyntaxDocument doc, int offset) {
+		Element root = doc.getDefaultRootElement();
+		int lineIndex = root.getElementIndex(offset);
+		Token t = doc.getTokenListForLine(lineIndex);
+		return RSyntaxUtilities.getTokenAtOffsetOrLastTokenIfEndOfLine(t, offset);
 	}
 
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RtfGenerator.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RtfGenerator.java
@@ -116,23 +116,6 @@ public class RtfGenerator {
 	 * @param text The text to append.
 	 * @param f The font of the text.  If this is <code>null</code>, the
 	 *        default font is used.
-	 * @param bg The background color of the text.  If this is
-	 *        <code>null</code>, the default background color is used.
-	 * @param underline Whether the text should be underlined.
-	 * @see #appendNewline()
-	 */
-	public void appendToDocNoFG(String text, Font f, Color bg,
-							boolean underline) {
-		appendToDoc(text, f, null, bg, underline, false);
-	}
-
-
-	/**
-	 * Appends styled text to the RTF document being generated.
-	 *
-	 * @param text The text to append.
-	 * @param f The font of the text.  If this is <code>null</code>, the
-	 *        default font is used.
 	 * @param fg The foreground of the text.  If this is <code>null</code>,
 	 *        the default foreground color is used.
 	 * @param bg The background color of the text.  If this is
@@ -253,6 +236,23 @@ public class RtfGenerator {
 
 		}
 
+	}
+
+
+	/**
+	 * Appends styled text to the RTF document being generated.
+	 *
+	 * @param text The text to append.
+	 * @param f The font of the text.  If this is <code>null</code>, the
+	 *        default font is used.
+	 * @param bg The background color of the text.  If this is
+	 *        <code>null</code>, the default background color is used.
+	 * @param underline Whether the text should be underlined.
+	 * @see #appendNewline()
+	 */
+	public void appendToDocNoFG(String text, Font f, Color bg,
+	                            boolean underline) {
+		appendToDoc(text, f, null, bg, underline, false);
 	}
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 }
 
 plugins {
-    id 'com.github.spotbugs' version '6.5.8'
+    id 'com.github.spotbugs' version '6.5.9'
     id 'io.github.gradle-nexus.publish-plugin' version '2.0.0'
 }
 
@@ -31,7 +31,7 @@ allprojects {
     }
 
     wrapper {
-        gradleVersion = '9.6.0'
+        gradleVersion = '9.6.1'
     }
 }
 
@@ -54,7 +54,7 @@ subprojects {
     }
 
     checkstyle {
-        toolVersion = '13.6.0'
+        toolVersion = '13.8.0'
         configDirectory = file("$rootProject.projectDir/config/checkstyle")
     }
 
@@ -85,7 +85,7 @@ subprojects {
     }
 
     dependencies {
-        testImplementation platform('org.junit:junit-bom:6.1.0')
+        testImplementation platform('org.junit:junit-bom:6.1.1')
         testImplementation 'org.junit.jupiter:junit-jupiter'
         testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
         testImplementation 'org.mockito:mockito-core:5.23.0'

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -244,6 +244,9 @@
         <!--<module name="MagicNumber"/> Unfortunately, too much noise -->
         <!--<module name="MissingSwitchDefault"/>-->
         <module name="MultipleVariableDeclarations"/>
+        <module name="OverloadMethodsDeclarationOrder">
+            <property name="orderByIncreasingParameterCount" value="true" />
+        </module>
         <module name="PatternVariableAssignment"/>
         <module name="SimplifyBooleanExpression"/>
         <module name="SimplifyBooleanReturn"/>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500


### PR DESCRIPTION
## Summary
- Bump Gradle 9.6.0 -> 9.6.1
- Bump spotbugs plugin 6.5.8 -> 6.5.9
- Bump checkstyle 13.6.0 -> 13.8.0
- Bump junit-bom 6.1.0 -> 6.1.1
- Enable the new `OverloadMethodsDeclarationOrder` checkstyle rule and reorder overloaded methods in `UnicodeWriter`, `RSyntaxTextArea`, `RSyntaxUtilities`, and `RtfGenerator` to satisfy it (no behavioral changes)

## Test plan
- [x] `./gradlew clean build` passes (checkstyle, spotbugs, tests all green)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)