### PR TITLE
feat: recognize PowerShell and VHDL files by filename

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/FileTypeUtil.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/FileTypeUtil.java
@@ -441,6 +441,7 @@ public final class FileTypeUtil implements SyntaxConstants {
 		initFiltersImpl(map, SYNTAX_STYLE_NSIS, "*.nsi");
 		initFiltersImpl(map, SYNTAX_STYLE_PERL, "*.perl", "*.pl", "*.pm");
 		initFiltersImpl(map, SYNTAX_STYLE_PHP, "*.php");
+		initFiltersImpl(map, SYNTAX_STYLE_POWERSHELL, "*.ps1", "*.psm1", "*.psd1");
 		initFiltersImpl(map, SYNTAX_STYLE_PROPERTIES_FILE, "*.properties");
 		initFiltersImpl(map, SYNTAX_STYLE_PROTO, "*.proto");
 		initFiltersImpl(map, SYNTAX_STYLE_PYTHON, "*.py");
@@ -452,6 +453,7 @@ public final class FileTypeUtil implements SyntaxConstants {
 		initFiltersImpl(map, SYNTAX_STYLE_TCL, "*.tcl", "*.tk");
 		initFiltersImpl(map, SYNTAX_STYLE_TYPESCRIPT, "*.ts", "*.tsx");
 		initFiltersImpl(map, SYNTAX_STYLE_UNIX_SHELL, "*.sh", "*.?sh");
+		initFiltersImpl(map, SYNTAX_STYLE_VHDL, "*.vhd", "*.vhdl");
 		initFiltersImpl(map, SYNTAX_STYLE_VISUAL_BASIC, "*.vb");
 		initFiltersImpl(map, SYNTAX_STYLE_WINDOWS_BATCH, "*.bat", "*.cmd");
 		initFiltersImpl(map, SYNTAX_STYLE_XML, "*.xml", "*.xsl", "*.xsd", "*.xslt", "*.wsdl", "*.svg",


### PR DESCRIPTION
This PR adds file extension awareness to `FileTypeUtil` for a couple of languages that were missed. We've supported syntax highlighting for Powershell and VHDL for awhile, but `FileTypeUtil` wasn't auto-detecting files of those types.

## Summary
- Add filename filters for PowerShell (`*.ps1`, `*.psm1`, `*.psd1`) so these files are auto-detected as `SYNTAX_STYLE_POWERSHELL`
- Add filename filters for VHDL (`*.vhd`, `*.vhdl`) so these files are auto-detected as `SYNTAX_STYLE_VHDL`

## Test plan
- [x] `./gradlew clean build` passes (checkstyle, spotbugs, tests)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)