### PR TITLE
perf: defer Fold/Position creation in XmlFoldParser until confirmed multi-line

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/XmlFoldParser.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/folding/XmlFoldParser.java
@@ -17,15 +17,21 @@ import org.fife.ui.rsyntaxtextarea.TokenTypes;
 /**
  * Fold parser for XML.  Any tags that span more than one line, as well as
  * comment regions spanning more than one line, are identified as foldable
- * regions.
+ * regions.<p>
+ *
+ * Tags are tracked on a lightweight stack of plain offsets while scanning,
+ * and a {@code Fold} (and the {@code Position} it wraps) is only created
+ * once a tag is confirmed to span multiple lines.  This avoids a lot of
+ * wasted {@code Fold}/{@code Position} churn on XML documents, which tend to
+ * have many single-line elements.
  *
  * @author Robert Futrell
  * @version 1.0
  */
 public class XmlFoldParser implements FoldParser {
 
-	private static final char[] MARKUP_CLOSING_TAG_START = { '<', '/' };
 	private static final char[] MARKUP_SHORT_TAG_END = { '/', '>' };
+	private static final char[] MARKUP_CLOSING_TAG_START = { '<', '/' };
 	private static final char[] MLC_END = { '-', '-', '>' };
 
 
@@ -34,7 +40,7 @@ public class XmlFoldParser implements FoldParser {
 
 		List<Fold> folds = new ArrayList<>();
 
-		Fold currentFold = null;
+		List<PendingTag> tagStack = new ArrayList<>();
 		int lineCount = textArea.getLineCount();
 		boolean inMLC = false;
 		int mlcStart = 0;
@@ -53,17 +59,16 @@ public class XmlFoldParser implements FoldParser {
 							// Found the end of the MLC starting on a previous line...
 							if (t.endsWith(MLC_END)) {
 								int mlcEnd = t.getEndOffset() - 1;
-								if (currentFold==null) {
-									currentFold = new Fold(FoldType.COMMENT, textArea, mlcStart);
-									currentFold.setEndOffset(mlcEnd);
-									folds.add(currentFold);
-									currentFold = null;
+								Fold parentFold = materializeTop(tagStack, textArea, folds);
+								Fold commentFold;
+								if (parentFold==null) {
+									commentFold = new Fold(FoldType.COMMENT, textArea, mlcStart);
+									folds.add(commentFold);
 								}
 								else {
-									currentFold = currentFold.createChild(FoldType.COMMENT, mlcStart);
-									currentFold.setEndOffset(mlcEnd);
-									currentFold = currentFold.getParent();
+									commentFold = parentFold.createChild(FoldType.COMMENT, mlcStart);
 								}
+								commentFold.setEndOffset(mlcEnd);
 								inMLC = false;
 								mlcStart = 0;
 							}
@@ -82,32 +87,35 @@ public class XmlFoldParser implements FoldParser {
 					}
 
 					else if (t.isSingleChar(TokenTypes.MARKUP_TAG_DELIMITER, '<')) {
-						if (currentFold==null) {
-							currentFold = new Fold(FoldType.CODE, textArea, t.getOffset());
-							folds.add(currentFold);
-						}
-						else {
-							currentFold = currentFold.createChild(FoldType.CODE, t.getOffset());
-						}
+						// Cheap - just remember where the tag started.  We don't
+						// know yet whether it'll span multiple lines, so don't
+						// create a Fold (and its backing Position) until we do.
+						tagStack.add(new PendingTag(t.getOffset(), line));
 					}
 
 					else if (t.is(TokenTypes.MARKUP_TAG_DELIMITER, MARKUP_SHORT_TAG_END)) {
-						if (currentFold!=null) {
-							Fold parentFold = currentFold.getParent();
-							removeFold(currentFold, folds);
-							currentFold = parentFold;
+						if (!tagStack.isEmpty()) {
+							// Self-closing tags never become Folds, so just
+							// forget about this one; nothing was ever created.
+							tagStack.remove(tagStack.size()-1);
 						}
 					}
 
 					else if (t.is(TokenTypes.MARKUP_TAG_DELIMITER, MARKUP_CLOSING_TAG_START)) {
-						if (currentFold!=null) {
-							currentFold.setEndOffset(t.getOffset());
-							Fold parentFold = currentFold.getParent();
-							// Don't add fold markers for single-line blocks
-							if (currentFold.isOnSingleLine()) {
-								removeFold(currentFold, folds);
+						if (!tagStack.isEmpty()) {
+							int tagIndex = tagStack.size() - 1;
+							PendingTag tag = tagStack.get(tagIndex);
+							// Don't create fold markers for single-line blocks.
+							// Note tag.fold may already be non-null here, if a
+							// nested multi-line tag or comment forced it to be
+							// materialized early; materialize() handles that.
+							if (tag.startLine!=line) {
+								Fold newFold = materialize(tagStack, tagIndex, textArea, folds);
+								newFold.setEndOffset(t.getOffset());
 							}
-							currentFold = parentFold;
+							// else: tag was entirely on one line, so it's
+							// discarded having never had a Fold created for it.
+							tagStack.remove(tagIndex);
 						}
 					}
 
@@ -127,17 +135,75 @@ public class XmlFoldParser implements FoldParser {
 
 
 	/**
-	 * If this fold has a parent fold, this method removes it from its parent.
-	 * Otherwise, it's assumed to be the most recent (top-level) fold in the
-	 * <code>folds</code> list, and is removed from that.
+	 * Ensures the tag currently at the top of the tag stack, if any, has
+	 * had a {@code Fold} created for it (materializing any of its still-open
+	 * ancestors along the way, as needed), and returns that fold.
 	 *
-	 * @param fold The fold to remove.
-	 * @param folds The list of top-level folds.
+	 * @param tagStack The stack of currently-open tags.
+	 * @param textArea The text area.
+	 * @param folds The top-level list of folds found so far.
+	 * @return The fold for the tag at the top of the stack, or {@code null}
+	 *         if the stack is empty.
 	 */
-	private static void removeFold(Fold fold, List<Fold> folds) {
-		if (!fold.removeFromParent()) {
-			folds.remove(folds.size()-1);
+	private static Fold materializeTop(List<PendingTag> tagStack, RSyntaxTextArea textArea,
+			List<Fold> folds) throws BadLocationException {
+		return tagStack.isEmpty() ? null :
+			materialize(tagStack, tagStack.size() - 1, textArea, folds);
+	}
+
+
+	/**
+	 * Materializes the tag at the given index in the tag stack into an
+	 * actual {@code Fold}, if it hasn't been already, recursively
+	 * materializing its ancestors first as needed.
+	 *
+	 * @param tagStack The stack of currently-open tags.
+	 * @param index The index of the tag to materialize.
+	 * @param textArea The text area.
+	 * @param folds The top-level list of folds found so far.
+	 * @return The (possibly newly-created) fold for the tag.
+	 */
+	private static Fold materialize(List<PendingTag> tagStack, int index, RSyntaxTextArea textArea,
+			List<Fold> folds) throws BadLocationException {
+
+		PendingTag tag = tagStack.get(index);
+		if (tag.fold!=null) {
+			return tag.fold;
 		}
+
+		Fold parentFold = index>0 ? materialize(tagStack, index - 1, textArea, folds) : null;
+
+		Fold newFold;
+		if (parentFold==null) {
+			newFold = new Fold(FoldType.CODE, textArea, tag.startOffset);
+			folds.add(newFold);
+		}
+		else {
+			newFold = parentFold.createChild(FoldType.CODE, tag.startOffset);
+		}
+
+		tag.fold = newFold;
+		return newFold;
+
+	}
+
+
+	/**
+	 * A tag that has been opened but not yet closed.  This is intentionally
+	 * a lightweight record - no {@code Fold} or {@code Position} is created
+	 * for a tag unless/until it's confirmed to be foldable.
+	 */
+	private static final class PendingTag {
+
+		private final int startOffset;
+		private final int startLine;
+		private Fold fold;
+
+		PendingTag(int startOffset, int startLine) {
+			this.startOffset = startOffset;
+			this.startLine = startLine;
+		}
+
 	}
 
 

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/folding/XmlFoldParserTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/folding/XmlFoldParserTest.java
@@ -1,0 +1,533 @@
+/*
+ * This library is distributed under a modified BSD license.  See the included
+ * LICENSE file for details.
+ */
+package org.fife.ui.rsyntaxtextarea.folding;
+
+import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea;
+import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+
+/**
+ * Unit tests for the XML fold parser.
+ *
+ * @author Robert Futrell
+ * @version 1.0
+ */
+class XmlFoldParserTest {
+
+	private static List<Fold> getFolds(String code) {
+		RSyntaxTextArea textArea = new RSyntaxTextArea(code);
+		textArea.setSyntaxEditingStyle(SyntaxConstants.SYNTAX_STYLE_XML);
+		FoldParser parser = new XmlFoldParser();
+		return parser.getFolds(textArea);
+	}
+
+
+	@Test
+	void testGetFolds_emptyDocument() {
+		List<Fold> folds = getFolds("");
+		Assertions.assertEquals(0, folds.size());
+	}
+
+
+	@Test
+	void testGetFolds_noTags() {
+		List<Fold> folds = getFolds("just some plain text\nwith no markup at all\n");
+		Assertions.assertEquals(0, folds.size());
+	}
+
+
+	@Test
+	void testGetFolds_tag_onOneLineIsNotAFold() {
+		String code = "<body>foo</body>\n";
+		List<Fold> folds = getFolds(code);
+		Assertions.assertEquals(0, folds.size());
+	}
+
+
+	@Test
+	void testGetFolds_tag_twoLines() {
+		String code = """
+			<body>
+			</body>
+			""";
+		List<Fold> folds = getFolds(code);
+
+		Assertions.assertEquals(1, folds.size());
+		Fold fold = folds.getFirst();
+		Assertions.assertEquals(FoldType.CODE, fold.getFoldType());
+		Assertions.assertEquals(0, fold.getChildCount());
+		Assertions.assertEquals(1, fold.getLineCount());
+		Assertions.assertEquals(0, fold.getStartOffset());
+		Assertions.assertEquals(code.indexOf("</"), fold.getEndOffset());
+	}
+
+
+	@Test
+	void testGetFolds_tag_manyLines() {
+		String code = """
+			<body>
+			line 1
+			line 2
+			line 3
+			</body>
+			""";
+		List<Fold> folds = getFolds(code);
+
+		Assertions.assertEquals(1, folds.size());
+		Fold fold = folds.getFirst();
+		Assertions.assertEquals(FoldType.CODE, fold.getFoldType());
+		Assertions.assertEquals(4, fold.getLineCount());
+		Assertions.assertEquals(0, fold.getStartOffset());
+		Assertions.assertEquals(code.indexOf("</"), fold.getEndOffset());
+	}
+
+
+	@Test
+	void testGetFolds_tag_withAttributes() {
+		String code = """
+			<body id="foo" class="bar">
+			</body>
+			""";
+		List<Fold> folds = getFolds(code);
+
+		Assertions.assertEquals(1, folds.size());
+		Fold fold = folds.getFirst();
+		Assertions.assertEquals(FoldType.CODE, fold.getFoldType());
+		Assertions.assertEquals(0, fold.getStartOffset());
+		Assertions.assertEquals(code.indexOf("</"), fold.getEndOffset());
+	}
+
+
+	@Test
+	void testGetFolds_selfClosingTag_isNeverAFold() {
+		String code = """
+			<body>
+			<br/>
+			</body>
+			""";
+		List<Fold> folds = getFolds(code);
+
+		Assertions.assertEquals(1, folds.size());
+		Fold fold = folds.getFirst();
+		Assertions.assertEquals(0, fold.getChildCount());
+	}
+
+
+	@Test
+	void testGetFolds_selfClosingTag_withSpaceBeforeSlash() {
+		String code = """
+			<body>
+			<br />
+			</body>
+			""";
+		List<Fold> folds = getFolds(code);
+
+		Assertions.assertEquals(1, folds.size());
+		Fold fold = folds.getFirst();
+		Assertions.assertEquals(0, fold.getChildCount());
+	}
+
+
+	@Test
+	void testGetFolds_selfClosingTag_atTopLevelCreatesNoFold() {
+		String code = "<br/>\n";
+		List<Fold> folds = getFolds(code);
+		Assertions.assertEquals(0, folds.size());
+	}
+
+
+	@Test
+	void testGetFolds_nestedTags_bothMultiLine() {
+		String code = """
+			<html>
+			<body>
+			content
+			</body>
+			</html>
+			""";
+		List<Fold> folds = getFolds(code);
+
+		Assertions.assertEquals(1, folds.size());
+		Fold outer = folds.getFirst();
+		Assertions.assertEquals(FoldType.CODE, outer.getFoldType());
+		Assertions.assertEquals(0, outer.getStartOffset());
+		Assertions.assertEquals(code.lastIndexOf("</"), outer.getEndOffset());
+		Assertions.assertEquals(1, outer.getChildCount());
+
+		Fold inner = outer.getChild(0);
+		Assertions.assertEquals(FoldType.CODE, inner.getFoldType());
+		Assertions.assertEquals(code.indexOf("<body>"), inner.getStartOffset());
+		Assertions.assertEquals(code.indexOf("</body>"), inner.getEndOffset());
+		Assertions.assertEquals(0, inner.getChildCount());
+		Assertions.assertSame(outer, inner.getParent());
+	}
+
+
+	@Test
+	void testGetFolds_nestedTags_onlyOuterSpansMultipleLines() {
+		String code = """
+			<html>
+			<body>content</body>
+			</html>
+			""";
+		List<Fold> folds = getFolds(code);
+
+		// Inner "body" tag is entirely on one line, so it should not
+		// become a fold but should not corrupt the outer fold either.
+		Assertions.assertEquals(1, folds.size());
+		Fold outer = folds.getFirst();
+		Assertions.assertEquals(0, outer.getChildCount());
+		Assertions.assertEquals(0, outer.getStartOffset());
+		Assertions.assertEquals(code.lastIndexOf("</"), outer.getEndOffset());
+	}
+
+
+	@Test
+	void testGetFolds_nestedTags_onlyInnerSpansMultipleLines() {
+		String code = """
+			<html><body>
+			content
+			</body></html>
+			""";
+		List<Fold> folds = getFolds(code);
+
+		// The outer "html" tag starts and ends on lines that, when taken
+		// together with the fact that "body" is multi-line, still make
+		// "html" span multiple lines overall, so both should fold.
+		Assertions.assertEquals(1, folds.size());
+		Fold outer = folds.getFirst();
+		Assertions.assertEquals(FoldType.CODE, outer.getFoldType());
+		Assertions.assertEquals(1, outer.getChildCount());
+
+		Fold inner = outer.getChild(0);
+		Assertions.assertEquals(code.indexOf("<body>"), inner.getStartOffset());
+		Assertions.assertEquals(code.indexOf("</body>"), inner.getEndOffset());
+	}
+
+
+	@Test
+	void testGetFolds_deeplyNestedTags() {
+		String code = """
+			<a>
+			<b>
+			<c>
+			content
+			</c>
+			</b>
+			</a>
+			""";
+		List<Fold> folds = getFolds(code);
+
+		Assertions.assertEquals(1, folds.size());
+		Fold a = folds.getFirst();
+		Assertions.assertEquals(1, a.getChildCount());
+
+		Fold b = a.getChild(0);
+		Assertions.assertEquals(1, b.getChildCount());
+
+		Fold c = b.getChild(0);
+		Assertions.assertEquals(0, c.getChildCount());
+		Assertions.assertEquals(code.indexOf("<c>"), c.getStartOffset());
+		Assertions.assertEquals(code.indexOf("</c>"), c.getEndOffset());
+	}
+
+
+	@Test
+	void testGetFolds_siblingTags_bothMultiLine() {
+		String code = """
+			<root>
+			<a>
+			content 1
+			</a>
+			<b>
+			content 2
+			</b>
+			</root>
+			""";
+		List<Fold> folds = getFolds(code);
+
+		Assertions.assertEquals(1, folds.size());
+		Fold root = folds.getFirst();
+		Assertions.assertEquals(2, root.getChildCount());
+
+		Fold a = root.getChild(0);
+		Assertions.assertEquals(code.indexOf("<a>"), a.getStartOffset());
+		Assertions.assertEquals(code.indexOf("</a>"), a.getEndOffset());
+
+		Fold b = root.getChild(1);
+		Assertions.assertEquals(code.indexOf("<b>"), b.getStartOffset());
+		Assertions.assertEquals(code.indexOf("</b>"), b.getEndOffset());
+	}
+
+
+	@Test
+	void testGetFolds_siblingTags_atTopLevel() {
+		String code = """
+			<a>
+			content 1
+			</a>
+			<b>
+			content 2
+			</b>
+			""";
+		List<Fold> folds = getFolds(code);
+
+		Assertions.assertEquals(2, folds.size());
+
+		Fold a = folds.getFirst();
+		Assertions.assertEquals(code.indexOf("<a>"), a.getStartOffset());
+		Assertions.assertEquals(code.indexOf("</a>"), a.getEndOffset());
+
+		Fold b = folds.get(1);
+		Assertions.assertEquals(code.indexOf("<b>"), b.getStartOffset());
+		Assertions.assertEquals(code.indexOf("</b>"), b.getEndOffset());
+	}
+
+
+	@Test
+	void testGetFolds_manySiblingSingleLineTagsProduceNoFolds() {
+		StringBuilder sb = new StringBuilder("<root>\n");
+		for (int i = 0; i < 50; i++) {
+			sb.append("<item>value").append(i).append("</item>\n");
+		}
+		sb.append("</root>\n");
+		String code = sb.toString();
+
+		List<Fold> folds = getFolds(code);
+
+		Assertions.assertEquals(1, folds.size());
+		Fold root = folds.getFirst();
+		Assertions.assertEquals(0, root.getChildCount());
+		Assertions.assertEquals(0, root.getStartOffset());
+		Assertions.assertEquals(code.lastIndexOf("</"), root.getEndOffset());
+	}
+
+
+	@Test
+	void testGetFolds_selfClosingTagBetweenOtherTagsDoesNotBreakParent() {
+		String code = """
+			<root>
+			<a/>
+			<b>
+			content
+			</b>
+			</root>
+			""";
+		List<Fold> folds = getFolds(code);
+
+		Assertions.assertEquals(1, folds.size());
+		Fold root = folds.getFirst();
+		Assertions.assertEquals(1, root.getChildCount());
+
+		Fold b = root.getChild(0);
+		Assertions.assertEquals(code.indexOf("<b>"), b.getStartOffset());
+		Assertions.assertEquals(code.indexOf("</b>"), b.getEndOffset());
+	}
+
+
+	@Test
+	void testGetFolds_xmlDeclaration_doesNotByItselfCreateFold() {
+		String code = """
+			<?xml version="1.0" encoding="UTF-8"?>
+			<root>content</root>
+			""";
+		List<Fold> folds = getFolds(code);
+
+		// Nothing here spans multiple lines, so there should be no folds.
+		for (Fold fold : folds) {
+			Assertions.assertNotEquals(-1, fold.getStartLine()); // Sanity: fold exists validly
+		}
+		// No multi-line construct present -> no folds expected.
+		Assertions.assertEquals(0, folds.size());
+	}
+
+
+	@Test
+	void testGetFolds_comment_onOneLineIsNotAFold() {
+		String code = "<!-- a comment all on one line -->\n";
+		List<Fold> folds = getFolds(code);
+		Assertions.assertEquals(0, folds.size());
+	}
+
+
+	@Test
+	void testGetFolds_comment_twoLines() {
+		String code = """
+			<!-- line one
+			line two -->
+			""";
+		List<Fold> folds = getFolds(code);
+
+		Assertions.assertEquals(1, folds.size());
+		Fold fold = folds.getFirst();
+		Assertions.assertEquals(FoldType.COMMENT, fold.getFoldType());
+		Assertions.assertEquals(0, fold.getChildCount());
+		Assertions.assertEquals(1, fold.getLineCount());
+		Assertions.assertEquals(0, fold.getStartOffset());
+		Assertions.assertEquals(code.length() - 2, fold.getEndOffset());
+	}
+
+
+	@Test
+	void testGetFolds_comment_manyLines() {
+		String code = """
+			<!-- line one
+			line two
+			line three
+			line four -->
+			""";
+		List<Fold> folds = getFolds(code);
+
+		Assertions.assertEquals(1, folds.size());
+		Fold fold = folds.getFirst();
+		Assertions.assertEquals(FoldType.COMMENT, fold.getFoldType());
+		Assertions.assertEquals(3, fold.getLineCount());
+	}
+
+
+	@Test
+	void testGetFolds_comment_insideMultiLineTag() {
+		String code = """
+			<root>
+			<!-- a comment
+			spanning two lines -->
+			</root>
+			""";
+		List<Fold> folds = getFolds(code);
+
+		Assertions.assertEquals(1, folds.size());
+		Fold root = folds.getFirst();
+		Assertions.assertEquals(1, root.getChildCount());
+
+		Fold comment = root.getChild(0);
+		Assertions.assertEquals(FoldType.COMMENT, comment.getFoldType());
+		Assertions.assertEquals(code.indexOf("<!--"), comment.getStartOffset());
+	}
+
+
+	@Test
+	void testGetFolds_multipleTopLevelComments() {
+		String code = """
+			<!-- comment one
+			still one -->
+			<root>content</root>
+			<!-- comment two
+			still two -->
+			""";
+		List<Fold> folds = getFolds(code);
+
+		Assertions.assertEquals(2, folds.size());
+		Assertions.assertEquals(FoldType.COMMENT, folds.get(0).getFoldType());
+		Assertions.assertEquals(FoldType.COMMENT, folds.get(1).getFoldType());
+	}
+
+
+	@Test
+	void testGetFolds_unclosedTag_doesNotThrow() {
+		String code = """
+			<root>
+			<unclosed>
+			content
+			""";
+		Assertions.assertDoesNotThrow(() -> getFolds(code));
+	}
+
+
+	@Test
+	void testGetFolds_unmatchedClosingTag_doesNotThrow() {
+		String code = """
+			content
+			</root>
+			more content
+			""";
+		Assertions.assertDoesNotThrow(() -> getFolds(code));
+	}
+
+
+	@Test
+	void testGetFolds_unclosedComment_doesNotThrow() {
+		String code = """
+			<!-- a comment that never ends
+			more text
+			even more text
+			""";
+		Assertions.assertDoesNotThrow(() -> getFolds(code));
+	}
+
+
+	@Test
+	void testGetFolds_emptyElementWithOnlyWhitespaceBetweenTags() {
+		String code = """
+			<root>
+			  \s
+			</root>
+			""";
+		List<Fold> folds = getFolds(code);
+
+		Assertions.assertEquals(1, folds.size());
+		Fold fold = folds.getFirst();
+		Assertions.assertEquals(2, fold.getLineCount());
+	}
+
+
+	@Test
+	void testGetFolds_cdataSection_doesNotBreakParsing() {
+		String code = """
+			<root>
+			<![CDATA[ some <fake>tags</fake> in here ]]>
+			</root>
+			""";
+		Assertions.assertDoesNotThrow(() -> {
+			List<Fold> folds = getFolds(code);
+			// Whatever the outcome, the top-level "root" tag should still
+			// be recognized as a multi-line fold.
+			Assertions.assertFalse(folds.isEmpty());
+		});
+	}
+
+
+	@Test
+	void testGetFolds_realisticDocument() {
+		String code =
+			"""
+				<?xml version="1.0" encoding="UTF-8" ?>
+				<!-- Books available in our library. -->
+				<books>
+
+				   <book>
+				      <title>How to Win at Life</title>
+				      <author>Donald Trump</author>
+				      <publish-year>2004</publish-year>
+				   </book>
+				  \s
+				   <book>
+				      <title>Coding for Dummies</title>
+				      <author>Nikhil Abraham</author>
+				      <publish-year>2015</publish-year>
+				   </book>
+				  \s
+				</books>
+				""";
+
+		List<Fold> folds = getFolds(code);
+
+		Assertions.assertEquals(1, folds.size());
+		Fold books = folds.getFirst();
+		Assertions.assertEquals(FoldType.CODE, books.getFoldType());
+		Assertions.assertEquals(2, books.getChildCount());
+
+		Fold book1 = books.getChild(0);
+		Assertions.assertEquals(0, book1.getChildCount());
+		Assertions.assertEquals(code.indexOf("<book>"), book1.getStartOffset());
+
+		Fold book2 = books.getChild(1);
+		Assertions.assertEquals(0, book2.getChildCount());
+		Assertions.assertEquals(code.lastIndexOf("<book>"), book2.getStartOffset());
+	}
+}


### PR DESCRIPTION
## Summary
- Fixes #138: `XmlFoldParser` was creating a `Fold` (and the `Position` it wraps) for every opening tag encountered, then immediately discarding it if the tag turned out to be on a single line. Most tags in typical XML documents are single-line, so this caused a large amount of wasted `Fold`/`Position` churn on large documents.
- Tags are now tracked on a lightweight offset stack while scanning; a `Fold` is only materialized once a tag is confirmed to span multiple lines, lazily materializing still-open ancestor tags as needed so the fold tree stays correctly nested (e.g. when a nested multi-line comment or child tag forces an ancestor to be created early).
- Behavior is unchanged from the caller's perspective — same fold tree shape, same offsets — this is purely an internal allocation optimization.
- Added `XmlFoldParserTest` with exhaustive coverage: single/multi-line tags, self-closing tags, nested/sibling tags at various depths, single- and multi-line comments (including nested inside tags), malformed/unclosed markup, and a realistic multi-element document.

## Test plan
- [x] `./gradlew clean build` passes (checkstyle, spotbugs, tests all green)
- [x] New `XmlFoldParserTest` (29 tests) passes
- [x] Manually verified against a large (500k-line) generated XML file that fold parsing time dropped substantially with the deferred-materialization approach

🤖 Generated with [Claude Code](https://claude.ai/claude-code)