### PR TITLE
feat: recognize .env files as SYNTAX_STYLE_ENV by filename

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/FileTypeUtil.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/FileTypeUtil.java
@@ -416,6 +416,7 @@ public final class FileTypeUtil implements SyntaxConstants {
 		initFiltersImpl(map, SYNTAX_STYLE_DELPHI, "*.pas");
 		initFiltersImpl(map, SYNTAX_STYLE_DOCKERFILE, "*.dockerfile", "Dockerfile");
 		initFiltersImpl(map, SYNTAX_STYLE_DTD, "*.dtd");
+		initFiltersImpl(map, SYNTAX_STYLE_ENV, "*.env", "*.env.*");
 		initFiltersImpl(map, SYNTAX_STYLE_FORTRAN, "*.f", "*.for", "*.fort", "*.f77", "*.f90");
 		initFiltersImpl(map, SYNTAX_STYLE_GO, "*.go");
 		initFiltersImpl(map, SYNTAX_STYLE_GROOVY, "*.groovy", "*.gradle", "*.grv", "*.gy", "*.gvy", "*.gsh");

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/FileTypeUtilTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/FileTypeUtilTest.java
@@ -229,7 +229,13 @@ class FileTypeUtilTest extends AbstractRSyntaxTextAreaTest {
 
 		FileTypeUtil util = FileTypeUtil.get();
 
-		File file = new File("makefile");
+		File file = new File(".env");
+		Assertions.assertEquals(SyntaxConstants.SYNTAX_STYLE_ENV, util.guessContentType(file));
+
+		file = new File(".env.sample");
+		Assertions.assertEquals(SyntaxConstants.SYNTAX_STYLE_ENV, util.guessContentType(file));
+
+		file = new File("makefile");
 		Assertions.assertEquals(SyntaxConstants.SYNTAX_STYLE_MAKEFILE, util.guessContentType(file));
 
 		file = new File("test.java");


### PR DESCRIPTION
## Summary
- `FileTypeUtil` now maps `*.env` and `*.env.*` filenames to `SYNTAX_STYLE_ENV`, so `.env`/`.env.sample`-style files are auto-detected without needing to set the syntax style manually.

## Test plan
- [x] Added unit tests in `FileTypeUtilTest` for `.env` and `.env.sample`
- [x] `./gradlew clean build` passes (checkstyle, spotbugs, tests)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)