### PR TITLE
chore: bump version to 4.0.2-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # This controls the javac "release" version.
 javaLanguageVersion=11
 osgiRequiredCompatibility=11
-version=4.0.1
+version=4.0.2-SNAPSHOT
 
 # Ugh, see https://github.com/gradle/gradle/issues/11308
 systemProp.org.gradle.internal.publish.checksums.insecure=true


### PR DESCRIPTION
## Summary
- Bump version in `gradle.properties` from `4.0.1` to `4.0.2-SNAPSHOT` to resume development after the 4.0.1 release

## Test plan
- [x] `./gradlew clean build` passes locally (checkstyle, spotbugs, tests)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)