### PR TITLE
Fixed RsyntaxTextArea still displays caret when focusable is false

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextArea.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rtextarea/RTextArea.java
@@ -888,6 +888,7 @@ public class RTextArea extends RTextAreaBase implements Printable {
 		markAllHighlightPainter = new SmartHighlightPainter(
 										markAllHighlightColor);
 		setMarkAllHighlightColor(markAllHighlightColor);
+		textMode = TextMode.INSERT;
 		carets = new EnumMap<>(TextMode.class);
 		setCaretStyle(TextMode.INSERT, CaretStyle.THICK_VERTICAL_LINE_STYLE);
 		setCaretStyle(TextMode.OVERWRITE, CaretStyle.BLOCK_STYLE);


### PR DESCRIPTION
This PR fixed issue #729.

When an `RSyntaxTextArea` is configured with `setFocusable(false)`, it cannot receive keyboard focus, but its caret may still remain visible. This can make the text area appear focused or editable even though it is not focusable.

#### Fix
Initialize `textMode` to `TextMode.INSERT` instead of leaving it `null`.


Thank you!