### PR TITLE
chore: bump version to 4.0.1-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # This controls the javac "release" version.
 javaLanguageVersion=11
 osgiRequiredCompatibility=11
-version=4.0.0
+version=4.0.1-SNAPSHOT
 
 # Ugh, see https://github.com/gradle/gradle/issues/11308
 systemProp.org.gradle.internal.publish.checksums.insecure=true


### PR DESCRIPTION
## Summary
- Bump `version` in `gradle.properties` from `4.0.0` to `4.0.1-SNAPSHOT` to begin post-release development.

## Test plan
- [x] `./gradlew clean build` passes locally

🤖 Generated with [Claude Code](https://claude.ai/claude-code)