### PR TITLE
chore: preparing for 4.0.1 release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # This controls the javac "release" version.
 javaLanguageVersion=11
 osgiRequiredCompatibility=11
-version=4.0.1-SNAPSHOT
+version=4.0.1
 
 # Ugh, see https://github.com/gradle/gradle/issues/11308
 systemProp.org.gradle.internal.publish.checksums.insecure=true


### PR DESCRIPTION
## Summary
- Preparing for 4.0.1 release
- Bump version in `gradle.properties` from `4.0.1-SNAPSHOT` to `4.0.1`

## Test plan
- [x] `./gradlew clean build` passes locally (checkstyle, spotbugs, tests)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)