### PR TITLE
refactor: simplify Java file license headers

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/io/DocumentReader.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/io/DocumentReader.java
@@ -1,9 +1,4 @@
 /*
- * 02/24/2004
- *
- * DocumentReader.java - A reader for javax.swing.text.Document
- * objects.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/io/UnicodeReader.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/io/UnicodeReader.java
@@ -1,9 +1,4 @@
 /*
- * 09/23/2004
- *
- * UnicodeReader.java - A reader for Unicode input streams that is capable of
- * discerning which particular encoding is being used via the BOM.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/io/UnicodeWriter.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/io/UnicodeWriter.java
@@ -1,8 +1,4 @@
 /*
- * 09/24/2004
- *
- * UnicodeWriter.java - Writes Unicode output with the proper BOM.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/print/RPrintUtilities.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/print/RPrintUtilities.java
@@ -1,9 +1,4 @@
 /*
- * 11/14/2003
- *
- * RPrintUtilities.java - A collection of static methods useful for printing
- * text from Swing text components.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/AbstractTokenMakerFactory.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/AbstractTokenMakerFactory.java
@@ -1,8 +1,4 @@
 /*
- * 12/14/08
- *
- * AbstractTokenMakerFactory.java - Base class for TokenMaker implementations.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/ActiveLineRangeEvent.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/ActiveLineRangeEvent.java
@@ -1,9 +1,4 @@
 /*
- * 02/06/2011
- *
- * ActiveLineRangeEvent.java - Notifies listeners of an "active line range"
- * change in an RSyntaxTextArea.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/ActiveLineRangeListener.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/ActiveLineRangeListener.java
@@ -1,9 +1,4 @@
 /*
- * 02/06/2011
- *
- * ActiveLineRangeListener.java - Listens for "active line range" changes
- * in an RSyntaxTextArea.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/CodeTemplateManager.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/CodeTemplateManager.java
@@ -1,8 +1,4 @@
 /*
- * 02/21/2005
- *
- * CodeTemplateManager.java - manages code templates.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/DefaultOccurrenceMarker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/DefaultOccurrenceMarker.java
@@ -1,9 +1,4 @@
 /*
- * 03/09/2013
- *
- * DefaultOccurrenceMarker - Marks occurrences of the current token for most
- * languages.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/DefaultTokenFactory.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/DefaultTokenFactory.java
@@ -1,8 +1,4 @@
 /*
- * 10/28/2004
- *
- * DefaultTokenFactory.java - Default token factory.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/DefaultTokenMakerFactory.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/DefaultTokenMakerFactory.java
@@ -1,8 +1,4 @@
 /*
- * 12/14/2008
- *
- * DefaultTokenMakerFactory.java - The default TokenMaker factory.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/DefaultTokenPainter.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/DefaultTokenPainter.java
@@ -1,8 +1,4 @@
 /*
- * 03/16/2013
- *
- * DefaultTokenPainter - Standard implementation of a token painter.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/ErrorStrip.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/ErrorStrip.java
@@ -1,9 +1,4 @@
 /*
- * 08/10/2009
- *
- * ErrorStrip.java - A component that can visually show Parser messages (syntax
- * errors, etc.) in an RSyntaxTextArea.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/FileFileLocation.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/FileFileLocation.java
@@ -1,8 +1,4 @@
 /*
- * 11/13/2008
- *
- * FileFileLocation.java - The location of a local file.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/FileLocation.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/FileLocation.java
@@ -1,8 +1,4 @@
 /*
- * 11/13/2008
- *
- * FileLocation.java - Holds the location of a local or remote file.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/FoldingAwareIconRowHeader.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/FoldingAwareIconRowHeader.java
@@ -1,9 +1,4 @@
 /*
- * 03/07/2012
- *
- * FoldingAwareIconRowHeader - Icon row header that paints itself correctly
- * even when code folding is enabled.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/HtmlOccurrenceMarker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/HtmlOccurrenceMarker.java
@@ -1,6 +1,4 @@
 /*
- * 12/01/2014
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/LinkGenerator.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/LinkGenerator.java
@@ -1,6 +1,4 @@
 /*
- * 02/16/2012
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/LinkGeneratorResult.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/LinkGeneratorResult.java
@@ -1,6 +1,4 @@
 /*
- * 02/16/2012
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/MarkOccurrencesSupport.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/MarkOccurrencesSupport.java
@@ -1,9 +1,4 @@
 /*
- * 01/06/2009
- *
- * MarkOccurrencesSupport.java - Handles marking all occurrences of the
- * currently selected identifier in a text area.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/MatchedBracketPopup.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/MatchedBracketPopup.java
@@ -1,6 +1,4 @@
 /*
- * 07/03/2016
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/OccurrenceMarker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/OccurrenceMarker.java
@@ -1,8 +1,4 @@
 /*
- * 03/09/2013
- *
- * OccurrenceMarker - Marks occurrences of the current token.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/ParserManager.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/ParserManager.java
@@ -1,9 +1,4 @@
 /*
- * 09/26/2005
- *
- * ParserManager.java - Manages the parsing of an RSyntaxTextArea's document,
- * if necessary.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/PopupWindowDecorator.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/PopupWindowDecorator.java
@@ -1,9 +1,4 @@
 /*
- * 01/11/2011
- *
- * PopupWindowDecorator.java - Hook allowing hosting applications to decorate
- * JWindows created by the AutoComplete library.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSTAView.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSTAView.java
@@ -1,8 +1,4 @@
 /*
- * 02/10/2009
- *
- * RSTAView.java - An <code>RSyntaxTextArea</code> view.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxDocument.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxDocument.java
@@ -1,9 +1,4 @@
 /*
- * 10/16/2004
- *
- * RSyntaxDocument.java - A document capable of syntax highlighting, used by
- * RSyntaxTextArea.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaDefaultInputMap.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaDefaultInputMap.java
@@ -1,9 +1,4 @@
 /*
- * 10/27/2004
- *
- * RSyntaxTextAreaDefaultInputMap.java - The default input map for
- * RSyntaxTextAreas.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaEditorKit.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaEditorKit.java
@@ -1,8 +1,4 @@
 /*
- * 08/29/2004
- *
- * RSyntaxTextAreaEditorKit.java - The editor kit used by RSyntaxTextArea.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaHighlighter.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaHighlighter.java
@@ -1,8 +1,4 @@
 /*
- * 04/23/2009
- *
- * RSyntaxTextAreaHighlighter.java - Highlighter for RSyntaxTextAreas.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaUI.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaUI.java
@@ -1,8 +1,4 @@
 /*
- * 02/24/2004
- *
- * RSyntaxTextAreaUI.java - UI for an RSyntaxTextArea.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxUtilities.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxUtilities.java
@@ -1,9 +1,4 @@
 /*
- * 08/06/2004
- *
- * RSyntaxUtilities.java - Utility methods used by RSyntaxTextArea and its
- * views.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RTfToText.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RTfToText.java
@@ -1,8 +1,4 @@
 /*
- * 07/28/2008
- *
- * RtfToText.java - Returns the plain text version of RTF documents.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RtfGenerator.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RtfGenerator.java
@@ -1,8 +1,4 @@
 /*
- * 07/28/2008
- *
- * RtfGenerator.java - Generates RTF via a simple Java API.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/SelectRegionLinkGeneratorResult.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/SelectRegionLinkGeneratorResult.java
@@ -1,6 +1,4 @@
 /*
- * 02/16/2012
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/SquiggleUnderlineHighlightPainter.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/SquiggleUnderlineHighlightPainter.java
@@ -1,10 +1,4 @@
 /*
- * 09/13/2005
- *
- * SquiggleUnderlineHighlightPainter.java - Highlighter that draws a squiggle
- * underline under "highlighted" text, similar to error markers in Microsoft
- * Visual Studio or Eclipse.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/Style.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/Style.java
@@ -1,9 +1,4 @@
 /*
- * 08/06/2004
- *
- * Style.java - A set of traits for a particular token type to use while
- * painting.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/StyledTextTransferable.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/StyledTextTransferable.java
@@ -1,8 +1,4 @@
 /*
- * 07/28/2008
- *
- * StyledTextTransferable.java - Used during drag-and-drop to represent RTF text.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/SyntaxConstants.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/SyntaxConstants.java
@@ -1,8 +1,4 @@
 /*
- * 03/08/2004
- *
- * SyntaxConstants.java - Constants used by RSyntaxTextArea and friends.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/SyntaxScheme.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/SyntaxScheme.java
@@ -1,9 +1,4 @@
 /*
- * 02/26/2004
- *
- * SyntaxScheme.java - The set of colors and tokens used by an RSyntaxTextArea
- * to color tokens.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/SyntaxView.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/SyntaxView.java
@@ -1,9 +1,4 @@
 /*
- * 02/24/2004
- *
- * SyntaxView.java - The View object used by RSyntaxTextArea when word wrap is
- * disabled.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TextEditorPane.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TextEditorPane.java
@@ -1,9 +1,4 @@
 /*
- * 11/25/2008
- *
- * TextEditorPane.java - A syntax highlighting text area that has knowledge of
- * the file it is editing on disk.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/Theme.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/Theme.java
@@ -1,8 +1,4 @@
 /*
- * 10/30/2011
- *
- * Theme.java - A color theme for RSyntaxTextArea.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/Token.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/Token.java
@@ -1,8 +1,4 @@
 /*
- * 02/21/2004
- *
- * Token.java - A token used in syntax highlighting.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TokenFactory.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TokenFactory.java
@@ -1,8 +1,4 @@
 /*
- * 10/28/2004
- *
- * TokenFactory.java - Interface for a class that generates tokens of some type.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TokenImpl.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TokenImpl.java
@@ -1,8 +1,4 @@
 /*
- * 02/21/2004
- *
- * Token.java - A token used in syntax highlighting.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TokenIterator.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TokenIterator.java
@@ -1,8 +1,4 @@
 /*
- * 08/28/2013
- *
- * TokenIterator.java - An iterator over the Tokens in an RSyntaxDocument.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TokenMakerBase.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TokenMakerBase.java
@@ -1,8 +1,4 @@
 /*
- * 08/26/2004
- *
- * TokenMakerBase.java - A base class for token makers.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TokenMakerFactory.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TokenMakerFactory.java
@@ -1,8 +1,4 @@
 /*
- * 12/12/2008
- *
- * TokenMakerFactory.java - A factory for TokenMakers.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TokenMap.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TokenMap.java
@@ -1,9 +1,4 @@
 /*
- * 08/26/2004
- *
- * TokenMap.java - Similar to a Map in Java, only designed specifically for
- * org.fife.ui.rsyntaxtextarea.Tokens.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TokenOrientedView.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TokenOrientedView.java
@@ -1,9 +1,4 @@
 /*
- * 08/06/2004
- *
- * TokenOrientedView.java - An interface for the syntax-highlighting
- * token-oriented views for token-oriented methods.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TokenPainter.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TokenPainter.java
@@ -1,8 +1,4 @@
 /*
- * 03/16/2013
- *
- * TokenPainter - Renders tokens in an instance of RSyntaxTextArea.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TokenTypes.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TokenTypes.java
@@ -1,8 +1,4 @@
 /*
- * 12/04/2011
- *
- * TokenTypes.java - All token types supported by RSyntaxTextArea.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/URLFileLocation.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/URLFileLocation.java
@@ -1,8 +1,4 @@
 /*
- * 11/13/2008
- *
- * URLFileLocation.java - The location of a file at a (remote) URL.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/VisibleWhitespaceTokenPainter.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/VisibleWhitespaceTokenPainter.java
@@ -1,9 +1,4 @@
 /*
- * 03/16/2013
- *
- * VisibleWhitespaceTokenPainter - Renders tokens in an instance of
- * RSyntaxTextArea, with special glyphs to denote spaces and tabs.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/WrappedSyntaxView.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/WrappedSyntaxView.java
@@ -1,9 +1,4 @@
 /*
- * 08/06/2004
- *
- * WrappedSyntaxView.java - Test implementation of WrappedSyntaxView that
- * is also aware of RSyntaxTextArea's different fonts per token type.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/XmlOccurrenceMarker.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/XmlOccurrenceMarker.java
@@ -1,8 +1,4 @@
 /*
- * 03/09/2013
- *
- * XmlOccurrenceMarker - Marks occurrences of the current token for XML.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/focusabletip/FocusableTip.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/focusabletip/FocusableTip.java
@@ -1,8 +1,4 @@
 /*
- * 07/29/2009
- *
- * FocusableTip.java - A focusable tool tip, like those in Eclipse.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/focusabletip/SizeGrip.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/focusabletip/SizeGrip.java
@@ -1,9 +1,4 @@
 /*
- * 12/23/2008
- *
- * SizeGrip.java - A size grip component that sits at the bottom of the window,
- * allowing the user to easily resize that window.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/focusabletip/TipUtil.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/focusabletip/TipUtil.java
@@ -1,8 +1,4 @@
 /*
- * 08/13/2009
- *
- * TipUtil.java - Utility methods for homemade tool tips.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/focusabletip/TipWindow.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/focusabletip/TipWindow.java
@@ -1,8 +1,4 @@
 /*
- * 07/29/2009
- *
- * TipWindow.java - The actual window component representing the tool tip.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/CurlyFoldParser.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/CurlyFoldParser.java
@@ -1,8 +1,4 @@
 /*
- * 10/08/2011
- *
- * CurlyFoldParser.java - Fold parser for languages with C-style syntax.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/DefaultFoldManager.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/DefaultFoldManager.java
@@ -1,6 +1,4 @@
 /*
- * 10/08/2011
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/Fold.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/Fold.java
@@ -1,8 +1,4 @@
 /*
- * 10/08/2011
- *
- * Fold.java - A foldable region of text in an RSyntaxTextArea instance.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/FoldCollapser.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/FoldCollapser.java
@@ -1,9 +1,4 @@
 /*
- * 10/23/2011
- *
- * FoldCollapser.java - Goes through an RSTA instance and collapses folds of
- * specific types, such as comments.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/FoldManager.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/FoldManager.java
@@ -1,8 +1,4 @@
 /*
- * 10/08/2011
- *
- * FoldManager.java - Manages code folding in an RSyntaxTextArea instance.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/FoldParser.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/FoldParser.java
@@ -1,8 +1,4 @@
 /*
- * 10/08/2011
- *
- * FoldParser.java - Locates folds in an RSyntaxTextArea instance.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/FoldParserManager.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/FoldParserManager.java
@@ -1,9 +1,4 @@
 /*
- * 10/08/2011
- *
- * FoldParserManager.java - Used by RSTA to determine what fold parser to use
- * for each language it supports.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/FoldType.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/FoldType.java
@@ -1,8 +1,4 @@
 /*
- * 10/08/2011
- *
- * FoldType.java - Types of folds found in many programming languages.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/HtmlFoldParser.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/HtmlFoldParser.java
@@ -1,8 +1,4 @@
 /*
- * 09/30/2012
- *
- * HtmlFoldParser.java - Fold parser for HTML 5 and PHP.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/JsonFoldParser.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/JsonFoldParser.java
@@ -1,8 +1,4 @@
 /*
- * 12/23/2012
- *
- * JsonFoldParser.java - Fold parser for JSON.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/LatexFoldParser.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/LatexFoldParser.java
@@ -1,8 +1,4 @@
 /*
- * 04/24/2012
- *
- * LatexFoldParser.java - Fold parser for LaTeX.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/LispFoldParser.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/LispFoldParser.java
@@ -1,8 +1,4 @@
 /*
- * 08/08/2012
- *
- * LispFoldParser.java - Fold parser for Lisp and related languages.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/NsisFoldParser.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/NsisFoldParser.java
@@ -1,8 +1,4 @@
 /*
- * 10/07/2012
- *
- * NsisFoldParser.java - Fold parser for NSIS.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/XmlFoldParser.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/XmlFoldParser.java
@@ -1,8 +1,4 @@
 /*
- * 10/23/2011
- *
- * XmlFoldParser.java - Fold parser for XML.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/YamlFoldParser.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/YamlFoldParser.java
@@ -1,7 +1,4 @@
 /*
- *
- * YamlFoldParser.java - Fold parser for YAML.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/parser/AbstractParser.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/parser/AbstractParser.java
@@ -1,8 +1,4 @@
 /*
- * 07/31/2009
- *
- * AbstractParser.java - A base implementation for parsers.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/parser/DefaultParseResult.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/parser/DefaultParseResult.java
@@ -1,8 +1,4 @@
 /*
- * 07/27/2009
- *
- * DefaultParseResult.java - A basic implementation of a ParseResult.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/parser/DefaultParserNotice.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/parser/DefaultParserNotice.java
@@ -1,8 +1,4 @@
 /*
- * 08/11/2009
- *
- * DefaultParserNotice.java - Base implementation of a parser notice.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/parser/ExtendedHyperlinkListener.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/parser/ExtendedHyperlinkListener.java
@@ -1,8 +1,4 @@
 /*
- * 07/31/2009
- *
- * ExtendedHyperlinkListener.java - A hyperlink event from a FocusableTip.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/parser/ParseResult.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/parser/ParseResult.java
@@ -1,9 +1,4 @@
 /*
- * 07/27/2009
- *
- * ParseResult.java - The result of a Parser parsing some section of an
- * RSyntaxTextArea.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/parser/Parser.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/parser/Parser.java
@@ -1,8 +1,4 @@
 /*
- * 09/23/2005
- *
- * Parser.java - An interface for a parser for RSyntaxTextArea.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/parser/ParserNotice.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/parser/ParserNotice.java
@@ -1,8 +1,4 @@
 /*
- * 09/23/2005
- *
- * ParserNotice.java - A notice (i.e, and error or warning) from a parser.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/parser/TaskTagParser.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/parser/TaskTagParser.java
@@ -1,8 +1,4 @@
 /*
- * 08/11/2009
- *
- * TaskTagParser.java - Parser that scans code comments for task tags.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/parser/ToolTipInfo.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/parser/ToolTipInfo.java
@@ -1,8 +1,4 @@
 /*
- * 07/29/2009
- *
- * ToolTipInfo.java - A tool tip's text and hyperlink listener.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/parser/XmlParser.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/parser/XmlParser.java
@@ -1,8 +1,4 @@
 /*
- * 08/16/2008
- *
- * XMLParser.java - Simple XML parser.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/templates/AbstractCodeTemplate.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/templates/AbstractCodeTemplate.java
@@ -1,8 +1,4 @@
 /*
- * 12/01/2008
- *
- * AbstractCodeTemplate.java - Base class for code templates.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/templates/CodeTemplate.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/templates/CodeTemplate.java
@@ -1,8 +1,4 @@
 /*
- * 11/29/2008
- *
- * CodeTemplate.java - A "template" (macro) for commonly-typed code.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/templates/StaticCodeTemplate.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/templates/StaticCodeTemplate.java
@@ -1,8 +1,4 @@
 /*
- * 02/21/2005
- *
- * CodeTemplate.java - A "template" (macro) for commonly-typed code.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/AbstractGutterComponent.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/AbstractGutterComponent.java
@@ -1,8 +1,4 @@
 /*
- * 02/17/2009
- *
- * AbstractGutterComponent.java - A component that can be displayed in a Gutter.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/BackgroundPainterStrategy.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/BackgroundPainterStrategy.java
@@ -1,9 +1,4 @@
 /*
- * 01/22/2005
- *
- * BackgroundPainterStrategy.java - Renders an RTextAreaBase's background
- * using some strategy.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/BufferedImageBackgroundPainterStrategy.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/BufferedImageBackgroundPainterStrategy.java
@@ -1,9 +1,4 @@
 /*
- * 01/22/2005
- *
- * BufferedImageBackgroundPainterStrategy.java - Renders an RTextAreaBase's
- * background as an image using a BufferedImage.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/CaretStyle.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/CaretStyle.java
@@ -1,6 +1,4 @@
 /*
- * 04/23/2014
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/ChangeableHighlightPainter.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/ChangeableHighlightPainter.java
@@ -1,9 +1,4 @@
 /*
- * 11/10/2004
- *
- * ChangeableHighlightPainter.java - A highlight painter whose color you can
- * change.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/ClipboardHistory.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/ClipboardHistory.java
@@ -1,8 +1,4 @@
 /*
- * 08/29/2014
- *
- * ClipboardHistory.java - A history of text added to the clipboard.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/ClipboardHistoryPopup.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/ClipboardHistoryPopup.java
@@ -1,8 +1,4 @@
 /*
- * 08/16/2014
- *
- * ClipboardHistoryPopup.java - Shows clipboard history in a popup window.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/ColorBackgroundPainterStrategy.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/ColorBackgroundPainterStrategy.java
@@ -1,9 +1,4 @@
 /*
- * 01/22/2005
- *
- * ColorBackgroundPainterStrategy.java - Renders an RTextAreaBase's background
- * as a single color.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/ConfigurableCaret.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/ConfigurableCaret.java
@@ -1,8 +1,4 @@
 /*
- * 12/21/2004
- *
- * ConfigurableCaret.java - The caret used by RTextArea.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/DocumentRange.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/DocumentRange.java
@@ -1,8 +1,4 @@
 /*
- * 08/11/2009
- *
- * DocumentRange.java - A range of text in a document.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/FoldIndicator.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/FoldIndicator.java
@@ -1,9 +1,4 @@
 /*
- * 10/08/2011
- *
- * FoldIndicator.java - Gutter component allowing the user to expand and
- * collapse folds.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/Gutter.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/Gutter.java
@@ -1,9 +1,4 @@
 /*
- * 02/17/2009
- *
- * Gutter.java - Manages line numbers, icons, etc. on the left-hand side of
- * an RTextArea.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/GutterIconInfo.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/GutterIconInfo.java
@@ -1,8 +1,4 @@
 /*
- * 02/19/2009
- *
- * GutterIconInfo.java - Information about an Icon in a Gutter.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/IconGroup.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/IconGroup.java
@@ -1,8 +1,4 @@
 /*
- * 09/05/2004
- *
- * IconGroup.java - Class encapsulating images used for RTextArea actions.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/IconRowEvent.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/IconRowEvent.java
@@ -1,8 +1,4 @@
 /*
- * 02/09/2025
- *
- * IconRowEvent.java - Event for IconRowHeader.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/IconRowHeader.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/IconRowHeader.java
@@ -1,8 +1,4 @@
 /*
- * 02/17/2009
- *
- * IconRowHeader.java - Renders icons in the gutter.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/IconRowListener.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/IconRowListener.java
@@ -1,8 +1,4 @@
 /*
- * 02/09/2025
- *
- * IconRowListener.java - Interface for an object that listens for changes in IconRowHeader.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/ImageBackgroundPainterStrategy.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/ImageBackgroundPainterStrategy.java
@@ -1,9 +1,4 @@
 /*
- * 01/22/2005
- *
- * ImageBackgroundPainterStrategy.java - Renders an RTextAreaBase's
- * background as an image.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/LineHighlightManager.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/LineHighlightManager.java
@@ -1,8 +1,4 @@
 /*
- * 02/10/2009
- *
- * LineHighlightManager - Manages line highlights.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/LineNumberFormatter.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/LineNumberFormatter.java
@@ -1,8 +1,4 @@
 /*
- * 29/07/2023
- *
- * LineNumber - Format line numbers into a comprehensible String.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/Macro.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/Macro.java
@@ -1,8 +1,4 @@
 /*
- * 09/16/2004
- *
- * Macro.java - A macro as recorded/played back by an RTextArea.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RDocument.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RDocument.java
@@ -1,8 +1,4 @@
 /*
- * 06/30/2012
- *
- * RDocument.java - Document class used by RTextAreas.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RDocumentCharSequence.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RDocumentCharSequence.java
@@ -1,9 +1,4 @@
 /*
- * 06/30/2012
- *
- * RDocumentCharSequence.java - Iterator over a portion of an RTextArea's
- * document.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTADefaultInputMap.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTADefaultInputMap.java
@@ -1,8 +1,4 @@
 /*
- * 08/19/2004
- *
- * RTADefaultInputMap.java - The default input map for RTextAreas.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTATextTransferHandler.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTATextTransferHandler.java
@@ -1,9 +1,4 @@
 /*
- * 07/29/2004
- *
- * RTATextTransferHandler.java - Handles the transfer of data to/from an
- * RTextArea via drag-and-drop.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextArea.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextArea.java
@@ -1,8 +1,4 @@
 /*
- * 11/14/2003
- *
- * RTextArea.java - An extension of JTextArea that adds many features.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextAreaBase.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextAreaBase.java
@@ -1,8 +1,4 @@
 /*
- * 04/07/2005
- *
- * RTextAreaBase.java - The base class for an RTextArea.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextAreaEditorKit.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextAreaEditorKit.java
@@ -1,8 +1,4 @@
 /*
- * 08/13/2004
- *
- * RTextAreaEditorKit.java - The editor kit used by RTextArea.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextAreaHighlighter.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextAreaHighlighter.java
@@ -1,8 +1,4 @@
 /*
- * 10/13/2013
- *
- * RTextAreaHighlighter.java - Highlighter for RTextAreas.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextAreaUI.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextAreaUI.java
@@ -1,8 +1,4 @@
 /*
- * 04/25/2007
- *
- * RTextAreaUI.java - UI used by instances of RTextArea.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextScrollPane.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextScrollPane.java
@@ -1,9 +1,4 @@
 /*
- * 11/14/2003
- *
- * RTextScrollPane.java - A JScrollPane that will only accept RTextAreas
- * so that it can display line numbers, fold indicators, and icons.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RUndoManager.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RUndoManager.java
@@ -1,8 +1,4 @@
 /*
- * 12/06/2008
- *
- * RUndoManager.java - Handles undo/redo behavior for RTextArea.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RecordableTextAction.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RecordableTextAction.java
@@ -1,9 +1,4 @@
 /*
- * 08/19/2004
- *
- * RecordableTextAction.java - An action that can be recorded and replayed
- * in an RTextArea macro.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RegExReplaceInfo.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RegExReplaceInfo.java
@@ -1,8 +1,4 @@
 /*
- * 02/19/2006
- *
- * RegExReplaceInfo.java - Information about a regex text match.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/SearchContext.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/SearchContext.java
@@ -1,8 +1,4 @@
 /*
- * 02/17/2012
- *
- * SearchContext.java - Container for options of a search/replace operation.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/SearchEngine.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/SearchEngine.java
@@ -1,8 +1,4 @@
 /*
- * 02/19/2006
- *
- * SearchEngine.java - Handles find/replace operations in an RTextArea.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/SearchResult.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/SearchResult.java
@@ -1,8 +1,4 @@
 /*
- * 09/21/2013
- *
- * SearchResult - The result of a find, replace, or "mark all" operation.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/SmartHighlightPainter.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/SmartHighlightPainter.java
@@ -1,9 +1,4 @@
 /*
- * 10/01/2009
- *
- * SmartHighlightPainter.java - A highlight painter whose rendered highlights
- * don't "grow" when the user appends text to the end of them.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/ToolTipSupplier.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/ToolTipSupplier.java
@@ -1,9 +1,4 @@
 /*
- * 02/05/2009
- *
- * ToolTipSupplier.java - Can provide tool tips to RTextAreas without the need
- * for subclassing.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/VolatileImageBackgroundPainterStrategy.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/VolatileImageBackgroundPainterStrategy.java
@@ -1,9 +1,4 @@
 /*
- * 01/22/2005
- *
- * VolatileImageBackgroundPainterStrategy.java - Renders an RTextAreaBase's
- * background as an image using VolatileImages.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/util/DynamicIntArray.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/util/DynamicIntArray.java
@@ -1,9 +1,4 @@
 /*
- * 03/26/2004
- *
- * DynamicIntArray.java - Similar to an ArrayList, but holds ints instead
- * of Objects.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/main/java/org/fife/util/SwingUtils.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/util/SwingUtils.java
@@ -1,6 +1,4 @@
 /*
- * 04/23/2014
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/io/DocumentReaderTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/io/DocumentReaderTest.java
@@ -1,6 +1,4 @@
 /*
- * 03/13/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/FileLocationTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/FileLocationTest.java
@@ -1,6 +1,4 @@
 /*
- * 01/30/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxDocumentTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxDocumentTest.java
@@ -1,6 +1,4 @@
 /*
- * 01/12/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaChangeFoldStateActionTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaChangeFoldStateActionTest.java
@@ -1,6 +1,4 @@
 /*
- * 08/22/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaCloseCurlyBraceActionTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaCloseCurlyBraceActionTest.java
@@ -1,6 +1,4 @@
 /*
- * 08/22/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaCloseMarkupTagActionTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaCloseMarkupTagActionTest.java
@@ -1,6 +1,4 @@
 /*
- * 08/22/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaEditorKitCollapseAllCommentFoldsActionTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaEditorKitCollapseAllCommentFoldsActionTest.java
@@ -1,6 +1,4 @@
 /*
- * 08/22/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaEditorKitCollapseAllFoldsActionTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaEditorKitCollapseAllFoldsActionTest.java
@@ -1,6 +1,4 @@
 /*
- * 08/22/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaEditorKitCopyCutAsStyledTextActionTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaEditorKitCopyCutAsStyledTextActionTest.java
@@ -1,6 +1,4 @@
 /*
- * 08/22/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaEditorKitDecreaseFontSizeActionTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaEditorKitDecreaseFontSizeActionTest.java
@@ -1,6 +1,4 @@
 /*
- * 08/22/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaEditorKitDecreaseIndentActionTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaEditorKitDecreaseIndentActionTest.java
@@ -1,6 +1,4 @@
 /*
- * 08/22/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaEditorKitDeletePrevWordActionTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaEditorKitDeletePrevWordActionTest.java
@@ -1,6 +1,4 @@
 /*
- * 08/22/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaEditorKitDumbCompleteWordActionTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaEditorKitDumbCompleteWordActionTest.java
@@ -1,6 +1,4 @@
 /*
- * 03/06/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaEditorKitEndWordActionTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaEditorKitEndWordActionTest.java
@@ -1,6 +1,4 @@
 /*
- * 08/22/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaEditorKitExpandAllFoldsActionTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaEditorKitExpandAllFoldsActionTest.java
@@ -1,6 +1,4 @@
 /*
- * 08/22/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaEditorKitGoToMatchingBracketActionTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaEditorKitGoToMatchingBracketActionTest.java
@@ -1,6 +1,4 @@
 /*
- * 08/22/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaEditorKitIncreaseFontSizeActionTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaEditorKitIncreaseFontSizeActionTest.java
@@ -1,6 +1,4 @@
 /*
- * 08/22/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaEditorKitInsertBreakActionTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaEditorKitInsertBreakActionTest.java
@@ -1,6 +1,4 @@
 /*
- * 08/22/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaTest.java
@@ -1,6 +1,4 @@
 /*
- * 03/14/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxUtilitiesTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxUtilitiesTest.java
@@ -1,6 +1,4 @@
 /*
- * 12/10/2016
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RtfGeneratorTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RtfGeneratorTest.java
@@ -1,6 +1,4 @@
 /*
- * 10/18/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/TextEditorPaneTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/TextEditorPaneTest.java
@@ -1,6 +1,4 @@
 /*
- * 12/09/2016
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/ThemeTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/ThemeTest.java
@@ -1,6 +1,4 @@
 /*
- * 02/15/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/TokenImplTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/TokenImplTest.java
@@ -1,6 +1,4 @@
 /*
- * 12/10/2016
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/TokenIteratorTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/TokenIteratorTest.java
@@ -1,9 +1,4 @@
 /*
- * 03/28/2014
- *
- * TokenIteratorTest.java - Unit tests for the iterator returned from an
- * RSyntaxDocument.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/AbstractCDerivedTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/AbstractCDerivedTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 06/05/2016
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/AbstractTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/AbstractTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 06/05/2016
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/ActionScriptTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/ActionScriptTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 11/24/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/Assembler6502TokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/Assembler6502TokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 06/05/2016
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/AssemblerX86TokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/AssemblerX86TokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 06/05/2016
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/BBCodeTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/BBCodeTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 06/21/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/CPlusPlusTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/CPlusPlusTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 03/12/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/CSSTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/CSSTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 07/18/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/CSharpTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/CSharpTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 06/05/2016
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/CTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/CTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 03/12/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/ClojureTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/ClojureTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 07/09/2016
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/CsvTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/CsvTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 03/22/2019
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/DTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/DTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 06/21/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/DartTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/DartTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 06/21/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/DelphiTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/DelphiTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 03/12/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/DockerTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/DockerTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 11/24/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/DtdTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/DtdTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 07/09/2016
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/GoTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/GoTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 03/12/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/GroovyTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/GroovyTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 06/21/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/HTMLTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/HTMLTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 03/23/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/HandlebarsTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/HandlebarsTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 03/23/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/HostsTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/HostsTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 10/17/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/HtaccessTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/HtaccessTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 06/05/2016
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/IniTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/IniTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 11/04/2016
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/JSPTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/JSPTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 03/23/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/JavaScriptTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/JavaScriptTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 03/12/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/JavaTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/JavaTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 03/12/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/JshintrcTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/JshintrcTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 03/15/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/JsonTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/JsonTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 03/15/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/LatexTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/LatexTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 09/20/2016
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/LessTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/LessTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 08/22/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/LispTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/LispTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 06/06/2016
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/MakefileTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/MakefileTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 06/06/2016
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/MxmlTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/MxmlTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 03/23/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/NSISTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/NSISTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 03/12/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/PerlTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/PerlTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 09/20/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/PlainTextTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/PlainTextTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 03/12/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/PropertiesFileTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/PropertiesFileTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 07/09/2016
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/ProtoTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/ProtoTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 03/12/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/RubyTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/RubyTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 06/21/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/SASTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/SASTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 06/06/2016
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/SQLTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/SQLTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 06/06/2016
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/ScalaTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/ScalaTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 06/05/2016
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/TclTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/TclTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 12/15/2019
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/TypeScriptTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/TypeScriptTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 11/24/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/UnixShellTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/UnixShellTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 03/16/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/WindowsBatchTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/WindowsBatchTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 03/16/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/XMLTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/XMLTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 03/23/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/YamlTokenMakerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/modes/YamlTokenMakerTest.java
@@ -1,6 +1,4 @@
 /*
- * 12/29/2016
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/parser/AbstractParserTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/parser/AbstractParserTest.java
@@ -1,6 +1,4 @@
 /*
- * 10/03/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/parser/DefaultParseResultTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/parser/DefaultParseResultTest.java
@@ -1,6 +1,4 @@
 /*
- * 10/03/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/parser/DefaultParserNoticeTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/parser/DefaultParserNoticeTest.java
@@ -1,6 +1,4 @@
 /*
- * 03/16/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/parser/MockExtendedHyperlinkListener.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/parser/MockExtendedHyperlinkListener.java
@@ -1,6 +1,4 @@
 /*
- * 10/03/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/parser/MockParser.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/parser/MockParser.java
@@ -1,6 +1,4 @@
 /*
- * 10/03/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/parser/ParserNoticeLevelTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/parser/ParserNoticeLevelTest.java
@@ -1,6 +1,4 @@
 /*
- * 10/03/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/parser/TaskTagParserTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/parser/TaskTagParserTest.java
@@ -1,6 +1,4 @@
 /*
- * 10/03/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/parser/ToolTipInfoTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/parser/ToolTipInfoTest.java
@@ -1,6 +1,4 @@
 /*
- * 10/03/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/parser/XmlParserTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/parser/XmlParserTest.java
@@ -1,6 +1,4 @@
 /*
- * 10/03/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/DocumentRangeTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/DocumentRangeTest.java
@@ -1,6 +1,4 @@
 /*
- * 03/14/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/FoldIndicatorTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/FoldIndicatorTest.java
@@ -1,6 +1,4 @@
 /*
- * 12/21/2016
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/LineHighlightManagerTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/LineHighlightManagerTest.java
@@ -1,6 +1,4 @@
 /*
- * 03/04/2016
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/RDocumentTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/RDocumentTest.java
@@ -1,6 +1,4 @@
 /*
- * 01/18/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/RTextAreaEditorKitDumbCompleteWordActionTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/RTextAreaEditorKitDumbCompleteWordActionTest.java
@@ -1,6 +1,4 @@
 /*
- * 03/06/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/SearchContextTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/SearchContextTest.java
@@ -1,6 +1,4 @@
 /*
- * 01/29/2016
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/SearchEngineTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rtextarea/SearchEngineTest.java
@@ -1,8 +1,4 @@
 /*
- * 05/12/2010
- *
- * SearchEngineTest.java - Test cases for SearchEngine.java
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/RSyntaxTextArea/src/test/java/org/fife/util/DynamicIntArrayTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/util/DynamicIntArrayTest.java
@@ -1,6 +1,4 @@
 /*
- * 06/18/2015
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE file for details.
  */

--- a/config/checkstyle/javaHeader.txt
+++ b/config/checkstyle/javaHeader.txt
@@ -1,1 +1,4 @@
 /*
+ * This library is distributed under a modified BSD license.  See the included
+ * LICENSE file for details.
+ */


### PR DESCRIPTION
## Summary
- Strip the per-file date/filename/description boilerplate from the top of every Java source header comment, leaving only the BSD license notice
- Update `config/checkstyle/javaHeader.txt` so the checkstyle header check matches the new, simplified format

## Test plan
- [x] `./gradlew clean build` passes (checkstyle, spotbugs, and tests all green)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)